### PR TITLE
Add 'Done' keyboard toolbar to dismiss search keyboard

### DIFF
--- a/romm/romm/UI/Search/SearchView.swift
+++ b/romm/romm/UI/Search/SearchView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct SearchView: View {
     @State private var searchViewModel = SearchViewModel()
     @State private var searchText = ""
-    @Environment(\.isSearching) private var isSearching
 
     var body: some View {
         searchContentView
@@ -20,7 +19,7 @@ struct SearchView: View {
                 searchViewModel.search(query: searchText)
             }
             .toolbar {
-                cancelToolbarItem
+                keyboardToolbar
             }
             .alert(
                 "Error",
@@ -144,14 +143,14 @@ struct SearchView: View {
     }
 
     @ToolbarContentBuilder
-    private var cancelToolbarItem: some ToolbarContent {
-        if isSearching || !searchText.isEmpty {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button("Abbrechen") {
-                    searchText = ""
-                    searchViewModel.clearResults()
-                }
-                .foregroundColor(.blue)
+    private var keyboardToolbar: some ToolbarContent {
+        ToolbarItemGroup(placement: .keyboard) {
+            Spacer()
+            Button("Fertig") {
+                UIApplication.shared.sendAction(
+                    #selector(UIResponder.resignFirstResponder),
+                    to: nil, from: nil, for: nil
+                )
             }
         }
     }

--- a/romm/romm/UI/Search/SearchView.swift
+++ b/romm/romm/UI/Search/SearchView.swift
@@ -146,7 +146,7 @@ struct SearchView: View {
     private var keyboardToolbar: some ToolbarContent {
         ToolbarItemGroup(placement: .keyboard) {
             Spacer()
-            Button("Fertig") {
+            Button("Done") {
                 UIApplication.shared.sendAction(
                     #selector(UIResponder.resignFirstResponder),
                     to: nil, from: nil, for: nil


### PR DESCRIPTION
## Summary
- The previous cancel button was gated on \`Environment(.isSearching)\`, which is always \`false\` on the same view that owns \`.searchable\`, so it never appeared.
- There was no reliable way to dismiss the keyboard from the empty/no-results states (\`.scrollDismissesKeyboard\` only fires on actual scrolling).
- Replaced the dead cancel toolbar with a keyboard accessory **Fertig** button that resigns first responder, so users can always close the keyboard.

## Test plan
- [ ] Open Search tab → keyboard pops up, 'Fertig' visible above keyboard, tap dismisses
- [ ] Type query, no results → 'Fertig' still works
- [ ] Type query, results shown → 'Fertig' dismisses keyboard, results stay