### PR TITLE
feat: add Group ROMs setting to match web behavior

### DIFF
--- a/romm/romm/Data/API/RommAPIClient+Roms.swift
+++ b/romm/romm/Data/API/RommAPIClient+Roms.swift
@@ -33,6 +33,7 @@ extension RommAPIClient {
         orderDir: String? = nil,
         filters: RomFilters
     ) async throws -> CustomLimitOffsetPageSimpleRomSchema {
+        let groupByMetaId = GetGroupRomsUseCase().execute()
         let path = withQuery("api/roms", [
             ("with_char_index", withCharIndex.map(String.init)),
             ("search_term", searchTerm),
@@ -45,7 +46,7 @@ extension RommAPIClient {
             ("missing", filters.missing.map(String.init)),
             ("has_ra", filters.hasRa.map(String.init)),
             ("verified", filters.verified.map(String.init)),
-            ("group_by_meta_id", "false"),
+            ("group_by_meta_id", groupByMetaId ? "true" : "false"),
             ("genres", filters.selectedGenre),
             ("franchises", filters.selectedFranchise),
             ("collections", filters.selectedCollection),

--- a/romm/romm/Domain/UseCases/UI/GetGroupRomsUseCase.swift
+++ b/romm/romm/Domain/UseCases/UI/GetGroupRomsUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  GetGroupRomsUseCase.swift
+//  romm
+//
+
+import Foundation
+
+protocol PGetGroupRomsUseCase {
+    func execute() -> Bool
+}
+
+class GetGroupRomsUseCase: PGetGroupRomsUseCase {
+
+    static let storageKey = "groupRomsByMetaId"
+
+    func execute() -> Bool {
+        if let value = UserDefaults.standard.object(forKey: Self.storageKey) as? Bool {
+            return value
+        }
+        return true
+    }
+}

--- a/romm/romm/Domain/UseCases/UI/SaveGroupRomsUseCase.swift
+++ b/romm/romm/Domain/UseCases/UI/SaveGroupRomsUseCase.swift
@@ -1,0 +1,17 @@
+//
+//  SaveGroupRomsUseCase.swift
+//  romm
+//
+
+import Foundation
+
+protocol PSaveGroupRomsUseCase {
+    func execute(_ enabled: Bool)
+}
+
+class SaveGroupRomsUseCase: PSaveGroupRomsUseCase {
+
+    func execute(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: GetGroupRomsUseCase.storageKey)
+    }
+}

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -80,6 +80,8 @@ protocol PDependencyFactory {
     // UI Use Cases
     func makeGetViewModeUseCase() -> PGetViewModeUseCase
     func makeSaveViewModeUseCase() -> PSaveViewModeUseCase
+    func makeGetGroupRomsUseCase() -> PGetGroupRomsUseCase
+    func makeSaveGroupRomsUseCase() -> PSaveGroupRomsUseCase
 
     // Emulator Use Cases
     func makeCheckEmulatorSupportUseCase() -> PCheckEmulatorSupportUseCase
@@ -333,6 +335,14 @@ class DefaultDependencyFactory: PDependencyFactory {
 
     func makeSaveViewModeUseCase() -> PSaveViewModeUseCase {
         SaveViewModeUseCase(repository: viewModePreferenceRepository)
+    }
+
+    func makeGetGroupRomsUseCase() -> PGetGroupRomsUseCase {
+        GetGroupRomsUseCase()
+    }
+
+    func makeSaveGroupRomsUseCase() -> PSaveGroupRomsUseCase {
+        SaveGroupRomsUseCase()
     }
 
     // MARK: - Emulator Use Cases

--- a/romm/romm/UI/DI/MockDependencyFactory.swift
+++ b/romm/romm/UI/DI/MockDependencyFactory.swift
@@ -245,6 +245,14 @@ class MockDependencyFactory: PDependencyFactory {
     func makeSaveViewModeUseCase() -> PSaveViewModeUseCase {
         SaveViewModeUseCase(repository: viewModePreferenceRepository)
     }
+
+    func makeGetGroupRomsUseCase() -> PGetGroupRomsUseCase {
+        GetGroupRomsUseCase()
+    }
+
+    func makeSaveGroupRomsUseCase() -> PSaveGroupRomsUseCase {
+        SaveGroupRomsUseCase()
+    }
     
     // MARK: - SFTP ViewModels
     

--- a/romm/romm/UI/Profile/ProfileViewModel.swift
+++ b/romm/romm/UI/Profile/ProfileViewModel.swift
@@ -15,10 +15,22 @@ class ProfileViewModel {
     private let logger = Logger.viewModel
     private let logoutUseCase: LogoutUseCase
     private let clearSetupConfigurationUseCase: PClearSetupConfigurationUseCase
-    
+    private let getGroupRomsUseCase: PGetGroupRomsUseCase
+    private let saveGroupRomsUseCase: PSaveGroupRomsUseCase
+
+    var groupRomsByMetaId: Bool {
+        didSet {
+            guard oldValue != groupRomsByMetaId else { return }
+            saveGroupRomsUseCase.execute(groupRomsByMetaId)
+        }
+    }
+
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
         self.logoutUseCase = factory.makeLogoutUseCase()
         self.clearSetupConfigurationUseCase = factory.makeClearSetupConfigurationUseCase()
+        self.getGroupRomsUseCase = factory.makeGetGroupRomsUseCase()
+        self.saveGroupRomsUseCase = factory.makeSaveGroupRomsUseCase()
+        self.groupRomsByMetaId = getGroupRomsUseCase.execute()
     }
     
     func logout() {

--- a/romm/romm/UI/Profile/SettingsView.swift
+++ b/romm/romm/UI/Profile/SettingsView.swift
@@ -25,7 +25,8 @@ struct SettingsView: View {
     }
     
     var body: some View {
-        List {
+        @Bindable var profileVM = profileViewModel
+        return List {
             // User Section
             if let user = appData.currentUser {
                 Section("User") {
@@ -100,6 +101,23 @@ struct SettingsView: View {
                         Text("Server Statistics")
                     }
                 }
+            }
+
+            // Platforms Section
+            Section {
+                Toggle(isOn: $profileVM.groupRomsByMetaId) {
+                    HStack {
+                        Image(systemName: "rectangle.stack")
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Group ROMs")
+                            Text("Group versions of the same ROM together in the gallery")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            } header: {
+                Text("Platforms")
             }
 
             // App Settings Section


### PR DESCRIPTION
## Summary
- ROMs erschienen in der App doppelt (z. B. Multi-Region/Multi-Disc), weil `group_by_meta_id` hart auf `false` stand. Die Web-UI nutzt standardmäßig `true`.
- Neuer Bereich **Platforms** in den Settings mit Toggle **Group ROMs** (Default: an), persistiert via dedizierten `Get`/`SaveGroupRomsUseCase` über `PDependencyFactory` — passend zur MVVM + Use-Case-Architektur (`docs/architecture.md`).
- `RommAPIClient+Roms.getRomsWithFilters` reicht den Wert dynamisch als `group_by_meta_id` an `/api/roms` durch.

## Test plan
- [ ] Settings öffnen → Sektion **Platforms** sichtbar, Toggle aktiv per Default
- [ ] Platform-Detail (z. B. GBA) zeigt keine Duplikate mehr bei aktivem Toggle
- [ ] Toggle aus → ungruppierte Liste, Setting bleibt nach App-Restart erhalten
- [ ] Network-Log zeigt `group_by_meta_id=true|false` entsprechend dem Toggle