### PR TITLE
fix(cloudsync): stop discarding server states not named slotN.state

### DIFF
--- a/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
+++ b/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
@@ -95,8 +95,37 @@ final class CloudSaveSyncService {
     private func pullStates() async {
         do {
             let states = try await listStatesUseCase.execute(romId: config.romId)
+
+            // First pass: map states with a recognizable `slotN.state` name to
+            // their real slot. States with any other server-side name (e.g.
+            // "Chrono Trigger (USA) [2026-05-06 ...].state") are collected so we
+            // can assign them synthetic slots that never collide with real ones.
+            var realSlots = Set<Int>()
+            var unnamed: [StateSchema] = []
             for s in states {
-                guard let slot = Self.slotFromFileName(s.fileName) else { continue }
+                if let slot = Self.slotFromFileName(s.fileName) {
+                    realSlots.insert(slot)
+                } else {
+                    unnamed.append(s)
+                }
+            }
+
+            // Deterministically order the unnamed states (by updatedAt, then id)
+            // so the same server state maps to the same synthetic slot across
+            // launches, then hand each the next free slot index.
+            let ordered = unnamed.sorted {
+                $0.updatedAt == $1.updatedAt ? $0.id < $1.id : $0.updatedAt < $1.updatedAt
+            }
+            var syntheticSlotByStateId: [Int: Int] = [:]
+            var nextSlot = 0
+            for s in ordered {
+                while realSlots.contains(nextSlot) { nextSlot += 1 }
+                syntheticSlotByStateId[s.id] = nextSlot
+                realSlots.insert(nextSlot)
+            }
+
+            for s in states {
+                guard let slot = Self.slotFromFileName(s.fileName) ?? syntheticSlotByStateId[s.id] else { continue }
                 serverStateIdBySlot[slot] = s.id
 
                 let localMTime = saveStore.stateModifiedAt(romId: config.romId, slot: slot)

--- a/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
+++ b/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
@@ -116,12 +116,20 @@ final class CloudSaveSyncService {
             let ordered = unnamed.sorted {
                 $0.updatedAt == $1.updatedAt ? $0.id < $1.id : $0.updatedAt < $1.updatedAt
             }
+            // Cap at the highest slot the UI can display (slots 0…20 = 21 total,
+            // see EmulatorMenuSheet). Anything beyond that has no visible slot.
+            let maxSlot = 20
             var syntheticSlotByStateId: [Int: Int] = [:]
             var nextSlot = 0
+            var overflow = 0
             for s in ordered {
                 while realSlots.contains(nextSlot) { nextSlot += 1 }
+                guard nextSlot <= maxSlot else { overflow += 1; continue }
                 syntheticSlotByStateId[s.id] = nextSlot
                 realSlots.insert(nextSlot)
+            }
+            if overflow > 0 {
+                print("[CloudSync] \(overflow) server state(s) skipped: no free slot (max \(maxSlot + 1))")
             }
 
             for s in states {

--- a/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
+++ b/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
@@ -10,7 +10,9 @@ struct EmulatorMenuSheet: View {
     @SwiftUI.State private var refreshTick: Int = 0
     @SwiftUI.State private var showQuitConfirmation = false
 
-    private let slots = Array(1...20)
+    // Slots are 0-based to match the save-state storage / cloud-sync layer
+    // (files are `slot0.state`…`slot20.state`). Slot 0 is a real, usable slot.
+    private let slots = Array(0...20)
 
     var body: some View {
         NavigationStack {


### PR DESCRIPTION
Fixes #33. `pullStates()` dropped any server state whose filename wasn't `slotN.state`, so web-frontend saves like `Chrono Trigger (USA) [...].state` never showed up in the menu.

Those now get a synthetic local slot — the next free index, assigned deterministically by `updatedAt` so it stays stable across launches. Real `slotN` states are unchanged.

Closes #33
