### PR TITLE
Track last_played on emulator launch

### DIFF
--- a/romm/romm/Data/API/RommAPIClient+Roms.swift
+++ b/romm/romm/Data/API/RommAPIClient+Roms.swift
@@ -87,12 +87,12 @@ extension RommAPIClient {
         return result
     }
 
-    func updateRomFavorite(id: Int, isFavorite: Bool) async throws -> RomUserSchema {
-        let updateBody = BodyUpdateRomUserApiRomsIdPropsPut(
+    func updateRomLastPlayed(id: Int) async throws -> RomUserSchema {
+        let body = BodyUpdateRomUserApiRomsIdPropsPut(
             updateLastPlayed: true,
             removeLastPlayed: false
         )
-        return try await put("api/roms/\(id)/props", body: updateBody, responseType: RomUserSchema.self)
+        return try await put("api/roms/\(id)/props", body: body, responseType: RomUserSchema.self)
     }
 
     func getRomManual(romId: Int) async throws -> Manual? {

--- a/romm/romm/Data/API/RommAPIClient.swift
+++ b/romm/romm/Data/API/RommAPIClient.swift
@@ -77,6 +77,9 @@ protocol PRommAPIClient {
     func getHeartbeat() async throws -> HeartbeatResponse
     func getHeartbeat(from serverURL: String) async throws -> HeartbeatResponse
 
+    // ROM user props
+    func updateRomLastPlayed(id: Int) async throws -> RomUserSchema
+
     // Stats, Saves, States
     func getStats() async throws -> StatsReturn
     func getSaves(romId: Int) async throws -> [SaveSchema]

--- a/romm/romm/Data/Repositories/RomsRepository.swift
+++ b/romm/romm/Data/Repositories/RomsRepository.swift
@@ -186,6 +186,17 @@ class RomsRepository: PRomsRepository {
         }
     }
     
+    func updateLastPlayed(romId: Int) async throws {
+        logger.info("⏱️ Updating last_played for ROM \(romId)")
+        do {
+            _ = try await apiClient.updateRomLastPlayed(id: romId)
+            logger.info("✅ last_played updated for ROM \(romId)")
+        } catch {
+            logger.error("❌ Failed to update last_played for ROM \(romId): \(error)")
+            throw RomError.networkError
+        }
+    }
+
     func isRomFavorite(romId: Int) async throws -> Bool {
         logger.info("🔍 Checking favorite status for ROM \(romId)")
         

--- a/romm/romm/Domain/RepositoryProtocols/PRomsRepository.swift
+++ b/romm/romm/Domain/RepositoryProtocols/PRomsRepository.swift
@@ -25,6 +25,7 @@ protocol PRomsRepository {
     func getRomDetails(id: Int) async throws -> RomDetails
     func toggleRomFavorite(romId: Int, isFavorite: Bool) async throws
     func isRomFavorite(romId: Int) async throws -> Bool
+    func updateLastPlayed(romId: Int) async throws
     func searchRoms(query: String) async throws -> [Rom]
     func searchRomsLegacy(query: String) async throws -> [Rom]
 }

--- a/romm/romm/Domain/UseCases/Roms/UpdateLastPlayedUseCase.swift
+++ b/romm/romm/Domain/UseCases/Roms/UpdateLastPlayedUseCase.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+protocol PUpdateLastPlayedUseCase {
+    func execute(romId: Int) async throws
+}
+
+final class UpdateLastPlayedUseCase: PUpdateLastPlayedUseCase {
+    private let romsRepository: PRomsRepository
+
+    init(romsRepository: PRomsRepository) {
+        self.romsRepository = romsRepository
+    }
+
+    func execute(romId: Int) async throws {
+        guard romId > 0 else {
+            throw RomError.invalidRomId
+        }
+        try await romsRepository.updateLastPlayed(romId: romId)
+    }
+}

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -36,6 +36,7 @@ protocol PDependencyFactory {
     func makeGetRomDetailsUseCase() -> GetRomDetailsUseCase
     func makeToggleRomFavoriteUseCase() -> ToggleRomFavoriteUseCase
     func makeCheckRomFavoriteStatusUseCase() -> CheckRomFavoriteStatusUseCase
+    func makeUpdateLastPlayedUseCase() -> PUpdateLastPlayedUseCase
     func makeSearchRomsUseCase() -> SearchRomsUseCase
     func makeLoadManualUseCase() -> LoadManualUseCase
     func makeGetPlatformsUseCase() -> GetPlatformsUseCase
@@ -173,7 +174,11 @@ class DefaultDependencyFactory: PDependencyFactory {
     func makeCheckRomFavoriteStatusUseCase() -> CheckRomFavoriteStatusUseCase {
         CheckRomFavoriteStatusUseCase(romsRepository: romsRepository)
     }
-    
+
+    func makeUpdateLastPlayedUseCase() -> PUpdateLastPlayedUseCase {
+        UpdateLastPlayedUseCase(romsRepository: romsRepository)
+    }
+
     func makeSearchRomsUseCase() -> SearchRomsUseCase {
         SearchRomsUseCase(romsRepository: romsRepository)
     }

--- a/romm/romm/UI/DI/MockDependencyFactory.swift
+++ b/romm/romm/UI/DI/MockDependencyFactory.swift
@@ -105,6 +105,10 @@ class MockDependencyFactory: PDependencyFactory {
     func makeCheckRomFavoriteStatusUseCase() -> CheckRomFavoriteStatusUseCase {
         CheckRomFavoriteStatusUseCase(romsRepository: romsRepository)
     }
+
+    func makeUpdateLastPlayedUseCase() -> PUpdateLastPlayedUseCase {
+        UpdateLastPlayedUseCase(romsRepository: romsRepository)
+    }
     
     func makeSearchRomsUseCase() -> SearchRomsUseCase {
         SearchRomsUseCase(romsRepository: romsRepository)

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
@@ -17,6 +17,7 @@ struct PlatformROMsListView: View {
     @State private var launchingRomId: Int?
     @State private var romPendingDelete: DownloadedROM?
     private let launchUseCase: PLaunchEmulatorUseCase = DefaultDependencyFactory.shared.makeLaunchEmulatorUseCase()
+    private let updateLastPlayedUseCase: PUpdateLastPlayedUseCase = DefaultDependencyFactory.shared.makeUpdateLastPlayedUseCase()
 
     var body: some View {
         List {
@@ -86,6 +87,9 @@ struct PlatformROMsListView: View {
         }
         if case .success(let decision) = result {
             launchDecision = decision
+            Task { [updateLastPlayedUseCase] in
+                try? await updateLastPlayedUseCase.execute(romId: rom.id)
+            }
         } else {
             launchingRomId = nil
         }

--- a/romm/romm/UI/RomDetail/RomDetailViewModel.swift
+++ b/romm/romm/UI/RomDetail/RomDetailViewModel.swift
@@ -44,6 +44,7 @@ class RomDetailViewModel {
     private let getCollectionsUseCase: GetCollectionsUseCase
     private let checkEmulatorSupportUseCase: PCheckEmulatorSupportUseCase
     private let launchEmulatorUseCase: PLaunchEmulatorUseCase
+    private let updateLastPlayedUseCase: PUpdateLastPlayedUseCase
 
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared,
          apiClient: PRommAPIClient = RommAPIClient.shared) {
@@ -55,6 +56,7 @@ class RomDetailViewModel {
         self.getCollectionsUseCase = factory.makeGetCollectionsUseCase()
         self.checkEmulatorSupportUseCase = factory.makeCheckEmulatorSupportUseCase()
         self.launchEmulatorUseCase = factory.makeLaunchEmulatorUseCase()
+        self.updateLastPlayedUseCase = factory.makeUpdateLastPlayedUseCase()
     }
     
     func loadRomDetails(romId: Int) async {
@@ -314,6 +316,13 @@ class RomDetailViewModel {
         case .success(let decision):
             logger.info("Launching emulator for ROM: \(rom.name) — decision: \(String(describing: decision))")
             self.launchDecision = decision
+            Task { [updateLastPlayedUseCase, logger] in
+                do {
+                    try await updateLastPlayedUseCase.execute(romId: rom.id)
+                } catch {
+                    logger.warning("Failed to update last_played for ROM \(rom.id): \(error)")
+                }
+            }
 
         case .failure(let error):
             logger.error("Failed to launch emulator: \(error.localizedDescription)")


### PR DESCRIPTION
## Summary
- New `UpdateLastPlayedUseCase` + repository method → `PUT /api/roms/{id}/props { update_last_played: true }`
- Fired fire-and-forget on successful launch in `RomDetailViewModel.launchEmulator` and `PlatformROMsListView.launch` (composed outside `LaunchEmulatorUseCase`)
- Replaced `RommAPIClient.updateRomFavorite` (unused, had `updateLastPlayed=true` as a default bug) with `updateRomLastPlayed(id:)`

## Test plan
- [ ] Install on iMonk, launch a ROM from the library → web frontend shows the ROM under "Recently Played"
- [ ] Launch a ROM from "Local Device" via `PlatformROMsListView` → same effect in the web frontend
- [ ] A 401/network error on the last-played call must not block the launch flow (expect a logging warning)