### PR TITLE
docs(readme): document submodule init for Vendor cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ Join the beta program and help improve the app:
   <img src="screenshots/iphone_3.png" width="200" alt="Screenshot 3" />
 </p>
 
+## Getting Started
+
+This repository uses git submodules for the embedded emulator cores in `Vendor/` (DeltaCore, GBADeltaCore, GBCDeltaCore, NESDeltaCore, SNESDeltaCore, N64DeltaCore, MelonDSDeltaCore, GPGXDeltaCore). Clone with submodules:
+
+```sh
+git clone --recurse-submodules https://github.com/ilyas-hallak/romm-ios-app.git
+```
+
+If you already cloned without submodules, initialize them afterwards:
+
+```sh
+git submodule update --init --recursive
+```
+
+Then open `romm/romm.xcodeproj` in Xcode and build.
+
 ## Contributing
 
 1. Follow the established Clean Architecture patterns


### PR DESCRIPTION
Adds a **Getting Started** section to the README explaining how to clone with submodules or initialize them post-clone. The Vendor/* DeltaCore subprojects are required to build the project.