### PR TITLE
Make ROM schema fields optional to fix API decoding errors

### DIFF
--- a/romm/romm/Data/DataSources/API/OpenAPIs/Models/RomUserSchema.swift
+++ b/romm/romm/Data/DataSources/API/OpenAPIs/Models/RomUserSchema.swift
@@ -15,9 +15,9 @@ public struct RomUserSchema: Codable, JSONEncodable, Hashable {
     public var createdAt: Date
     public var updatedAt: Date
     public var lastPlayed: Date?
-    public var noteRawMarkdown: String
-    public var noteIsPublic: Bool
-    public var isMainSibling: Bool
+    public var noteRawMarkdown: String?
+    public var noteIsPublic: Bool?
+    public var isMainSibling: Bool?
     public var backlogged: Bool
     public var nowPlaying: Bool
     public var hidden: Bool
@@ -27,7 +27,7 @@ public struct RomUserSchema: Codable, JSONEncodable, Hashable {
     public var status: RomUserStatus?
     public var userUsername: String
 
-    public init(id: Int, userId: Int, romId: Int, createdAt: Date, updatedAt: Date, lastPlayed: Date?, noteRawMarkdown: String, noteIsPublic: Bool, isMainSibling: Bool, backlogged: Bool, nowPlaying: Bool, hidden: Bool, rating: Int, difficulty: Int, completion: Int, status: RomUserStatus?, userUsername: String) {
+    public init(id: Int, userId: Int, romId: Int, createdAt: Date, updatedAt: Date, lastPlayed: Date?, noteRawMarkdown: String?, noteIsPublic: Bool?, isMainSibling: Bool?, backlogged: Bool, nowPlaying: Bool, hidden: Bool, rating: Int, difficulty: Int, completion: Int, status: RomUserStatus?, userUsername: String) {
         self.id = id
         self.userId = userId
         self.romId = romId
@@ -81,8 +81,8 @@ public struct RomUserSchema: Codable, JSONEncodable, Hashable {
         } else {
             lastPlayed = nil
         }
-        noteRawMarkdown = try container.decode(String.self, forKey: .noteRawMarkdown)
-        noteIsPublic = try container.decode(Bool.self, forKey: .noteIsPublic)
+        noteRawMarkdown = try container.decodeIfPresent(String.self, forKey: .noteRawMarkdown)
+        noteIsPublic = try container.decodeIfPresent(Bool.self, forKey: .noteIsPublic)
         isMainSibling = try container.decode(Bool.self, forKey: .isMainSibling)
         backlogged = try container.decode(Bool.self, forKey: .backlogged)
         nowPlaying = try container.decode(Bool.self, forKey: .nowPlaying)
@@ -104,9 +104,9 @@ public struct RomUserSchema: Codable, JSONEncodable, Hashable {
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(updatedAt, forKey: .updatedAt)
         try container.encode(lastPlayed, forKey: .lastPlayed)
-        try container.encode(noteRawMarkdown, forKey: .noteRawMarkdown)
-        try container.encode(noteIsPublic, forKey: .noteIsPublic)
-        try container.encode(isMainSibling, forKey: .isMainSibling)
+        try container.encodeIfPresent(noteRawMarkdown, forKey: .noteRawMarkdown)
+        try container.encodeIfPresent(noteIsPublic, forKey: .noteIsPublic)
+        try container.encodeIfPresent(isMainSibling, forKey: .isMainSibling)
         try container.encode(backlogged, forKey: .backlogged)
         try container.encode(nowPlaying, forKey: .nowPlaying)
         try container.encode(hidden, forKey: .hidden)

--- a/romm/romm/Data/DataSources/API/OpenAPIs/Models/SimpleRomSchema.swift
+++ b/romm/romm/Data/DataSources/API/OpenAPIs/Models/SimpleRomSchema.swift
@@ -56,7 +56,7 @@ public struct SimpleRomSchema: Codable, JSONEncodable, Hashable {
     public var crcHash: String?
     public var md5Hash: String?
     public var sha1Hash: String?
-    public var multi: Bool
+    public var multi: Bool?
     public var files: [RomFileSchema]
     public var fullPath: String
     public var createdAt: Date
@@ -65,7 +65,7 @@ public struct SimpleRomSchema: Codable, JSONEncodable, Hashable {
     public var siblings: [SiblingRomSchema]
     public var romUser: RomUserSchema
 
-    public init(id: Int, igdbId: Int?, sgdbId: Int?, mobyId: Int?, ssId: Int?, raId: Int?, launchboxId: Int?, hasheousId: Int?, tgdbId: Int?, platformId: Int, platformSlug: String, platformFsSlug: String, platformName: String, platformCustomName: String?, platformDisplayName: String, fsName: String, fsNameNoTags: String, fsNameNoExt: String, fsExtension: String, fsPath: String, fsSizeBytes: Int, name: String?, slug: String?, summary: String?, alternativeNames: [String], youtubeVideoId: String?, metadatum: RomMetadataSchema, igdbMetadata: RomIGDBMetadata?, mobyMetadata: RomMobyMetadata?, ssMetadata: RomSSMetadata?, launchboxMetadata: RomLaunchboxMetadata?, hasheousMetadata: RomHasheousMetadata?, pathCoverSmall: String?, pathCoverLarge: String?, urlCover: String?, hasManual: Bool, pathManual: String?, urlManual: String?, isUnidentified: Bool, isIdentified: Bool, revision: String?, regions: [String], languages: [String], tags: [String], crcHash: String?, md5Hash: String?, sha1Hash: String?, multi: Bool, files: [RomFileSchema], fullPath: String, createdAt: Date, updatedAt: Date, missingFromFs: Bool, siblings: [SiblingRomSchema], romUser: RomUserSchema) {
+    public init(id: Int, igdbId: Int?, sgdbId: Int?, mobyId: Int?, ssId: Int?, raId: Int?, launchboxId: Int?, hasheousId: Int?, tgdbId: Int?, platformId: Int, platformSlug: String, platformFsSlug: String, platformName: String, platformCustomName: String?, platformDisplayName: String, fsName: String, fsNameNoTags: String, fsNameNoExt: String, fsExtension: String, fsPath: String, fsSizeBytes: Int, name: String?, slug: String?, summary: String?, alternativeNames: [String], youtubeVideoId: String?, metadatum: RomMetadataSchema, igdbMetadata: RomIGDBMetadata?, mobyMetadata: RomMobyMetadata?, ssMetadata: RomSSMetadata?, launchboxMetadata: RomLaunchboxMetadata?, hasheousMetadata: RomHasheousMetadata?, pathCoverSmall: String?, pathCoverLarge: String?, urlCover: String?, hasManual: Bool, pathManual: String?, urlManual: String?, isUnidentified: Bool, isIdentified: Bool, revision: String?, regions: [String], languages: [String], tags: [String], crcHash: String?, md5Hash: String?, sha1Hash: String?, multi: Bool?, files: [RomFileSchema], fullPath: String, createdAt: Date, updatedAt: Date, missingFromFs: Bool, siblings: [SiblingRomSchema], romUser: RomUserSchema) {
         self.id = id
         self.igdbId = igdbId
         self.sgdbId = sgdbId
@@ -230,7 +230,7 @@ public struct SimpleRomSchema: Codable, JSONEncodable, Hashable {
         crcHash = try container.decodeIfPresent(String.self, forKey: .crcHash)
         md5Hash = try container.decodeIfPresent(String.self, forKey: .md5Hash)
         sha1Hash = try container.decodeIfPresent(String.self, forKey: .sha1Hash)
-        multi = try container.decode(Bool.self, forKey: .multi)
+        multi = try container.decodeIfPresent(Bool.self, forKey: .multi)
         files = try container.decode([RomFileSchema].self, forKey: .files)
         fullPath = try container.decode(String.self, forKey: .fullPath)
         createdAt = try container.decodeFlexibleDate(forKey: .createdAt)
@@ -290,7 +290,7 @@ public struct SimpleRomSchema: Codable, JSONEncodable, Hashable {
         try container.encode(crcHash, forKey: .crcHash)
         try container.encode(md5Hash, forKey: .md5Hash)
         try container.encode(sha1Hash, forKey: .sha1Hash)
-        try container.encode(multi, forKey: .multi)
+        try container.encodeIfPresent(multi, forKey: .multi)
         try container.encode(files, forKey: .files)
         try container.encode(fullPath, forKey: .fullPath)
         try container.encode(createdAt, forKey: .createdAt)


### PR DESCRIPTION
The RomM API doesn't always return fields marked as required in the OpenAPI
  spec. Make 'multi', 'noteRawMarkdown', 'noteIsPublic', and 'isMainSibling'
  optional to prevent keyNotFound errors when loading ROMs.

Issue #4 