### PR TITLE
Support RomM 5.1.x

### DIFF
--- a/romm/romm/Data/Repositories/HeartbeatRepository.swift
+++ b/romm/romm/Data/Repositories/HeartbeatRepository.swift
@@ -13,7 +13,7 @@ class HeartbeatRepository: PHeartbeatRepository {
     // MARK: - Constants
 
     let minSupportedServerVersion = "4.1.0"
-    let maxSupportedServerVersion = "4.9.0"
+    let maxSupportedServerVersion = "5.1.0"
     let versionCheckThrottleSeconds: TimeInterval = 30
 
     // MARK: - UserDefaults Keys


### PR DESCRIPTION
Bumps `maxSupportedServerVersion` from 4.9.0 to 5.1.0 in `HeartbeatRepository`. The compatibility check compares only major.minor, so this covers all 5.1.x releases. Confirmed working against a 5.1.x server.

Closes #32