### PR TITLE
feat(emulator): haptic feedback on button release

### DIFF
--- a/romm/romm/Data/Preferences/HapticsPreferences.swift
+++ b/romm/romm/Data/Preferences/HapticsPreferences.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Lightweight UserDefaults-backed preferences for on-screen controller haptics.
+/// Kept as a simple value store (not part of the DI graph) because the touch
+/// controller is a plain UIView instantiated outside the dependency factory.
+enum HapticsPreferences {
+    private static let onReleaseKey = "haptics.onRelease"
+
+    private static let defaults = UserDefaults.standard
+
+    /// Whether a haptic should fire when a finger lifts off an on-screen button.
+    /// Defaults to on to mirror the press haptic (like Ignited).
+    static var onRelease: Bool {
+        get {
+            if defaults.object(forKey: onReleaseKey) == nil { return true }
+            return defaults.bool(forKey: onReleaseKey)
+        }
+        set {
+            defaults.set(newValue, forKey: onReleaseKey)
+        }
+    }
+}

--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
@@ -90,6 +90,7 @@ private struct LibretroMenuSheet: View {
     @SwiftUI.State private var refreshTick: Int = 0
     @SwiftUI.State private var showQuitConfirmation = false
     @SwiftUI.State private var aspectRatio: LibretroAspectRatio
+    @SwiftUI.State private var hapticsOnRelease: Bool = HapticsPreferences.onRelease
 
     init(
         session: LibretroSession?,
@@ -221,6 +222,17 @@ private struct LibretroMenuSheet: View {
                     aspectRatioPreference.psx = newValue
                     session?.reloadAspectRatio()
                 }
+            }
+            HStack {
+                Text("Release Haptics")
+                    .font(.subheadline)
+                    .foregroundColor(.white.opacity(0.7))
+                Spacer()
+                Toggle("", isOn: $hapticsOnRelease)
+                    .labelsHidden()
+                    .onChange(of: hapticsOnRelease) { _, newValue in
+                        HapticsPreferences.onRelease = newValue
+                    }
             }
         }
     }

--- a/romm/romm/UI/Emulator/Libretro/LibretroTouchControllerView.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroTouchControllerView.swift
@@ -165,6 +165,8 @@ final class LibretroTouchControllerView: UIView {
     private let hitSlop: CGFloat = 28
     private let dpadSlop: CGFloat = 32
     private let haptic = UIImpactFeedbackGenerator(style: .medium)
+    /// Slightly softer tick fired when a finger lifts off a button (like Ignited).
+    private let releaseHaptic = UIImpactFeedbackGenerator(style: .light)
 
     // MARK: - Init
 
@@ -174,6 +176,13 @@ final class LibretroTouchControllerView: UIView {
         backgroundColor = .clear
         buildLayout()
         haptic.prepare()
+        releaseHaptic.prepare()
+    }
+
+    /// Fires the release haptic if the user hasn't disabled it.
+    private func fireReleaseHaptic() {
+        guard HapticsPreferences.onRelease else { return }
+        releaseHaptic.impactOccurred(intensity: 0.7)
     }
 
     required init?(coder: NSCoder) { fatalError() }
@@ -381,6 +390,7 @@ final class LibretroTouchControllerView: UIView {
                 if !stillHeld {
                     prev.isPressed = false
                     LibretroFrontend.shared.setButton(prev.button, pressed: false)
+                    fireReleaseHaptic()
                 }
             }
             if let hit {
@@ -409,9 +419,13 @@ final class LibretroTouchControllerView: UIView {
             LibretroFrontend.shared.setButton(b, pressed: true)
         }
         currentDpadButtons = target
-        // Leichter Tick bei Richtungswechsel — nicht bei Release auf .none.
-        if direction != previous, direction != .none {
-            haptic.impactOccurred(intensity: 0.85)
+        // Leichter Tick bei Richtungswechsel; weicher Release-Tick beim Loslassen.
+        if direction != previous {
+            if direction == .none {
+                if previous != .none { fireReleaseHaptic() }
+            } else {
+                haptic.impactOccurred(intensity: 0.85)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #37. Adds a soft `.light` haptic when a finger lifts off an on-screen button or the D-pad returns to neutral, mirroring the existing press tick.

New "Release Haptics" toggle in the Libretro menu (defaults on).
