### PR TITLE
UI: faster covers, per-list search, opaque nav bars

### DIFF
--- a/romm/romm/Data/Services/KingfisherCacheManager.swift
+++ b/romm/romm/Data/Services/KingfisherCacheManager.swift
@@ -15,7 +15,23 @@ class KingfisherCacheManager: ObservableObject {
     static let shared = KingfisherCacheManager()
     
     private let settings = ImageCacheSettings.shared
-    
+
+    private var authModifier: AnyModifier?
+
+    /// Shared downsampling target so on-demand loads and prefetch produce the same cache key.
+    static let downsampleSize = CGSize(width: 600, height: 600)
+
+    /// Image options shared between CachedKFImage and prefetching so both hit the same cache entry.
+    static var sharedImageOptions: KingfisherOptionsInfo {
+        [
+            .diskCacheExpiration(.days(30)),
+            .backgroundDecode,
+            .scaleFactor(UIScreen.main.scale),
+            .processor(DownsamplingImageProcessor(size: downsampleSize)),
+            .cacheOriginalImage
+        ]
+    }
+
     private init() {
         configureKingfisher()
     }
@@ -102,9 +118,13 @@ class KingfisherCacheManager: ObservableObject {
     }
     
     func preloadImages(urls: [URL]) {
-        guard settings.preloadEnabled else { return }
-        
-        let prefetcher = ImagePrefetcher(urls: urls)
+        guard settings.preloadEnabled, !urls.isEmpty else { return }
+
+        var options = Self.sharedImageOptions
+        if let authModifier {
+            options.append(.requestModifier(authModifier))
+        }
+        let prefetcher = ImagePrefetcher(urls: urls, options: options)
         prefetcher.start()
     }
     
@@ -151,6 +171,7 @@ class KingfisherCacheManager: ObservableObject {
             }
             return r
         }
+        self.authModifier = modifier
         KingfisherManager.shared.defaultOptions += [.requestModifier(modifier)]
     }
 }

--- a/romm/romm/Localizable.xcstrings
+++ b/romm/romm/Localizable.xcstrings
@@ -342,6 +342,28 @@
         }
       }
     },
+    "Search %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ durchsuchen"
+          }
+        }
+      }
+    },
+    "Search collections" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sammlungen durchsuchen"
+          }
+        }
+      }
+    },
     "Search failed: %@" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -349,6 +371,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suche fehlgeschlagen: %1$@"
+          }
+        }
+      }
+    },
+    "Search platforms" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plattformen durchsuchen"
           }
         }
       }

--- a/romm/romm/UI/Collection/CollectionDetailView.swift
+++ b/romm/romm/UI/Collection/CollectionDetailView.swift
@@ -81,6 +81,8 @@ struct CollectionDetailView: View {
         }
         .navigationTitle(collection.name)
         .navigationBarTitleDisplayMode(.large)
+        .opaqueNavigationBar()
+        .searchableWhen(loadedRoms.count > 10, text: $searchText, prompt: "Search \(collection.name)")
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 // Sort/Filter Button
@@ -136,6 +138,15 @@ struct CollectionDetailView: View {
         })
     }
     
+    private var loadedRoms: [Rom] {
+        switch viewModel.viewState {
+        case .loaded(let roms), .loadingMore(let roms):
+            return roms
+        default:
+            return []
+        }
+    }
+
     private func filteredRoms(from roms: [Rom]) -> [Rom] {
         if searchText.isEmpty {
             return roms

--- a/romm/romm/UI/Collection/CollectionView.swift
+++ b/romm/romm/UI/Collection/CollectionView.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct CollectionView: View {
     @State private var collectionsViewModel = CollectionsViewModel()
     @EnvironmentObject var appData: AppData
-    
+
+    @State private var searchText = ""
+
     var body: some View {
         VStack {
             switch collectionsViewModel.viewState {
@@ -23,6 +25,7 @@ struct CollectionView: View {
             }
         }
         .navigationTitle("Collections")
+        .searchableWhen(collectionsViewModel.virtualCollections.count + collectionsViewModel.collections.count > 10, text: $searchText, prompt: "Search collections")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Add") {
@@ -111,11 +114,21 @@ struct CollectionView: View {
         }
     }
     
+    private var filteredVirtual: [VirtualCollection] {
+        guard !searchText.isEmpty else { return collectionsViewModel.virtualCollections }
+        return collectionsViewModel.virtualCollections.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    private var filteredCollections: [Collection] {
+        guard !searchText.isEmpty else { return collectionsViewModel.collections }
+        return collectionsViewModel.collections.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
     @ViewBuilder
     private var virtualCollectionsSection: some View {
-        if !collectionsViewModel.virtualCollections.isEmpty {
+        if !filteredVirtual.isEmpty {
             Section("Virtual Collections") {
-                ForEach(collectionsViewModel.virtualCollections, id: \.id) { virtualCollection in
+                ForEach(filteredVirtual, id: \.id) { virtualCollection in
                     NavigationLink {
                         VirtualCollectionDetailView(virtualCollection: virtualCollection)
                     } label: {
@@ -128,17 +141,17 @@ struct CollectionView: View {
     
     @ViewBuilder
     private var customCollectionsSection: some View {
-        if !collectionsViewModel.collections.isEmpty {
+        if !filteredCollections.isEmpty {
             Section("Custom Collections") {
-                ForEach(collectionsViewModel.collections, id: \.id) { collection in
+                ForEach(filteredCollections, id: \.id) { collection in
                     NavigationLink {
                         CollectionDetailView(collection: collection)
                     } label: {
                         CollectionRowView(collection: collection, coverURL: collectionsViewModel.coverURL(for: collection))
                     }
                     .onAppear {
-                        // Load more when approaching the end
-                        if collection == collectionsViewModel.collections.last {
+                        // Load more when approaching the end (only while not filtering)
+                        if searchText.isEmpty && collection == collectionsViewModel.collections.last {
                             Task {
                                 await collectionsViewModel.loadMoreCollectionsIfNeeded()
                             }
@@ -147,7 +160,7 @@ struct CollectionView: View {
                 }
                 .onDelete { indexSet in
                     if let index = indexSet.first {
-                        let collection = collectionsViewModel.collections[index]
+                        let collection = filteredCollections[index]
                         collectionsViewModel.showDeleteConfirmation(for: collection)
                     }
                 }

--- a/romm/romm/UI/Collection/CollectionsViewModel.swift
+++ b/romm/romm/UI/Collection/CollectionsViewModel.swift
@@ -126,6 +126,7 @@ class CollectionsViewModel {
             self.canLoadMoreCollections = loadedCollections.count == self.collectionsPageSize
             self.isLoading = false
             self.hasLoadedOnce = true
+            prefetchCovers()
 
             logger.info("✅ Loaded \(loadedCollections.count) collections and \(loadedVirtualCollections.count) virtual collections")
 
@@ -166,7 +167,8 @@ class CollectionsViewModel {
             self.currentCollectionOffset = 0
             self.canLoadMoreCollections = loadedCollections.count == self.collectionsPageSize
             self.isLoading = false
-            
+            prefetchCovers()
+
             logger.info("✅ Refreshed \(loadedCollections.count) collections and \(loadedVirtualCollections.count) virtual collections")
             
         } catch {
@@ -258,7 +260,8 @@ class CollectionsViewModel {
                 // Append new collections to existing ones
                 collections.append(contentsOf: moreCollections)
                 currentCollectionOffset += collectionsPageSize
-                
+                prefetchCovers()
+
                 logger.info("✅ Loaded \(moreCollections.count) more collections. Total: \(collections.count)")
             }
             
@@ -269,7 +272,12 @@ class CollectionsViewModel {
         
         isLoadingMore = false
     }
-    
+
+    private func prefetchCovers() {
+        let urls = collections.compactMap { coverURL(for: $0) }.compactMap { URL(string: $0) }
+        KingfisherCacheManager.shared.preloadImages(urls: urls)
+    }
+
     private func resetPagination() {
         currentCollectionOffset = 0
         canLoadMoreCollections = true

--- a/romm/romm/UI/Home/HomeViewModel.swift
+++ b/romm/romm/UI/Home/HomeViewModel.swift
@@ -54,6 +54,7 @@ class HomeViewModel {
             group.addTask { await self.fetchPlatforms() }
             group.addTask { await self.fetchCollections() }
         }
+        prefetchCovers()
     }
 
     private func fetchRecentlyAdded() async {
@@ -104,5 +105,11 @@ class HomeViewModel {
             collections = []
         }
         isLoadingCollections = false
+    }
+
+    private func prefetchCovers() {
+        var urls = (recentlyAdded + continuePlaying).compactMap { $0.urlCover }.compactMap { URL(string: $0) }
+        urls += collections.compactMap { coverURL(for: $0) }.compactMap { URL(string: $0) }
+        KingfisherCacheManager.shared.preloadImages(urls: urls)
     }
 }

--- a/romm/romm/UI/Platforms/PlatformDetailView.swift
+++ b/romm/romm/UI/Platforms/PlatformDetailView.swift
@@ -18,6 +18,8 @@ struct PlatformDetailView: View {
     
     // Filter state
     @State private var filterStates = FilterStates()
+
+    @State private var searchText = ""
     
     // Check if custom sorting is active (not default name/asc)
     private var isCustomSortingActive: Bool {
@@ -111,6 +113,16 @@ struct PlatformDetailView: View {
         }
         .navigationTitle(platform.name)
         .navigationBarTitleDisplayMode(.large)
+        .opaqueNavigationBar()
+        .searchableWhen(getCurrentRoms().count > 10, text: $searchText, prompt: "Search \(platform.name)")
+        .onSubmit(of: .search) {
+            Task { await viewModel.searchRoms(query: searchText, platformId: platform.id) }
+        }
+        .onChange(of: searchText) { _, newValue in
+            if newValue.isEmpty {
+                Task { await viewModel.loadRoms(for: platform.id, refresh: true) }
+            }
+        }
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 // Sort/Filter Button

--- a/romm/romm/UI/Platforms/PlatformDetailViewModel.swift
+++ b/romm/romm/UI/Platforms/PlatformDetailViewModel.swift
@@ -164,14 +164,15 @@ class PlatformDetailViewModel {
             }
             
             let allRoms = existingRoms + response.roms
-            
+
             if allRoms.isEmpty {
                 viewState = .empty("No ROMs found for this platform")
             } else {
                 viewState = .loaded(allRoms)
                 lastLoadedRoms = allRoms // Update cached ROMs for smooth transitions
+                prefetchCovers(for: response.roms)
             }
-            
+
             currentOffset = response.offset + response.limit
             hasMoreRoms = response.hasMore
             totalRoms = response.total
@@ -228,8 +229,9 @@ class PlatformDetailViewModel {
                 viewState = .empty(query.isEmpty ? "No ROMs found" : "No results for '\(query)'")
             } else {
                 viewState = .loaded(response.roms)
+                prefetchCovers(for: response.roms)
             }
-            
+
             charIndex = processCharIndex(response.charIndex)
             hasMoreRoms = response.hasMore
             totalRoms = response.total
@@ -311,8 +313,9 @@ class PlatformDetailViewModel {
             } else {
                 viewState = .loaded(response.roms)
                 lastLoadedRoms = response.roms
+                prefetchCovers(for: response.roms)
             }
-            
+
             charIndex = processCharIndex(response.charIndex)
             hasMoreRoms = response.hasMore
             totalRoms = response.total
@@ -367,8 +370,9 @@ class PlatformDetailViewModel {
                     viewState = .empty("No ROMs found for '\(char!)'")
                 } else {
                     viewState = .loaded(response.roms)
+                    prefetchCovers(for: response.roms)
                 }
-                
+
                 // Don't overwrite charIndex when filtering - keep original index for navigation
                 // charIndex = processCharIndex(response.charIndex) // Keep original for char navigation
                 hasMoreRoms = response.hasMore
@@ -402,6 +406,13 @@ class PlatformDetailViewModel {
         
         return processedIndex
     }
+
+    private func prefetchCovers(for roms: [Rom]) {
+        let urls = roms.compactMap { $0.urlCover }.compactMap { URL(string: $0) }
+        KingfisherCacheManager.shared.preloadImages(urls: urls)
+    }
+
+    // MARK: - Helper Methods
 }
 
 // MARK: - Mock Data for Development

--- a/romm/romm/UI/Platforms/PlatformsView.swift
+++ b/romm/romm/UI/Platforms/PlatformsView.swift
@@ -12,7 +12,9 @@ struct PlatformsView: View {
     @State private var platformsViewModel = PlatformsViewModel()
 
     @EnvironmentObject var appData: AppData
-    
+
+    @State private var searchText = ""
+
     var body: some View {
         ZStack {
             if platformsViewModel.isLoading && platformsViewModel.platforms.isEmpty {
@@ -31,11 +33,13 @@ struct PlatformsView: View {
                 PlatformListView(
                     platforms: platformsViewModel.platforms,
                     isLoading: platformsViewModel.isLoading,
-                    viewModel: platformsViewModel
+                    viewModel: platformsViewModel,
+                    searchText: searchText
                 )
             }
         }
         .navigationTitle("Platforms")
+        .searchableWhen(platformsViewModel.platforms.filter { $0.romCount > 0 }.count > 10, text: $searchText, prompt: "Search platforms")
         .onAppear {
             // Load platforms on first appear for better performance
             // This prevents blocking during ViewModel initialization
@@ -65,10 +69,13 @@ struct PlatformListView: View {
     let platforms: [Platform]
     let isLoading: Bool
     let viewModel: PlatformsViewModel
+    let searchText: String
 
-    // Filter platforms with at least one ROM
+    // Filter platforms with at least one ROM, then by the search query
     private var nonEmptyPlatforms: [Platform] {
-        platforms.filter { $0.romCount > 0 }
+        let nonEmpty = platforms.filter { $0.romCount > 0 }
+        guard !searchText.isEmpty else { return nonEmpty }
+        return nonEmpty.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
     var body: some View {

--- a/romm/romm/UI/Shared/CachedKFImage.swift
+++ b/romm/romm/UI/Shared/CachedKFImage.swift
@@ -63,14 +63,16 @@ private struct CachedKFImageLoader<Content: View, Placeholder: View>: View {
     private func loadImage() {
         guard let url = url else { return }
 
-        let options: KingfisherOptionsInfo = [
-            .diskCacheExpiration(.days(30)),
-            .backgroundDecode,
-            .scaleFactor(UIScreen.main.scale),
-            .processor(DownsamplingImageProcessor(size: CGSize(width: 600, height: 600))),
-            .cacheOriginalImage,
-            .transition(.fade(0.2))
-        ]
+        let options = KingfisherCacheManager.sharedImageOptions
+
+        // Return a cached image synchronously to avoid the placeholder flashing while scrolling.
+        if let cached = ImageCache.default.retrieveImageInMemoryCache(
+            forKey: url.cacheKey,
+            options: KingfisherParsedOptionsInfo(options)
+        ) {
+            loadedImage = cached
+            return
+        }
 
         KingfisherManager.shared.retrieveImage(with: url, options: options) { result in
             switch result {

--- a/romm/romm/UI/Shared/OpaqueNavigationBar.swift
+++ b/romm/romm/UI/Shared/OpaqueNavigationBar.swift
@@ -1,0 +1,73 @@
+//
+//  OpaqueNavigationBar.swift
+//  romm
+//
+
+import SwiftUI
+import UIKit
+
+extension View {
+    /// Forces a fully opaque navigation bar for this screen.
+    ///
+    /// On iOS 26 (Liquid Glass) the default navigation bar is translucent, so content
+    /// scrolling underneath shows through — which looks broken next to a pinned section
+    /// header. This installs an opaque appearance while the screen is visible and restores
+    /// the previous appearance on exit, so pushed screens (e.g. a parallax detail header)
+    /// keep their translucent bar.
+    func opaqueNavigationBar(_ color: UIColor = .systemGroupedBackground) -> some View {
+        background(OpaqueNavBarConfigurator(color: color))
+    }
+}
+
+private struct OpaqueNavBarConfigurator: UIViewControllerRepresentable {
+    let color: UIColor
+
+    func makeUIViewController(context: Context) -> Configurator {
+        Configurator(color: color)
+    }
+
+    func updateUIViewController(_ uiViewController: Configurator, context: Context) {
+        uiViewController.color = color
+    }
+
+    final class Configurator: UIViewController {
+        var color: UIColor
+
+        private var savedStandard: UINavigationBarAppearance?
+        private var savedScrollEdge: UINavigationBarAppearance?
+        private var savedCompact: UINavigationBarAppearance?
+
+        init(color: UIColor) {
+            self.color = color
+            super.init(nibName: nil, bundle: nil)
+            view.backgroundColor = .clear
+        }
+
+        required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+        override func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+            guard let bar = navigationController?.navigationBar else { return }
+
+            savedStandard = bar.standardAppearance
+            savedScrollEdge = bar.scrollEdgeAppearance
+            savedCompact = bar.compactAppearance
+
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = color
+            bar.standardAppearance = appearance
+            bar.scrollEdgeAppearance = appearance
+            bar.compactAppearance = appearance
+        }
+
+        override func viewWillDisappear(_ animated: Bool) {
+            super.viewWillDisappear(animated)
+            guard let bar = navigationController?.navigationBar else { return }
+
+            if let savedStandard { bar.standardAppearance = savedStandard }
+            bar.scrollEdgeAppearance = savedScrollEdge
+            bar.compactAppearance = savedCompact
+        }
+    }
+}

--- a/romm/romm/UI/Shared/View+SearchableWhen.swift
+++ b/romm/romm/UI/Shared/View+SearchableWhen.swift
@@ -1,0 +1,19 @@
+//
+//  View+SearchableWhen.swift
+//  romm
+//
+
+import SwiftUI
+
+extension View {
+    /// Attaches a search field only when `condition` is true.
+    /// Used to show a per-list search once a list grows past a small threshold.
+    @ViewBuilder
+    func searchableWhen(_ condition: Bool, text: Binding<String>, prompt: String) -> some View {
+        if condition {
+            self.searchable(text: text, prompt: Text(prompt))
+        } else {
+            self
+        }
+    }
+}

--- a/romm/romm/UI/Shared/View+SearchableWhen.swift
+++ b/romm/romm/UI/Shared/View+SearchableWhen.swift
@@ -9,9 +9,9 @@ extension View {
     /// Attaches a search field only when `condition` is true.
     /// Used to show a per-list search once a list grows past a small threshold.
     @ViewBuilder
-    func searchableWhen(_ condition: Bool, text: Binding<String>, prompt: String) -> some View {
+    func searchableWhen(_ condition: Bool, text: Binding<String>, prompt: LocalizedStringKey) -> some View {
         if condition {
-            self.searchable(text: text, prompt: Text(prompt))
+            self.searchable(text: text, prompt: prompt)
         } else {
             self
         }


### PR DESCRIPTION
Three UI fixes:

- **Covers load faster** – cached images now render synchronously (no more placeholder flashing while scrolling) and get prefetched when a list loads. The existing prefetch method was never actually called.
- **Search per list** – platforms, collections and platform ROMs get a search bar once the list has more than 10 entries. Platform ROM search runs server-side; the others filter locally.
- **Opaque nav bars** – on iOS 26 the detail lists let content show through the translucent glass bar above the pinned letter header. Detail lists now force an opaque bar and restore the translucent one on exit, so the parallax rom detail header stays untouched.

Tested on device (iPhone 17 Pro, iOS 26.5).