### PR TITLE
Cloud sync for saves & states

### DIFF
--- a/romm/romm/Data/API/RommAPIClient+Saves.swift
+++ b/romm/romm/Data/API/RommAPIClient+Saves.swift
@@ -1,0 +1,135 @@
+//
+//  RommAPIClient+Saves.swift
+//  romm
+//
+
+import Foundation
+
+// MARK: - Saves API
+extension RommAPIClient {
+
+    func uploadSave(
+        romId: Int,
+        emulator: String?,
+        slot: String?,
+        deviceId: String?,
+        fileName: String,
+        fileData: Data,
+        screenshotData: Data?
+    ) async throws -> SaveSchema {
+        let path = withQuery("api/saves", [
+            ("rom_id", String(romId)),
+            ("emulator", emulator),
+            ("slot", slot),
+            ("device_id", deviceId)
+        ])
+        let boundary = "RommSavesBoundary\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        var formData = Data()
+        formData.appendFileField(
+            boundary: boundary,
+            name: "saveFile",
+            fileName: fileName,
+            mimeType: "application/octet-stream",
+            data: fileData
+        )
+        if let screenshotData {
+            formData.appendFileField(
+                boundary: boundary,
+                name: "screenshotFile",
+                fileName: "screenshot.png",
+                mimeType: "image/png",
+                data: screenshotData
+            )
+        }
+        formData.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let data = try await multipartRequest(
+            path: path,
+            method: .post,
+            boundary: boundary,
+            formData: formData,
+            additionalHeaders: nil
+        )
+        do {
+            return try JSONDecoder().decode(SaveSchema.self, from: data)
+        } catch {
+            throw APIClientError.decodingError(error)
+        }
+    }
+
+    func updateSave(
+        id: Int,
+        emulator: String?,
+        fileName: String,
+        fileData: Data,
+        screenshotData: Data?
+    ) async throws -> SaveSchema {
+        let path = withQuery("api/saves/\(id)", [("emulator", emulator)])
+        let boundary = "RommSavesBoundary\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        var formData = Data()
+        formData.appendFileField(
+            boundary: boundary,
+            name: "saveFile",
+            fileName: fileName,
+            mimeType: "application/octet-stream",
+            data: fileData
+        )
+        if let screenshotData {
+            formData.appendFileField(
+                boundary: boundary,
+                name: "screenshotFile",
+                fileName: "screenshot.png",
+                mimeType: "image/png",
+                data: screenshotData
+            )
+        }
+        formData.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let data = try await multipartRequest(
+            path: path,
+            method: .put,
+            boundary: boundary,
+            formData: formData,
+            additionalHeaders: nil
+        )
+        do {
+            return try JSONDecoder().decode(SaveSchema.self, from: data)
+        } catch {
+            throw APIClientError.decodingError(error)
+        }
+    }
+
+    func downloadSave(id: Int, deviceId: String?) async throws -> Data {
+        let path = withQuery("api/saves/\(id)/content", [
+            ("device_id", deviceId)
+        ])
+        return try await get(path)
+    }
+
+    func deleteSaves(ids: [Int]) async throws {
+        struct Body: Codable { let saves: [Int] }
+        _ = try await post("api/saves/delete", body: Body(saves: ids), responseType: BulkDeleteAck.self)
+    }
+}
+
+struct BulkDeleteAck: Codable {
+    let msg: String?
+}
+
+// MARK: - Multipart File Helper
+
+extension Data {
+    mutating func appendFileField(
+        boundary: String,
+        name: String,
+        fileName: String,
+        mimeType: String,
+        data: Data
+    ) {
+        append("--\(boundary)\r\n".data(using: .utf8)!)
+        append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(fileName)\"\r\n".data(using: .utf8)!)
+        append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
+        append(data)
+        append("\r\n".data(using: .utf8)!)
+    }
+}

--- a/romm/romm/Data/API/RommAPIClient+States.swift
+++ b/romm/romm/Data/API/RommAPIClient+States.swift
@@ -1,0 +1,106 @@
+//
+//  RommAPIClient+States.swift
+//  romm
+//
+
+import Foundation
+
+// MARK: - States API
+extension RommAPIClient {
+
+    func uploadState(
+        romId: Int,
+        emulator: String?,
+        fileName: String,
+        fileData: Data,
+        screenshotData: Data?
+    ) async throws -> StateSchema {
+        let path = withQuery("api/states", [
+            ("rom_id", String(romId)),
+            ("emulator", emulator)
+        ])
+        let boundary = "RommStatesBoundary\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        var formData = Data()
+        formData.appendFileField(
+            boundary: boundary,
+            name: "stateFile",
+            fileName: fileName,
+            mimeType: "application/octet-stream",
+            data: fileData
+        )
+        if let screenshotData {
+            formData.appendFileField(
+                boundary: boundary,
+                name: "screenshotFile",
+                fileName: "screenshot.png",
+                mimeType: "image/png",
+                data: screenshotData
+            )
+        }
+        formData.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let data = try await multipartRequest(
+            path: path,
+            method: .post,
+            boundary: boundary,
+            formData: formData,
+            additionalHeaders: nil
+        )
+        do {
+            return try JSONDecoder().decode(StateSchema.self, from: data)
+        } catch {
+            throw APIClientError.decodingError(error)
+        }
+    }
+
+    func updateState(
+        id: Int,
+        emulator: String?,
+        fileName: String,
+        fileData: Data,
+        screenshotData: Data?
+    ) async throws -> StateSchema {
+        let path = withQuery("api/states/\(id)", [("emulator", emulator)])
+        let boundary = "RommStatesBoundary\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        var formData = Data()
+        formData.appendFileField(
+            boundary: boundary,
+            name: "stateFile",
+            fileName: fileName,
+            mimeType: "application/octet-stream",
+            data: fileData
+        )
+        if let screenshotData {
+            formData.appendFileField(
+                boundary: boundary,
+                name: "screenshotFile",
+                fileName: "screenshot.png",
+                mimeType: "image/png",
+                data: screenshotData
+            )
+        }
+        formData.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let data = try await multipartRequest(
+            path: path,
+            method: .put,
+            boundary: boundary,
+            formData: formData,
+            additionalHeaders: nil
+        )
+        do {
+            return try JSONDecoder().decode(StateSchema.self, from: data)
+        } catch {
+            throw APIClientError.decodingError(error)
+        }
+    }
+
+    func downloadState(id: Int) async throws -> Data {
+        return try await get("api/states/\(id)/content")
+    }
+
+    func deleteStates(ids: [Int]) async throws {
+        struct Body: Codable { let states: [Int] }
+        _ = try await post("api/states/delete", body: Body(states: ids), responseType: BulkDeleteAck.self)
+    }
+}

--- a/romm/romm/Data/API/RommAPIClient.swift
+++ b/romm/romm/Data/API/RommAPIClient.swift
@@ -85,6 +85,17 @@ protocol PRommAPIClient {
     func getSaves(romId: Int) async throws -> [SaveSchema]
     func getStates(romId: Int) async throws -> [StateSchema]
 
+    // Saves sync
+    func uploadSave(romId: Int, emulator: String?, slot: String?, deviceId: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema
+    func updateSave(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema
+    func downloadSave(id: Int, deviceId: String?) async throws -> Data
+    func deleteSaves(ids: [Int]) async throws
+
+    // States sync
+    func uploadState(romId: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema
+    func updateState(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema
+    func downloadState(id: Int) async throws -> Data
+    func deleteStates(ids: [Int]) async throws
 }
 
 enum APIClientError: LocalizedError {

--- a/romm/romm/Data/Repositories/LocalSaveStoreRepository.swift
+++ b/romm/romm/Data/Repositories/LocalSaveStoreRepository.swift
@@ -25,6 +25,13 @@ final class LocalSaveStoreRepository: PSaveStore {
         try data.write(to: SaveStorePaths.batteryURL(root: rootDirectory, romId: romId), options: .atomic)
     }
 
+    func batteryModifiedAt(romId: Int) -> Date? {
+        let url = SaveStorePaths.batteryURL(root: rootDirectory, romId: romId)
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        let attrs = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+        return attrs?.contentModificationDate
+    }
+
     // MARK: - State
 
     func listStates(romId: Int) throws -> [SaveStateEntry] {

--- a/romm/romm/Data/Repositories/SavesRepository.swift
+++ b/romm/romm/Data/Repositories/SavesRepository.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+final class SavesRepository: PSavesRepository {
+    private let logger = Logger.data
+    private let apiClient: PRommAPIClient
+
+    init(apiClient: PRommAPIClient = RommAPIClient.shared) {
+        self.apiClient = apiClient
+    }
+
+    func listServerSaves(romId: Int) async throws -> [SaveSchema] {
+        try await apiClient.getSaves(romId: romId)
+    }
+
+    func uploadSave(romId: Int, emulator: String?, slot: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema {
+        logger.info("☁️ Uploading save romId=\(romId) emulator=\(emulator ?? "-") slot=\(slot ?? "-") size=\(fileData.count)")
+        return try await apiClient.uploadSave(
+            romId: romId,
+            emulator: emulator,
+            slot: slot,
+            deviceId: nil,
+            fileName: fileName,
+            fileData: fileData,
+            screenshotData: screenshotData
+        )
+    }
+
+    func updateSave(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema {
+        logger.info("☁️ Updating save id=\(id) size=\(fileData.count)")
+        return try await apiClient.updateSave(
+            id: id,
+            emulator: emulator,
+            fileName: fileName,
+            fileData: fileData,
+            screenshotData: screenshotData
+        )
+    }
+
+    func downloadSave(id: Int) async throws -> Data {
+        logger.info("☁️ Downloading save id=\(id)")
+        return try await apiClient.downloadSave(id: id, deviceId: nil)
+    }
+
+    func deleteSaves(ids: [Int]) async throws {
+        logger.info("☁️ Deleting saves \(ids)")
+        try await apiClient.deleteSaves(ids: ids)
+    }
+}

--- a/romm/romm/Data/Repositories/StatesRepository.swift
+++ b/romm/romm/Data/Repositories/StatesRepository.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+final class StatesRepository: PStatesRepository {
+    private let logger = Logger.data
+    private let apiClient: PRommAPIClient
+
+    init(apiClient: PRommAPIClient = RommAPIClient.shared) {
+        self.apiClient = apiClient
+    }
+
+    func listServerStates(romId: Int) async throws -> [StateSchema] {
+        try await apiClient.getStates(romId: romId)
+    }
+
+    func uploadState(romId: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema {
+        logger.info("☁️ Uploading state romId=\(romId) emulator=\(emulator ?? "-") file=\(fileName) size=\(fileData.count)")
+        return try await apiClient.uploadState(
+            romId: romId,
+            emulator: emulator,
+            fileName: fileName,
+            fileData: fileData,
+            screenshotData: screenshotData
+        )
+    }
+
+    func updateState(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema {
+        logger.info("☁️ Updating state id=\(id) size=\(fileData.count)")
+        return try await apiClient.updateState(
+            id: id,
+            emulator: emulator,
+            fileName: fileName,
+            fileData: fileData,
+            screenshotData: screenshotData
+        )
+    }
+
+    func downloadState(id: Int) async throws -> Data {
+        logger.info("☁️ Downloading state id=\(id)")
+        return try await apiClient.downloadState(id: id)
+    }
+
+    func deleteStates(ids: [Int]) async throws {
+        logger.info("☁️ Deleting states \(ids)")
+        try await apiClient.deleteStates(ids: ids)
+    }
+}

--- a/romm/romm/Data/Services/CloudSaveSyncSettings.swift
+++ b/romm/romm/Data/Services/CloudSaveSyncSettings.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+final class CloudSaveSyncSettings: ObservableObject {
+    static let shared = CloudSaveSyncSettings()
+
+    private let userDefaults = UserDefaults.standard
+    private enum Keys {
+        static let enabled = "cloud_save_sync_enabled"
+    }
+
+    @Published var isEnabled: Bool {
+        didSet { userDefaults.set(isEnabled, forKey: Keys.enabled) }
+    }
+
+    private init() {
+        self.isEnabled = userDefaults.bool(forKey: Keys.enabled)
+    }
+}

--- a/romm/romm/Domain/RepositoryProtocols/PSaveStore.swift
+++ b/romm/romm/Domain/RepositoryProtocols/PSaveStore.swift
@@ -3,6 +3,7 @@ import Foundation
 protocol PSaveStore {
     func readBattery(romId: Int) throws -> Data?
     func writeBattery(romId: Int, data: Data) throws
+    func batteryModifiedAt(romId: Int) -> Date?
 
     func listStates(romId: Int) throws -> [SaveStateEntry]
     func readState(romId: Int, slot: Int) throws -> Data?

--- a/romm/romm/Domain/RepositoryProtocols/PSavesRepository.swift
+++ b/romm/romm/Domain/RepositoryProtocols/PSavesRepository.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol PSavesRepository {
+    func listServerSaves(romId: Int) async throws -> [SaveSchema]
+    func uploadSave(romId: Int, emulator: String?, slot: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema
+    func updateSave(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema
+    func downloadSave(id: Int) async throws -> Data
+    func deleteSaves(ids: [Int]) async throws
+}

--- a/romm/romm/Domain/RepositoryProtocols/PStatesRepository.swift
+++ b/romm/romm/Domain/RepositoryProtocols/PStatesRepository.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol PStatesRepository {
+    func listServerStates(romId: Int) async throws -> [StateSchema]
+    func uploadState(romId: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema
+    func updateState(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema
+    func downloadState(id: Int) async throws -> Data
+    func deleteStates(ids: [Int]) async throws
+}

--- a/romm/romm/Domain/UseCases/Saves/SavesSyncUseCases.swift
+++ b/romm/romm/Domain/UseCases/Saves/SavesSyncUseCases.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+protocol PListServerSavesUseCase {
+    func execute(romId: Int) async throws -> [SaveSchema]
+}
+
+protocol PUploadSaveUseCase {
+    func execute(romId: Int, emulator: String?, slot: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema
+}
+
+protocol PUpdateSaveUseCase {
+    func execute(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema
+}
+
+protocol PDownloadSaveUseCase {
+    func execute(id: Int) async throws -> Data
+}
+
+final class ListServerSavesUseCase: PListServerSavesUseCase {
+    private let repository: PSavesRepository
+    init(repository: PSavesRepository) { self.repository = repository }
+    func execute(romId: Int) async throws -> [SaveSchema] {
+        guard romId > 0 else { throw RomError.invalidRomId }
+        return try await repository.listServerSaves(romId: romId)
+    }
+}
+
+final class UploadSaveUseCase: PUploadSaveUseCase {
+    private let repository: PSavesRepository
+    init(repository: PSavesRepository) { self.repository = repository }
+    func execute(romId: Int, emulator: String?, slot: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema {
+        guard romId > 0 else { throw RomError.invalidRomId }
+        return try await repository.uploadSave(
+            romId: romId,
+            emulator: emulator,
+            slot: slot,
+            fileName: fileName,
+            fileData: fileData,
+            screenshotData: screenshotData
+        )
+    }
+}
+
+final class UpdateSaveUseCase: PUpdateSaveUseCase {
+    private let repository: PSavesRepository
+    init(repository: PSavesRepository) { self.repository = repository }
+    func execute(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema {
+        try await repository.updateSave(
+            id: id,
+            emulator: emulator,
+            fileName: fileName,
+            fileData: fileData,
+            screenshotData: screenshotData
+        )
+    }
+}
+
+final class DownloadSaveUseCase: PDownloadSaveUseCase {
+    private let repository: PSavesRepository
+    init(repository: PSavesRepository) { self.repository = repository }
+    func execute(id: Int) async throws -> Data {
+        try await repository.downloadSave(id: id)
+    }
+}

--- a/romm/romm/Domain/UseCases/States/StatesSyncUseCases.swift
+++ b/romm/romm/Domain/UseCases/States/StatesSyncUseCases.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+protocol PListServerStatesUseCase {
+    func execute(romId: Int) async throws -> [StateSchema]
+}
+
+protocol PUploadStateUseCase {
+    func execute(romId: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema
+}
+
+protocol PUpdateStateUseCase {
+    func execute(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema
+}
+
+protocol PDownloadStateUseCase {
+    func execute(id: Int) async throws -> Data
+}
+
+final class ListServerStatesUseCase: PListServerStatesUseCase {
+    private let repository: PStatesRepository
+    init(repository: PStatesRepository) { self.repository = repository }
+    func execute(romId: Int) async throws -> [StateSchema] {
+        guard romId > 0 else { throw RomError.invalidRomId }
+        return try await repository.listServerStates(romId: romId)
+    }
+}
+
+final class UploadStateUseCase: PUploadStateUseCase {
+    private let repository: PStatesRepository
+    init(repository: PStatesRepository) { self.repository = repository }
+    func execute(romId: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema {
+        guard romId > 0 else { throw RomError.invalidRomId }
+        return try await repository.uploadState(
+            romId: romId,
+            emulator: emulator,
+            fileName: fileName,
+            fileData: fileData,
+            screenshotData: screenshotData
+        )
+    }
+}
+
+final class UpdateStateUseCase: PUpdateStateUseCase {
+    private let repository: PStatesRepository
+    init(repository: PStatesRepository) { self.repository = repository }
+    func execute(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema {
+        try await repository.updateState(
+            id: id,
+            emulator: emulator,
+            fileName: fileName,
+            fileData: fileData,
+            screenshotData: screenshotData
+        )
+    }
+}
+
+final class DownloadStateUseCase: PDownloadStateUseCase {
+    private let repository: PStatesRepository
+    init(repository: PStatesRepository) { self.repository = repository }
+    func execute(id: Int) async throws -> Data {
+        try await repository.downloadState(id: id)
+    }
+}

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -91,6 +91,7 @@ protocol PDependencyFactory {
     func makeResolveROMFileUseCase() -> PResolveROMFileUseCase
     func makeEmulatorSaveStatesUseCase() -> PEmulatorSaveStatesUseCase
     func makeBIOSSyncUseCase() -> PBIOSSyncUseCase
+    @MainActor func makeCloudSaveSyncService(romId: Int, emulator: String, batteryFileName: String) -> CloudSaveSyncService
     @MainActor func makeLibretroEmulatorViewModel(rom: Rom, core: LibretroCore) -> LibretroEmulatorViewModel
 
     // Emulator Engine
@@ -373,6 +374,8 @@ class DefaultDependencyFactory: PDependencyFactory {
     }
 
     lazy var saveStore: PSaveStore = LocalSaveStoreRepository()
+    lazy var savesRepository: PSavesRepository = SavesRepository()
+    lazy var statesRepository: PStatesRepository = StatesRepository()
     lazy var fileSystemService: PFileSystemService = DefaultFileSystemService()
     lazy var viewModePreferenceRepository: PViewModePreferenceRepository = UserDefaultsViewModePreferenceStore()
 
@@ -392,6 +395,21 @@ class DefaultDependencyFactory: PDependencyFactory {
         BIOSSyncUseCase(apiClient: apiClient, fileSystem: fileSystemService)
     }
 
+    @MainActor func makeCloudSaveSyncService(romId: Int, emulator: String, batteryFileName: String) -> CloudSaveSyncService {
+        CloudSaveSyncService(
+            config: .init(romId: romId, emulator: emulator, batteryFileName: batteryFileName),
+            saveStore: saveStore,
+            listSavesUseCase: ListServerSavesUseCase(repository: savesRepository),
+            uploadSaveUseCase: UploadSaveUseCase(repository: savesRepository),
+            updateSaveUseCase: UpdateSaveUseCase(repository: savesRepository),
+            downloadSaveUseCase: DownloadSaveUseCase(repository: savesRepository),
+            listStatesUseCase: ListServerStatesUseCase(repository: statesRepository),
+            uploadStateUseCase: UploadStateUseCase(repository: statesRepository),
+            updateStateUseCase: UpdateStateUseCase(repository: statesRepository),
+            downloadStateUseCase: DownloadStateUseCase(repository: statesRepository)
+        )
+    }
+
     @MainActor func makeLibretroEmulatorViewModel(rom: Rom, core: LibretroCore) -> LibretroEmulatorViewModel {
         LibretroEmulatorViewModel(
             rom: rom,
@@ -400,7 +418,8 @@ class DefaultDependencyFactory: PDependencyFactory {
             resolveROMFile: makeResolveROMFileUseCase(),
             saveStates: makeEmulatorSaveStatesUseCase(),
             biosSync: makeBIOSSyncUseCase(),
-            aspectRatioPreference: libretroAspectRatioPreference
+            aspectRatioPreference: libretroAspectRatioPreference,
+            factory: self
         )
     }
 

--- a/romm/romm/UI/DI/MockDependencyFactory.swift
+++ b/romm/romm/UI/DI/MockDependencyFactory.swift
@@ -336,6 +336,24 @@ class MockDependencyFactory: PDependencyFactory {
         BIOSSyncUseCase(apiClient: apiClient, fileSystem: fileSystemService)
     }
 
+    lazy var savesRepository: PSavesRepository = SavesRepository(apiClient: apiClient)
+    lazy var statesRepository: PStatesRepository = StatesRepository(apiClient: apiClient)
+
+    @MainActor func makeCloudSaveSyncService(romId: Int, emulator: String, batteryFileName: String) -> CloudSaveSyncService {
+        CloudSaveSyncService(
+            config: .init(romId: romId, emulator: emulator, batteryFileName: batteryFileName),
+            saveStore: saveStore,
+            listSavesUseCase: ListServerSavesUseCase(repository: savesRepository),
+            uploadSaveUseCase: UploadSaveUseCase(repository: savesRepository),
+            updateSaveUseCase: UpdateSaveUseCase(repository: savesRepository),
+            downloadSaveUseCase: DownloadSaveUseCase(repository: savesRepository),
+            listStatesUseCase: ListServerStatesUseCase(repository: statesRepository),
+            uploadStateUseCase: UploadStateUseCase(repository: statesRepository),
+            updateStateUseCase: UpdateStateUseCase(repository: statesRepository),
+            downloadStateUseCase: DownloadStateUseCase(repository: statesRepository)
+        )
+    }
+
     @MainActor func makeLibretroEmulatorViewModel(rom: Rom, core: LibretroCore) -> LibretroEmulatorViewModel {
         LibretroEmulatorViewModel(
             rom: rom,
@@ -344,7 +362,8 @@ class MockDependencyFactory: PDependencyFactory {
             resolveROMFile: makeResolveROMFileUseCase(),
             saveStates: makeEmulatorSaveStatesUseCase(),
             biosSync: makeBIOSSyncUseCase(),
-            aspectRatioPreference: libretroAspectRatioPreference
+            aspectRatioPreference: libretroAspectRatioPreference,
+            factory: self
         )
     }
 }

--- a/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
+++ b/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+/// Orchestrates cloud sync of battery/state files against the RomM server for
+/// a single emulator session. Lives at the Session layer (not as a UseCase) so
+/// it can compose the individual sync UseCases without violating the
+/// "no UseCase-inside-UseCase" rule.
+@MainActor
+final class CloudSaveSyncService {
+
+    struct Config {
+        let romId: Int
+        /// Server-side `emulator` tag used to group saves/states. Examples:
+        /// "delta-ios" for DeltaCore, "libretro-pcsx-rearmed" for Libretro PSX.
+        let emulator: String
+        /// File-stem used for battery uploads. Web frontend identifies battery
+        /// saves by filename; keep this stable across uploads for the same ROM.
+        let batteryFileName: String
+    }
+
+    private let config: Config
+    private let saveStore: PSaveStore
+    private let listSavesUseCase: PListServerSavesUseCase
+    private let uploadSaveUseCase: PUploadSaveUseCase
+    private let updateSaveUseCase: PUpdateSaveUseCase
+    private let downloadSaveUseCase: PDownloadSaveUseCase
+    private let listStatesUseCase: PListServerStatesUseCase
+    private let uploadStateUseCase: PUploadStateUseCase
+    private let updateStateUseCase: PUpdateStateUseCase
+    private let downloadStateUseCase: PDownloadStateUseCase
+    private let settings: CloudSaveSyncSettings
+
+    private var serverBatteryId: Int?
+    private var serverStateIdBySlot: [Int: Int] = [:]
+
+    init(
+        config: Config,
+        saveStore: PSaveStore,
+        listSavesUseCase: PListServerSavesUseCase,
+        uploadSaveUseCase: PUploadSaveUseCase,
+        updateSaveUseCase: PUpdateSaveUseCase,
+        downloadSaveUseCase: PDownloadSaveUseCase,
+        listStatesUseCase: PListServerStatesUseCase,
+        uploadStateUseCase: PUploadStateUseCase,
+        updateStateUseCase: PUpdateStateUseCase,
+        downloadStateUseCase: PDownloadStateUseCase,
+        settings: CloudSaveSyncSettings = .shared
+    ) {
+        self.config = config
+        self.saveStore = saveStore
+        self.listSavesUseCase = listSavesUseCase
+        self.uploadSaveUseCase = uploadSaveUseCase
+        self.updateSaveUseCase = updateSaveUseCase
+        self.downloadSaveUseCase = downloadSaveUseCase
+        self.listStatesUseCase = listStatesUseCase
+        self.uploadStateUseCase = uploadStateUseCase
+        self.updateStateUseCase = updateStateUseCase
+        self.downloadStateUseCase = downloadStateUseCase
+        self.settings = settings
+    }
+
+    var isEnabled: Bool { settings.isEnabled }
+
+    // MARK: - Pull (download newer-than-local before emulator starts)
+
+    /// Lists server saves/states for this ROM and pulls any that are newer
+    /// than the corresponding local file. Errors are swallowed and logged so a
+    /// failed pull never blocks emulator launch.
+    func pullBeforeLaunch() async {
+        guard isEnabled else { return }
+        await pullBattery()
+        await pullStates()
+    }
+
+    private func pullBattery() async {
+        do {
+            let saves = try await listSavesUseCase.execute(romId: config.romId)
+            let match = saves.first { $0.fileName == config.batteryFileName } ?? saves.first
+            guard let match else { return }
+            serverBatteryId = match.id
+
+            let localMTime = saveStore.batteryModifiedAt(romId: config.romId)
+            if let localMTime, localMTime >= match.updatedAt { return }
+
+            let data = try await downloadSaveUseCase.execute(id: match.id)
+            try saveStore.writeBattery(romId: config.romId, data: data)
+            print("[CloudSync] battery pulled (\(data.count) bytes)")
+        } catch {
+            print("[CloudSync] battery pull failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func pullStates() async {
+        do {
+            let states = try await listStatesUseCase.execute(romId: config.romId)
+            for s in states {
+                guard let slot = Self.slotFromFileName(s.fileName) else { continue }
+                serverStateIdBySlot[slot] = s.id
+
+                let localMTime = saveStore.stateModifiedAt(romId: config.romId, slot: slot)
+                if let localMTime, localMTime >= s.updatedAt { continue }
+
+                let data = try await downloadStateUseCase.execute(id: s.id)
+                try saveStore.writeState(romId: config.romId, slot: slot, data: data)
+                print("[CloudSync] state slot \(slot) pulled (\(data.count) bytes)")
+            }
+        } catch {
+            print("[CloudSync] states pull failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Push (fire-and-forget after local write)
+
+    func pushBattery(data: Data) {
+        guard isEnabled else { return }
+        let cfg = config
+        let serverId = serverBatteryId
+        Task { [uploadSaveUseCase, updateSaveUseCase] in
+            do {
+                let result: SaveSchema
+                if let serverId {
+                    result = try await updateSaveUseCase.execute(
+                        id: serverId,
+                        emulator: cfg.emulator,
+                        fileName: cfg.batteryFileName,
+                        fileData: data,
+                        screenshotData: nil
+                    )
+                } else {
+                    result = try await uploadSaveUseCase.execute(
+                        romId: cfg.romId,
+                        emulator: cfg.emulator,
+                        slot: nil,
+                        fileName: cfg.batteryFileName,
+                        fileData: data,
+                        screenshotData: nil
+                    )
+                }
+                await self.recordBatteryId(result.id)
+                print("[CloudSync] battery pushed id=\(result.id)")
+            } catch {
+                print("[CloudSync] battery push failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func pushState(slot: Int, data: Data, thumbnail: Data?) {
+        guard isEnabled else { return }
+        let cfg = config
+        let fileName = Self.stateFileName(slot: slot)
+        let serverId = serverStateIdBySlot[slot]
+        Task { [uploadStateUseCase, updateStateUseCase] in
+            do {
+                let result: StateSchema
+                if let serverId {
+                    result = try await updateStateUseCase.execute(
+                        id: serverId,
+                        emulator: cfg.emulator,
+                        fileName: fileName,
+                        fileData: data,
+                        screenshotData: thumbnail
+                    )
+                } else {
+                    result = try await uploadStateUseCase.execute(
+                        romId: cfg.romId,
+                        emulator: cfg.emulator,
+                        fileName: fileName,
+                        fileData: data,
+                        screenshotData: thumbnail
+                    )
+                }
+                await self.recordStateId(slot: slot, id: result.id)
+                print("[CloudSync] state slot \(slot) pushed id=\(result.id)")
+            } catch {
+                print("[CloudSync] state slot \(slot) push failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func recordBatteryId(_ id: Int) { serverBatteryId = id }
+    private func recordStateId(slot: Int, id: Int) { serverStateIdBySlot[slot] = id }
+
+    // MARK: - Filename helpers
+
+    static func stateFileName(slot: Int) -> String { "slot\(slot).state" }
+
+    /// Parses `slotN.state` (or `slotN.*`) back to slot index `N`.
+    static func slotFromFileName(_ name: String) -> Int? {
+        let stem = (name as NSString).deletingPathExtension
+        guard stem.hasPrefix("slot") else { return nil }
+        return Int(stem.dropFirst("slot".count))
+    }
+}

--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
@@ -17,6 +17,7 @@ final class LibretroEmulatorViewModel {
     private let saveStates: PEmulatorSaveStatesUseCase
     private let biosSync: PBIOSSyncUseCase
     let aspectRatioPreference: PLibretroAspectRatioPreference
+    private let factory: PDependencyFactory
     private let logger = Logger.viewModel
 
     init(
@@ -26,7 +27,8 @@ final class LibretroEmulatorViewModel {
         resolveROMFile: PResolveROMFileUseCase,
         saveStates: PEmulatorSaveStatesUseCase,
         biosSync: PBIOSSyncUseCase,
-        aspectRatioPreference: PLibretroAspectRatioPreference
+        aspectRatioPreference: PLibretroAspectRatioPreference,
+        factory: PDependencyFactory
     ) {
         self.rom = rom
         self.core = core
@@ -35,6 +37,7 @@ final class LibretroEmulatorViewModel {
         self.saveStates = saveStates
         self.biosSync = biosSync
         self.aspectRatioPreference = aspectRatioPreference
+        self.factory = factory
     }
 
     func bootstrap() {
@@ -66,12 +69,19 @@ final class LibretroEmulatorViewModel {
                 isLoading = false
                 return
             }
+            let batteryFileName = url.deletingPathExtension().lastPathComponent + ".srm"
+            let cloudSync = factory.makeCloudSaveSyncService(
+                romId: rom.id,
+                emulator: "libretro-\(core.dylibName)",
+                batteryFileName: batteryFileName
+            )
             let s = LibretroSession(
                 gameURL: url,
                 core: core,
                 romId: rom.id,
                 saveStates: saveStates,
-                aspectRatioPreference: aspectRatioPreference
+                aspectRatioPreference: aspectRatioPreference,
+                cloudSync: cloudSync
             )
             s.onMenuRequested = { [weak self] in self?.onMenuRequested?() }
             session = s

--- a/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
@@ -9,6 +9,7 @@ final class LibretroSession: NSObject {
     private let romId: Int
     private let saveStates: PEmulatorSaveStatesUseCase
     private let aspectRatioPreference: PLibretroAspectRatioPreference
+    private let cloudSync: CloudSaveSyncService?
     private let frontend = LibretroFrontend.shared
 
     var onMenuRequested: (() -> Void)?
@@ -20,13 +21,15 @@ final class LibretroSession: NSObject {
         core: LibretroCore,
         romId: Int,
         saveStates: PEmulatorSaveStatesUseCase,
-        aspectRatioPreference: PLibretroAspectRatioPreference
+        aspectRatioPreference: PLibretroAspectRatioPreference,
+        cloudSync: CloudSaveSyncService? = nil
     ) {
         self.gameURL = gameURL
         self.core = core
         self.romId = romId
         self.saveStates = saveStates
         self.aspectRatioPreference = aspectRatioPreference
+        self.cloudSync = cloudSync
         self.viewController = LibretroGameViewController(
             core: core,
             gameURL: gameURL,
@@ -44,6 +47,13 @@ final class LibretroSession: NSObject {
         let videoView = viewController.videoView
         frontend.videoSink = videoView
 
+        Task { [weak self] in
+            await self?.cloudSync?.pullBeforeLaunch()
+            self?.startCore()
+        }
+    }
+
+    private func startCore() {
         do {
             let corePath = try locateCoreDylib()
             let systemDir = libretroSystemDirectory().path
@@ -76,6 +86,17 @@ final class LibretroSession: NSObject {
         // dlclose() any CGImage backed by core memory would crash on render.
         frontend.videoSink = nil
         frontend.stop()
+        flushBatteryFromSaveDir()
+    }
+
+    /// Libretro cores persist their battery saves (.srm) into `saveDir` during
+    /// runtime — we read the file once the core has stopped and push it.
+    private func flushBatteryFromSaveDir() {
+        let stem = gameURL.deletingPathExtension().lastPathComponent
+        let candidate = libretroSaveDirectory().appendingPathComponent("\(stem).srm")
+        guard let data = try? Data(contentsOf: candidate) else { return }
+        try? saveStates.writeBattery(romId: romId, data: data)
+        cloudSync?.pushBattery(data: data)
     }
 
     // MARK: - Save state API (mirrors DeltaCoreSession)
@@ -102,9 +123,11 @@ final class LibretroSession: NSObject {
         }
         try saveStates.backupSlotForUndoSave(romId: romId, slot: slot)
         try saveStates.writeState(romId: romId, slot: slot, data: data)
-        if let thumb = viewController.videoView.snapshot()?.pngData() {
+        let thumb = viewController.videoView.snapshot()?.pngData()
+        if let thumb {
             try saveStates.writeThumbnail(romId: romId, slot: slot, data: thumb)
         }
+        cloudSync?.pushState(slot: slot, data: data, thumbnail: thumb)
     }
 
     func loadState(slot: Int) throws {

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -46,6 +46,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     private let gameType: GameType
     private let saveStates: PEmulatorSaveStatesUseCase
     private let romId: Int
+    private let cloudSync: CloudSaveSyncService?
 
     var onMenuRequested: (() -> Void)?
 
@@ -61,11 +62,12 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         viewController.emulatorCore
     }
 
-    init(gameURL: URL, gameType: GameType, romId: Int, saveStates: PEmulatorSaveStatesUseCase) {
+    init(gameURL: URL, gameType: GameType, romId: Int, saveStates: PEmulatorSaveStatesUseCase, cloudSync: CloudSaveSyncService? = nil) {
         self.gameURL = gameURL
         self.gameType = gameType
         self.romId = romId
         self.saveStates = saveStates
+        self.cloudSync = cloudSync
 
         let vc = RommGameViewController()
         vc.loadViewIfNeeded()
@@ -103,10 +105,13 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     // MARK: - Lifecycle
 
     func start() {
-        loadBatteryIfAvailable()
-        viewController.startEmulation()
-        attachExternalControllers()
-        observeControllerConnections()
+        Task { [weak self] in
+            await self?.cloudSync?.pullBeforeLaunch()
+            self?.loadBatteryIfAvailable()
+            self?.viewController.startEmulation()
+            self?.attachExternalControllers()
+            self?.observeControllerConnections()
+        }
     }
 
     func pause() { viewController.pauseEmulation() }
@@ -195,10 +200,12 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         core.saveSaveState(to: tmp)
         let data = try Data(contentsOf: tmp)
         try saveStates.writeState(romId: romId, slot: slot, data: data)
-        if let thumb = currentThumbnailPNG() {
+        let thumb = currentThumbnailPNG()
+        if let thumb {
             try saveStates.writeThumbnail(romId: romId, slot: slot, data: thumb)
         }
         try? FileManager.default.removeItem(at: tmp)
+        cloudSync?.pushState(slot: slot, data: data, thumbnail: thumb)
     }
 
     func loadState(slot: Int) throws {
@@ -257,6 +264,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         let savURL = Game(fileURL: gameURL, type: gameType).gameSaveURL
         if let data = try? Data(contentsOf: savURL) {
             try? saveStates.writeBattery(romId: romId, data: data)
+            cloudSync?.pushBattery(data: data)
         }
     }
 }

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorView.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorView.swift
@@ -12,7 +12,8 @@ struct NativeEmulatorView: View {
             rom: rom, gameType: gameType,
             getDownloadedROM: factory.makeGetDownloadedROMUseCase(),
             resolveROMFile: factory.makeResolveROMFileUseCase(),
-            saveStates: factory.makeEmulatorSaveStatesUseCase()
+            saveStates: factory.makeEmulatorSaveStatesUseCase(),
+            factory: factory
         ))
     }
 

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
@@ -22,6 +22,7 @@ final class NativeEmulatorViewModel {
     private let getDownloadedROM: PGetDownloadedROMUseCase
     private let resolveROMFile: PResolveROMFileUseCase
     private let saveStates: PEmulatorSaveStatesUseCase
+    private let factory: PDependencyFactory
     private let logger = Logger.viewModel
 
     init(
@@ -29,13 +30,15 @@ final class NativeEmulatorViewModel {
         gameType: DeltaGameType,
         getDownloadedROM: PGetDownloadedROMUseCase,
         resolveROMFile: PResolveROMFileUseCase,
-        saveStates: PEmulatorSaveStatesUseCase
+        saveStates: PEmulatorSaveStatesUseCase,
+        factory: PDependencyFactory
     ) {
         self.rom = rom
         self.gameType = gameType
         self.getDownloadedROM = getDownloadedROM
         self.resolveROMFile = resolveROMFile
         self.saveStates = saveStates
+        self.factory = factory
     }
 
     func bootstrap() {
@@ -52,9 +55,16 @@ final class NativeEmulatorViewModel {
                 return
             }
             let deltaType = Self.deltaCoreGameType(for: gameType)
+            let batteryFileName = url.deletingPathExtension().lastPathComponent + ".sav"
+            let cloudSync = factory.makeCloudSaveSyncService(
+                romId: rom.id,
+                emulator: "delta-ios",
+                batteryFileName: batteryFileName
+            )
             session = NativeEmulatorSession(
                 gameURL: url, gameType: deltaType,
-                romId: rom.id, saveStates: saveStates
+                romId: rom.id, saveStates: saveStates,
+                cloudSync: cloudSync
             )
             session?.start()
             Task { @MainActor in

--- a/romm/romm/UI/Profile/SettingsView.swift
+++ b/romm/romm/UI/Profile/SettingsView.swift
@@ -13,6 +13,7 @@ struct SettingsView: View {
     @EnvironmentObject var appData: AppData
     @State private var profileViewModel = ProfileViewModel()
     @StateObject private var experimentalSettings = ExperimentalFeatureSettings.shared
+    @StateObject private var cloudSyncSettings = CloudSaveSyncSettings.shared
     @State private var showingLogoutAlert = false
     @State private var showingResetAlert = false
     
@@ -171,6 +172,18 @@ struct SettingsView: View {
                             HStack {
                                 Image(systemName: "cpu")
                                 Text("BIOS Files")
+                            }
+                        }
+
+                        Toggle(isOn: $cloudSyncSettings.isEnabled) {
+                            HStack {
+                                Image(systemName: "icloud.and.arrow.up")
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Cloud-Sync für Saves")
+                                    Text("Spielstände und Save States mit RomM-Server synchronisieren")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Sync battery saves and save states to the RomM server via multipart upload (POST/PUT) and binary download
- `CloudSaveSyncService` coordinates at the session layer: `pullBeforeLaunch` downloads when `server.updated_at > local mtime`; push runs fire-and-forget after local writes
- Toggle in Settings (under the Emulator section), gated by `CloudSaveSyncSettings.isEnabled`
- Integrated into `NativeEmulatorSession` (DeltaCore, `delta-ios`) and `LibretroSession` (`libretro-<dylibName>`); states encode the slot in the filename (`slotN.state`), saves use the `slot` query param

## Architecture
- API: `RommAPIClient+Saves` / `+States` (multipart helper as a `Data` extension)
- Domain: `PSavesRepository` / `PStatesRepository` plus use cases (List/Upload/Update/Download, 4 each)
- Composition lives in `CloudSaveSyncService` (no use-case-in-use-case)
- DI via `PDependencyFactory.makeCloudSaveSyncService(romId:emulator:batteryFileName:)`

## Test plan
- [ ] Enable the cloud sync toggle, create a save → it appears on the server
- [ ] Save state in slot 1 → upload, then save again → update (PUT)
- [ ] Server save newer than local → downloaded on launch
- [ ] Local newer than server → server stays untouched on launch
- [ ] Libretro PSX: `.srm` is pushed on `stop()`