### PR TITLE
feat(emulator): align emulator screen to top for gamepad cases

### DIFF
--- a/romm/romm/Data/Preferences/UserDefaultsEmulatorScreenPositionPreferenceStore.swift
+++ b/romm/romm/Data/Preferences/UserDefaultsEmulatorScreenPositionPreferenceStore.swift
@@ -2,6 +2,7 @@ import Foundation
 
 final class UserDefaultsEmulatorScreenPositionPreferenceStore: PEmulatorScreenPositionPreference {
     private let key = "emulator.screenPosition"
+    private let heightKey = "emulator.screenHeightFraction"
     private let userDefaults: UserDefaults
 
     init(userDefaults: UserDefaults = .standard) {
@@ -18,6 +19,16 @@ final class UserDefaultsEmulatorScreenPositionPreferenceStore: PEmulatorScreenPo
         }
         set {
             userDefaults.set(newValue.rawValue, forKey: key)
+        }
+    }
+
+    var heightFraction: Double {
+        get {
+            guard userDefaults.object(forKey: heightKey) != nil else { return 1.0 }
+            return userDefaults.double(forKey: heightKey)
+        }
+        set {
+            userDefaults.set(min(1.0, max(0.3, newValue)), forKey: heightKey)
         }
     }
 }

--- a/romm/romm/Data/Preferences/UserDefaultsEmulatorScreenPositionPreferenceStore.swift
+++ b/romm/romm/Data/Preferences/UserDefaultsEmulatorScreenPositionPreferenceStore.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+final class UserDefaultsEmulatorScreenPositionPreferenceStore: PEmulatorScreenPositionPreference {
+    private let key = "emulator.screenPosition"
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    var position: EmulatorScreenPosition {
+        get {
+            guard let raw = userDefaults.string(forKey: key),
+                  let value = EmulatorScreenPosition(rawValue: raw) else {
+                return .center
+            }
+            return value
+        }
+        set {
+            userDefaults.set(newValue.rawValue, forKey: key)
+        }
+    }
+}

--- a/romm/romm/Domain/Models/EmulatorScreenPosition.swift
+++ b/romm/romm/Domain/Models/EmulatorScreenPosition.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Vertical placement of the emulator video output within the display.
+/// `.top` is useful for physical gamepad cases (e.g. GameBaby / flip-pad
+/// style) where the game surface should sit flush with the top of the screen.
+enum EmulatorScreenPosition: String, CaseIterable, Identifiable {
+    case center = "center"
+    case top = "top"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .center: return "Center"
+        case .top:    return "Top"
+        }
+    }
+}

--- a/romm/romm/Domain/Models/EmulatorScreenPosition.swift
+++ b/romm/romm/Domain/Models/EmulatorScreenPosition.swift
@@ -11,7 +11,7 @@ enum EmulatorScreenPosition: String, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
-        case .center: return "Center"
+        case .center: return "Default"
         case .top:    return "Top"
         }
     }

--- a/romm/romm/Domain/Models/EmulatorScreenPositionPreference.swift
+++ b/romm/romm/Domain/Models/EmulatorScreenPositionPreference.swift
@@ -2,4 +2,8 @@ import Foundation
 
 protocol PEmulatorScreenPositionPreference: AnyObject {
     var position: EmulatorScreenPosition { get set }
+
+    /// Fraction (0...1) of the available height the video should occupy when
+    /// `position == .top`. Ignored for `.center` (which fills as before).
+    var heightFraction: Double { get set }
 }

--- a/romm/romm/Domain/Models/EmulatorScreenPositionPreference.swift
+++ b/romm/romm/Domain/Models/EmulatorScreenPositionPreference.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol PEmulatorScreenPositionPreference: AnyObject {
+    var position: EmulatorScreenPosition { get set }
+}

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -112,6 +112,7 @@ protocol PDependencyFactory {
     // Emulator Engine
     var enginePreference: PEmulatorEnginePreference { get }
     var libretroAspectRatioPreference: PLibretroAspectRatioPreference { get }
+    var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference { get }
     func makePlatformEngineSupport() -> PPlatformEngineSupport
 
     // SFTP ViewModels
@@ -379,6 +380,7 @@ class DefaultDependencyFactory: PDependencyFactory {
 
     lazy var enginePreference: PEmulatorEnginePreference = UserDefaultsEmulatorEnginePreferenceStore()
     lazy var libretroAspectRatioPreference: PLibretroAspectRatioPreference = UserDefaultsLibretroAspectRatioPreferenceStore()
+    lazy var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference = UserDefaultsEmulatorScreenPositionPreferenceStore()
 
     func makePlatformEngineSupport() -> PPlatformEngineSupport {
         PlatformEngineSupport()
@@ -500,6 +502,7 @@ class DefaultDependencyFactory: PDependencyFactory {
             saveStates: makeEmulatorSaveStatesUseCase(),
             biosSync: makeBIOSSyncUseCase(),
             aspectRatioPreference: libretroAspectRatioPreference,
+            screenPositionPreference: emulatorScreenPositionPreference,
             factory: self
         )
     }

--- a/romm/romm/UI/DI/InMemoryEmulatorScreenPositionPreference.swift
+++ b/romm/romm/UI/DI/InMemoryEmulatorScreenPositionPreference.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+final class InMemoryEmulatorScreenPositionPreference: PEmulatorScreenPositionPreference {
+    var position: EmulatorScreenPosition = .center
+}

--- a/romm/romm/UI/DI/InMemoryEmulatorScreenPositionPreference.swift
+++ b/romm/romm/UI/DI/InMemoryEmulatorScreenPositionPreference.swift
@@ -2,4 +2,5 @@ import Foundation
 
 final class InMemoryEmulatorScreenPositionPreference: PEmulatorScreenPositionPreference {
     var position: EmulatorScreenPosition = .center
+    var heightFraction: Double = 1.0
 }

--- a/romm/romm/UI/DI/MockDependencyFactory.swift
+++ b/romm/romm/UI/DI/MockDependencyFactory.swift
@@ -33,6 +33,7 @@ class MockDependencyFactory: PDependencyFactory {
     // Emulator engine
     lazy var enginePreference: PEmulatorEnginePreference = UserDefaultsEmulatorEnginePreferenceStore()
     lazy var libretroAspectRatioPreference: PLibretroAspectRatioPreference = InMemoryLibretroAspectRatioPreference()
+    lazy var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference = InMemoryEmulatorScreenPositionPreference()
     
     init(
         authRepository: PAuthRepository? = nil,
@@ -365,6 +366,7 @@ class MockDependencyFactory: PDependencyFactory {
             saveStates: makeEmulatorSaveStatesUseCase(),
             biosSync: makeBIOSSyncUseCase(),
             aspectRatioPreference: libretroAspectRatioPreference,
+            screenPositionPreference: emulatorScreenPositionPreference,
             factory: self
         )
     }

--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
@@ -17,6 +17,7 @@ final class LibretroEmulatorViewModel {
     private let saveStates: PEmulatorSaveStatesUseCase
     private let biosSync: PBIOSSyncUseCase
     let aspectRatioPreference: PLibretroAspectRatioPreference
+    let screenPositionPreference: PEmulatorScreenPositionPreference
     private let factory: PDependencyFactory
     private let logger = Logger.viewModel
 
@@ -28,6 +29,7 @@ final class LibretroEmulatorViewModel {
         saveStates: PEmulatorSaveStatesUseCase,
         biosSync: PBIOSSyncUseCase,
         aspectRatioPreference: PLibretroAspectRatioPreference,
+        screenPositionPreference: PEmulatorScreenPositionPreference,
         factory: PDependencyFactory
     ) {
         self.rom = rom
@@ -37,6 +39,7 @@ final class LibretroEmulatorViewModel {
         self.saveStates = saveStates
         self.biosSync = biosSync
         self.aspectRatioPreference = aspectRatioPreference
+        self.screenPositionPreference = screenPositionPreference
         self.factory = factory
     }
 
@@ -81,6 +84,7 @@ final class LibretroEmulatorViewModel {
                 romId: rom.id,
                 saveStates: saveStates,
                 aspectRatioPreference: aspectRatioPreference,
+                screenPositionPreference: screenPositionPreference,
                 cloudSync: cloudSync
             )
             s.onMenuRequested = { [weak self] in self?.onMenuRequested?() }

--- a/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
@@ -314,21 +314,30 @@ final class LibretroGameViewController: UIViewController {
             .forEach { view.removeConstraint($0) }
 
         let widthLimit = videoView.widthAnchor.constraint(lessThanOrEqualTo: view.widthAnchor)
-        let heightLimit = videoView.heightAnchor.constraint(lessThanOrEqualTo: view.heightAnchor)
         let widthFill = videoView.widthAnchor.constraint(equalTo: view.widthAnchor)
         widthFill.priority = .defaultHigh
-        let heightFill = videoView.heightAnchor.constraint(equalTo: view.heightAnchor)
-        heightFill.priority = .defaultHigh
 
-        // Vertical placement follows the user's screen-position preference:
-        // `.top` pins the video to the safe-area top (useful for physical
-        // gamepad cases); `.center` keeps it vertically centered (default).
+        // Vertical placement + height follow the user's screen-position
+        // preference. `.top` pins to the safe-area top and limits the video to
+        // a user-chosen fraction of the safe-area height (leaving the rest free
+        // for a physical gamepad case). `.center` (aka "Default") fills the
+        // whole view and centers, as before — the height fraction is ignored.
         let verticalConstraint: NSLayoutConstraint
+        let heightLimit: NSLayoutConstraint
+        let heightFill: NSLayoutConstraint
         switch screenPositionPreference.position {
         case .top:
-            verticalConstraint = videoView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+            let fraction = CGFloat(min(1.0, max(0.3, screenPositionPreference.heightFraction)))
+            let guide = view.safeAreaLayoutGuide
+            verticalConstraint = videoView.topAnchor.constraint(equalTo: guide.topAnchor)
+            heightLimit = videoView.heightAnchor.constraint(lessThanOrEqualTo: guide.heightAnchor, multiplier: fraction)
+            heightFill = videoView.heightAnchor.constraint(equalTo: guide.heightAnchor, multiplier: fraction)
+            heightFill.priority = .defaultHigh
         case .center:
             verticalConstraint = videoView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            heightLimit = videoView.heightAnchor.constraint(lessThanOrEqualTo: view.heightAnchor)
+            heightFill = videoView.heightAnchor.constraint(equalTo: view.heightAnchor)
+            heightFill.priority = .defaultHigh
         }
 
         NSLayoutConstraint.activate([

--- a/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
@@ -9,6 +9,7 @@ final class LibretroSession: NSObject {
     private let romId: Int
     private let saveStates: PEmulatorSaveStatesUseCase
     private let aspectRatioPreference: PLibretroAspectRatioPreference
+    private let screenPositionPreference: PEmulatorScreenPositionPreference
     private let cloudSync: CloudSaveSyncService?
     private let frontend = LibretroFrontend.shared
 
@@ -22,6 +23,7 @@ final class LibretroSession: NSObject {
         romId: Int,
         saveStates: PEmulatorSaveStatesUseCase,
         aspectRatioPreference: PLibretroAspectRatioPreference,
+        screenPositionPreference: PEmulatorScreenPositionPreference,
         cloudSync: CloudSaveSyncService? = nil
     ) {
         self.gameURL = gameURL
@@ -29,11 +31,13 @@ final class LibretroSession: NSObject {
         self.romId = romId
         self.saveStates = saveStates
         self.aspectRatioPreference = aspectRatioPreference
+        self.screenPositionPreference = screenPositionPreference
         self.cloudSync = cloudSync
         self.viewController = LibretroGameViewController(
             core: core,
             gameURL: gameURL,
-            aspectRatioPreference: aspectRatioPreference
+            aspectRatioPreference: aspectRatioPreference,
+            screenPositionPreference: screenPositionPreference
         )
         super.init()
         self.viewController.controllerView.onMenuTapped = { [weak self] in
@@ -221,6 +225,7 @@ final class LibretroGameViewController: UIViewController {
     private let core: LibretroCore
     private let gameURL: URL
     private let aspectRatioPreference: PLibretroAspectRatioPreference
+    private let screenPositionPreference: PEmulatorScreenPositionPreference
     let videoView = LibretroVideoView()
     let controllerView = LibretroTouchControllerView()
     private let errorLabel = UILabel()
@@ -229,11 +234,13 @@ final class LibretroGameViewController: UIViewController {
     init(
         core: LibretroCore,
         gameURL: URL,
-        aspectRatioPreference: PLibretroAspectRatioPreference
+        aspectRatioPreference: PLibretroAspectRatioPreference,
+        screenPositionPreference: PEmulatorScreenPositionPreference
     ) {
         self.core = core
         self.gameURL = gameURL
         self.aspectRatioPreference = aspectRatioPreference
+        self.screenPositionPreference = screenPositionPreference
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -313,9 +320,20 @@ final class LibretroGameViewController: UIViewController {
         let heightFill = videoView.heightAnchor.constraint(equalTo: view.heightAnchor)
         heightFill.priority = .defaultHigh
 
+        // Vertical placement follows the user's screen-position preference:
+        // `.top` pins the video to the safe-area top (useful for physical
+        // gamepad cases); `.center` keeps it vertically centered (default).
+        let verticalConstraint: NSLayoutConstraint
+        switch screenPositionPreference.position {
+        case .top:
+            verticalConstraint = videoView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+        case .center:
+            verticalConstraint = videoView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        }
+
         NSLayoutConstraint.activate([
             videoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            videoView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            verticalConstraint,
             widthLimit, heightLimit, widthFill, heightFill
         ])
 

--- a/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
+++ b/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
@@ -26,33 +26,37 @@ struct EmulatorEngineSettingsView: View {
             }
             Section(footer: Text("Native runs emulation on-device via embedded cores (DeltaCore for Game Boy / Color, GBA, NES, SNES, N64, Nintendo DS, Sega Genesis; libretro for PlayStation). Other platforms fall back to Web automatically.")) { EmptyView() }
 
-            Section(
-                header: Text("Screen Position"),
-                footer: Text("Applies to the PlayStation (libretro) core. “Top” pins the game to the top and lets you pick how much of the height it uses — handy for physical gamepad cases so the lower part of the screen stays free for the controls.")
-            ) {
-                Picker("Screen Position", selection: $screenPosition) {
-                    ForEach(EmulatorScreenPosition.allCases) { position in
-                        Text(position.displayName).tag(position)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                if screenPosition == .top {
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack {
-                            Text("Height")
-                            Spacer()
-                            Text("\(Int((heightFraction * 100).rounded()))%")
-                                .foregroundStyle(.secondary)
-                                .monospacedDigit()
+            // Screen Position only affects the native (libretro) renderer — hide
+            // it entirely for the Web (EmulatorJS) engine, where it does nothing.
+            if selection == .native {
+                Section(
+                    header: Text("Screen Position"),
+                    footer: Text("Applies to the PlayStation (libretro) core in portrait. “Top” pins the game to the top and lets you pick how much of the height it uses — handy for physical gamepad cases so the lower part of the screen stays free for the controls. In landscape the game already fills the height, so this setting has no effect there.")
+                ) {
+                    Picker("Screen Position", selection: $screenPosition) {
+                        ForEach(EmulatorScreenPosition.allCases) { position in
+                            Text(position.displayName).tag(position)
                         }
-                        Slider(value: $heightFraction, in: 0.3...1.0, step: 0.05)
                     }
-                }
+                    .pickerStyle(.segmented)
 
-                ScreenLayoutPreview(position: screenPosition, fraction: heightFraction)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
+                    if screenPosition == .top {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text("Height")
+                                Spacer()
+                                Text("\(Int((heightFraction * 100).rounded()))%")
+                                    .foregroundStyle(.secondary)
+                                    .monospacedDigit()
+                            }
+                            Slider(value: $heightFraction, in: 0.3...1.0, step: 0.05)
+                        }
+                    }
+
+                    ScreenLayoutPreview(position: screenPosition, fraction: heightFraction)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                }
             }
         }
         .navigationTitle("Emulator")
@@ -62,48 +66,76 @@ struct EmulatorEngineSettingsView: View {
     }
 }
 
-/// Small phone-shaped mockup that shows where the game screen will sit and how
-/// much vertical space it takes, based on the current Screen Position settings.
+/// Side-by-side phone mockups that show where the game screen will sit.
+/// The portrait mock reflects the current Screen Position settings; the
+/// landscape mock illustrates that the game always fills the height there,
+/// so the setting has no effect in landscape.
 private struct ScreenLayoutPreview: View {
     let position: EmulatorScreenPosition
     let fraction: Double
 
-    private let phoneWidth: CGFloat = 104
-    private let phoneHeight: CGFloat = 208
-    private let inset: CGFloat = 6
+    private let inset: CGFloat = 5
 
     var body: some View {
-        let innerWidth = phoneWidth - inset * 2
-        let innerHeight = phoneHeight - inset * 2
         let frac = position == .top ? CGFloat(min(1.0, max(0.3, fraction))) : 1.0
-        let blockHeight = innerHeight * frac
 
-        VStack(spacing: 6) {
-            ZStack(alignment: position == .top ? .top : .center) {
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(Color(.secondarySystemBackground))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                            .stroke(Color(.separator), lineWidth: 1)
-                    )
-
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color.accentColor.opacity(0.85))
-                    .frame(width: innerWidth, height: blockHeight)
-                    .overlay(
-                        Image(systemName: "gamecontroller.fill")
-                            .font(.system(size: 18))
-                            .foregroundStyle(.white.opacity(0.9))
-                    )
-                    .padding(inset)
+        HStack(alignment: .top, spacing: 24) {
+            VStack(spacing: 6) {
+                phone(
+                    width: 84, height: 168,
+                    alignment: position == .top ? .top : .center,
+                    blockWidth: 84 - inset * 2,
+                    blockHeight: (168 - inset * 2) * frac
+                )
+                Text("Portrait")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
-            .frame(width: phoneWidth, height: phoneHeight)
-            .animation(.easeInOut(duration: 0.15), value: frac)
-            .animation(.easeInOut(duration: 0.15), value: position)
 
-            Text("Preview")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+            VStack(spacing: 6) {
+                // Landscape: a 4:3 picture already fills the full height and is
+                // pillar-boxed on the sides — the setting can't move it.
+                phone(
+                    width: 168, height: 84,
+                    alignment: .center,
+                    blockWidth: (84 - inset * 2) * (4.0 / 3.0),
+                    blockHeight: 84 - inset * 2
+                )
+                Text("Landscape · no effect")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         }
+        .frame(maxWidth: .infinity)
+        .animation(.easeInOut(duration: 0.15), value: frac)
+        .animation(.easeInOut(duration: 0.15), value: position)
+    }
+
+    private func phone(
+        width: CGFloat,
+        height: CGFloat,
+        alignment: Alignment,
+        blockWidth: CGFloat,
+        blockHeight: CGFloat
+    ) -> some View {
+        ZStack(alignment: alignment) {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color(.separator), lineWidth: 1)
+                )
+
+            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                .fill(Color.accentColor.opacity(0.85))
+                .frame(width: blockWidth, height: blockHeight)
+                .overlay(
+                    Image(systemName: "gamecontroller.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.white.opacity(0.9))
+                )
+                .padding(inset)
+        }
+        .frame(width: width, height: height)
     }
 }

--- a/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
+++ b/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
@@ -3,20 +3,16 @@ import SwiftUI
 struct EmulatorEngineSettingsView: View {
     @State private var selection: EmulatorEngine
     @State private var screenPosition: EmulatorScreenPosition
+    @State private var heightFraction: Double
     private let preference: PEmulatorEnginePreference
     private let screenPositionPreference: PEmulatorScreenPositionPreference
-    private let aspectRatioPreference: PLibretroAspectRatioPreference
 
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
         self.preference = factory.enginePreference
         self.screenPositionPreference = factory.emulatorScreenPositionPreference
-        self.aspectRatioPreference = factory.libretroAspectRatioPreference
         _selection = State(wrappedValue: factory.enginePreference.current)
         _screenPosition = State(wrappedValue: factory.emulatorScreenPositionPreference.position)
-    }
-
-    private var screenPositionHasNoEffect: Bool {
-        aspectRatioPreference.psx.ratio == nil
+        _heightFraction = State(wrappedValue: factory.emulatorScreenPositionPreference.heightFraction)
     }
 
     var body: some View {
@@ -32,7 +28,7 @@ struct EmulatorEngineSettingsView: View {
 
             Section(
                 header: Text("Screen Position"),
-                footer: Text("Aligns the game screen to the top of the display instead of centering it. Useful for physical gamepad cases. Applies to the PlayStation (libretro) core, and only when its aspect ratio is not set to “Full width” (a full-width picture already fills the screen, so there is nothing to reposition).")
+                footer: Text("Applies to the PlayStation (libretro) core. “Top” pins the game to the top and lets you pick how much of the height it uses — handy for physical gamepad cases so the lower part of the screen stays free for the controls.")
             ) {
                 Picker("Screen Position", selection: $screenPosition) {
                     ForEach(EmulatorScreenPosition.allCases) { position in
@@ -41,18 +37,73 @@ struct EmulatorEngineSettingsView: View {
                 }
                 .pickerStyle(.segmented)
 
-                if screenPositionHasNoEffect {
-                    Label(
-                        "No effect right now: the PlayStation aspect ratio is set to “Full width”. Switch it to 4:3 or 16:9 for this to take effect.",
-                        systemImage: "exclamationmark.triangle"
-                    )
-                    .font(.footnote)
-                    .foregroundStyle(.orange)
+                if screenPosition == .top {
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text("Height")
+                            Spacer()
+                            Text("\(Int((heightFraction * 100).rounded()))%")
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+                        Slider(value: $heightFraction, in: 0.3...1.0, step: 0.05)
+                    }
                 }
+
+                ScreenLayoutPreview(position: screenPosition, fraction: heightFraction)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
             }
         }
         .navigationTitle("Emulator")
         .onChange(of: selection) { _, new in preference.current = new }
         .onChange(of: screenPosition) { _, new in screenPositionPreference.position = new }
+        .onChange(of: heightFraction) { _, new in screenPositionPreference.heightFraction = new }
+    }
+}
+
+/// Small phone-shaped mockup that shows where the game screen will sit and how
+/// much vertical space it takes, based on the current Screen Position settings.
+private struct ScreenLayoutPreview: View {
+    let position: EmulatorScreenPosition
+    let fraction: Double
+
+    private let phoneWidth: CGFloat = 104
+    private let phoneHeight: CGFloat = 208
+    private let inset: CGFloat = 6
+
+    var body: some View {
+        let innerWidth = phoneWidth - inset * 2
+        let innerHeight = phoneHeight - inset * 2
+        let frac = position == .top ? CGFloat(min(1.0, max(0.3, fraction))) : 1.0
+        let blockHeight = innerHeight * frac
+
+        VStack(spacing: 6) {
+            ZStack(alignment: position == .top ? .top : .center) {
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(Color(.secondarySystemBackground))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .stroke(Color(.separator), lineWidth: 1)
+                    )
+
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.accentColor.opacity(0.85))
+                    .frame(width: innerWidth, height: blockHeight)
+                    .overlay(
+                        Image(systemName: "gamecontroller.fill")
+                            .font(.system(size: 18))
+                            .foregroundStyle(.white.opacity(0.9))
+                    )
+                    .padding(inset)
+            }
+            .frame(width: phoneWidth, height: phoneHeight)
+            .animation(.easeInOut(duration: 0.15), value: frac)
+            .animation(.easeInOut(duration: 0.15), value: position)
+
+            Text("Preview")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
     }
 }

--- a/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
+++ b/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
@@ -5,12 +5,18 @@ struct EmulatorEngineSettingsView: View {
     @State private var screenPosition: EmulatorScreenPosition
     private let preference: PEmulatorEnginePreference
     private let screenPositionPreference: PEmulatorScreenPositionPreference
+    private let aspectRatioPreference: PLibretroAspectRatioPreference
 
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
         self.preference = factory.enginePreference
         self.screenPositionPreference = factory.emulatorScreenPositionPreference
+        self.aspectRatioPreference = factory.libretroAspectRatioPreference
         _selection = State(wrappedValue: factory.enginePreference.current)
         _screenPosition = State(wrappedValue: factory.emulatorScreenPositionPreference.position)
+    }
+
+    private var screenPositionHasNoEffect: Bool {
+        aspectRatioPreference.psx.ratio == nil
     }
 
     var body: some View {
@@ -26,7 +32,7 @@ struct EmulatorEngineSettingsView: View {
 
             Section(
                 header: Text("Screen Position"),
-                footer: Text("Aligns the game screen to the top of the display instead of centering it. Useful for physical gamepad cases. Applies to the PlayStation (libretro) core.")
+                footer: Text("Aligns the game screen to the top of the display instead of centering it. Useful for physical gamepad cases. Applies to the PlayStation (libretro) core, and only when its aspect ratio is not set to “Full width” (a full-width picture already fills the screen, so there is nothing to reposition).")
             ) {
                 Picker("Screen Position", selection: $screenPosition) {
                     ForEach(EmulatorScreenPosition.allCases) { position in
@@ -34,6 +40,15 @@ struct EmulatorEngineSettingsView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+
+                if screenPositionHasNoEffect {
+                    Label(
+                        "No effect right now: the PlayStation aspect ratio is set to “Full width”. Switch it to 4:3 or 16:9 for this to take effect.",
+                        systemImage: "exclamationmark.triangle"
+                    )
+                    .font(.footnote)
+                    .foregroundStyle(.orange)
+                }
             }
         }
         .navigationTitle("Emulator")

--- a/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
+++ b/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
@@ -2,11 +2,15 @@ import SwiftUI
 
 struct EmulatorEngineSettingsView: View {
     @State private var selection: EmulatorEngine
+    @State private var screenPosition: EmulatorScreenPosition
     private let preference: PEmulatorEnginePreference
+    private let screenPositionPreference: PEmulatorScreenPositionPreference
 
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
         self.preference = factory.enginePreference
+        self.screenPositionPreference = factory.emulatorScreenPositionPreference
         _selection = State(wrappedValue: factory.enginePreference.current)
+        _screenPosition = State(wrappedValue: factory.emulatorScreenPositionPreference.position)
     }
 
     var body: some View {
@@ -19,8 +23,21 @@ struct EmulatorEngineSettingsView: View {
                 .pickerStyle(.inline)
             }
             Section(footer: Text("Native runs emulation on-device via embedded cores (DeltaCore for Game Boy / Color, GBA, NES, SNES, N64, Nintendo DS, Sega Genesis; libretro for PlayStation). Other platforms fall back to Web automatically.")) { EmptyView() }
+
+            Section(
+                header: Text("Screen Position"),
+                footer: Text("Aligns the game screen to the top of the display instead of centering it. Useful for physical gamepad cases. Applies to the PlayStation (libretro) core.")
+            ) {
+                Picker("Screen Position", selection: $screenPosition) {
+                    ForEach(EmulatorScreenPosition.allCases) { position in
+                        Text(position.displayName).tag(position)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
         }
         .navigationTitle("Emulator")
         .onChange(of: selection) { _, new in preference.current = new }
+        .onChange(of: screenPosition) { _, new in screenPositionPreference.position = new }
     }
 }


### PR DESCRIPTION
Closes #38. Adds a Screen Position setting in Emulator settings (Default / Top). "Top" pins the video to the top instead of centering it — useful for gamepad cases where the screen sits flush. With "Top" you can also set how much height it takes (%), with a small live preview. Hidden for the Web engine; no effect in landscape.

Follows the existing `LibretroAspectRatio` pattern (Domain enum + store + DI); applied in `applyAspectConstraints()` with aspect ratio preserved. Libretro (PSX) only — native DeltaCore positions its screen via vendored skin layouts.
