### PR TITLE
ROM detail downloads + background download queue

### DIFF
--- a/romm/romm/Data/Services/DownloadQueueManager.swift
+++ b/romm/romm/Data/Services/DownloadQueueManager.swift
@@ -131,6 +131,15 @@ final class DownloadQueueManager {
 
     private func updateStatus(id: Int, to status: DownloadTask.Status) {
         guard let index = tasks.firstIndex(where: { $0.id == id }) else { return }
+        // A late progress callback (dispatched async onto the main actor) can
+        // arrive after the download already finished — don't let it clobber a
+        // terminal state back into `.downloading`, or the spinner never stops.
+        if case .downloading = status {
+            switch tasks[index].status {
+            case .finished, .failed: return
+            default: break
+            }
+        }
         tasks[index].status = status
     }
 

--- a/romm/romm/Data/Services/DownloadQueueManager.swift
+++ b/romm/romm/Data/Services/DownloadQueueManager.swift
@@ -36,12 +36,12 @@ final class DownloadQueueManager {
 
     private(set) var tasks: [DownloadTask] = []
 
-    private let apiClient: PRommAPIClient
+    private let downloadUseCase: PDownloadROMUseCase
     private var isProcessing = false
     private let logger = Logger.viewModel
 
-    init(apiClient: PRommAPIClient = RommAPIClient.shared) {
-        self.apiClient = apiClient
+    init(downloadUseCase: PDownloadROMUseCase = DownloadROMUseCase()) {
+        self.downloadUseCase = downloadUseCase
     }
 
     // MARK: - Derived state
@@ -144,40 +144,13 @@ final class DownloadQueueManager {
     }
 
     private func download(_ task: DownloadTask) async throws {
-        let rom = task.rom
-        // Resolve the concrete files to download from the server details.
-        let details = try await apiClient.getRomDetails(id: rom.id)
-        var files: [RomFileInfo] = []
-        if !details.fsName.isEmpty {
-            files.append(RomFileInfo(
-                id: details.fsName,
-                fileName: details.fsName,
-                fileSizeBytes: Int64(details.fsSizeBytes),
-                fileExtension: (details.fsName as NSString).pathExtension
-            ))
-        }
-        for supplementary in details.files
-        where supplementary.fileName != details.fsName && !supplementary.fileName.isEmpty {
-            files.append(RomFileInfo(from: supplementary))
-        }
-        if files.isEmpty {
-            let fallbackName = rom.fileName ?? "\(rom.name).rom"
-            files = [RomFileInfo(
-                id: fallbackName,
-                fileName: fallbackName,
-                fileSizeBytes: Int64(rom.sizeBytes ?? 0),
-                fileExtension: (fallbackName as NSString).pathExtension
-            )]
-        }
-
-        let downloadService = LocalROMDownloadService(apiClient: apiClient)
-        _ = try await downloadService.downloadROM(rom: rom, files: files) { [weak self] downloaded, total in
+        _ = try await downloadUseCase.execute(rom: task.rom) { [weak self] downloaded, total in
             guard let self else { return }
             let progress: Double? = total > 0
                 ? min(max(Double(downloaded) / Double(total), 0), 1)
                 : nil
             Task { @MainActor in
-                self.updateStatus(id: rom.id, to: .downloading(progress: progress))
+                self.updateStatus(id: task.id, to: .downloading(progress: progress))
             }
         }
     }

--- a/romm/romm/Data/Services/DownloadQueueManager.swift
+++ b/romm/romm/Data/Services/DownloadQueueManager.swift
@@ -1,30 +1,6 @@
 import Foundation
 import Observation
 
-/// A single ROM download tracked by the queue.
-struct DownloadTask: Identifiable {
-    /// The ROM id — also used to de-duplicate (one active download per ROM).
-    let id: Int
-    let rom: Rom
-    let name: String
-    let platformSlug: String?
-    var status: Status
-
-    enum Status: Equatable {
-        case queued
-        case downloading(progress: Double?) // 0...1, or nil when size is unknown
-        case finished
-        case failed(String)
-    }
-
-    var isActive: Bool {
-        switch status {
-        case .queued, .downloading: return true
-        case .finished, .failed: return false
-        }
-    }
-}
-
 /// Serial, in-memory download queue shared across the app. Views observe it to
 /// show live progress; the ROM detail screen enqueues into it and can be left
 /// while downloads keep running. Finished ROMs land in the normal downloaded

--- a/romm/romm/Data/Services/DownloadQueueManager.swift
+++ b/romm/romm/Data/Services/DownloadQueueManager.swift
@@ -12,7 +12,7 @@ struct DownloadTask: Identifiable {
 
     enum Status: Equatable {
         case queued
-        case downloading(progress: Double) // 0...1
+        case downloading(progress: Double?) // 0...1, or nil when size is unknown
         case finished
         case failed(String)
     }
@@ -117,7 +117,7 @@ final class DownloadQueueManager {
         defer { isProcessing = false }
         while let index = tasks.firstIndex(where: { if case .queued = $0.status { return true } else { return false } }) {
             let task = tasks[index]
-            tasks[index].status = .downloading(progress: 0)
+            tasks[index].status = .downloading(progress: nil)
             do {
                 try await download(task)
                 updateStatus(id: task.id, to: .finished)
@@ -164,7 +164,9 @@ final class DownloadQueueManager {
         let downloadService = LocalROMDownloadService(apiClient: apiClient)
         _ = try await downloadService.downloadROM(rom: rom, files: files) { [weak self] downloaded, total in
             guard let self else { return }
-            let progress = total > 0 ? min(max(Double(downloaded) / Double(total), 0), 1) : 0
+            let progress: Double? = total > 0
+                ? min(max(Double(downloaded) / Double(total), 0), 1)
+                : nil
             Task { @MainActor in
                 self.updateStatus(id: rom.id, to: .downloading(progress: progress))
             }

--- a/romm/romm/Data/Services/DownloadQueueManager.swift
+++ b/romm/romm/Data/Services/DownloadQueueManager.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Observation
+
+/// A single ROM download tracked by the queue.
+struct DownloadTask: Identifiable {
+    /// The ROM id — also used to de-duplicate (one active download per ROM).
+    let id: Int
+    let rom: Rom
+    let name: String
+    let platformSlug: String?
+    var status: Status
+
+    enum Status: Equatable {
+        case queued
+        case downloading(progress: Double) // 0...1
+        case finished
+        case failed(String)
+    }
+
+    var isActive: Bool {
+        switch status {
+        case .queued, .downloading: return true
+        case .finished, .failed: return false
+        }
+    }
+}
+
+/// Serial, in-memory download queue shared across the app. Views observe it to
+/// show live progress; the ROM detail screen enqueues into it and can be left
+/// while downloads keep running. Finished ROMs land in the normal downloaded
+/// list, so the queue itself is not persisted across launches.
+@Observable
+@MainActor
+final class DownloadQueueManager {
+    static let shared = DownloadQueueManager()
+
+    private(set) var tasks: [DownloadTask] = []
+
+    private let apiClient: PRommAPIClient
+    private var isProcessing = false
+    private let logger = Logger.viewModel
+
+    init(apiClient: PRommAPIClient = RommAPIClient.shared) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Derived state
+
+    /// Number of downloads still queued or in progress.
+    var activeCount: Int {
+        tasks.filter { $0.isActive }.count
+    }
+
+    /// Count of finished downloads — used by the Downloads tab to refresh its list.
+    var finishedCount: Int {
+        tasks.filter { if case .finished = $0.status { return true } else { return false } }.count
+    }
+
+    func status(forRomId id: Int) -> DownloadTask.Status? {
+        tasks.first { $0.id == id }?.status
+    }
+
+    // MARK: - Queue operations
+
+    /// Adds a ROM to the queue. No-op if it is already queued, downloading or
+    /// finished. A previously failed task is re-queued.
+    func enqueue(rom: Rom) {
+        if let index = tasks.firstIndex(where: { $0.id == rom.id }) {
+            switch tasks[index].status {
+            case .queued, .downloading, .finished:
+                return
+            case .failed:
+                tasks[index].status = .queued
+            }
+        } else {
+            tasks.append(DownloadTask(
+                id: rom.id,
+                rom: rom,
+                name: rom.name,
+                platformSlug: rom.platformSlug,
+                status: .queued
+            ))
+        }
+        startProcessingIfNeeded()
+    }
+
+    /// Removes a queued, finished or failed task. In-progress downloads are not
+    /// cancellable in this version (the underlying service has no cancel hook).
+    func remove(id: Int) {
+        guard let index = tasks.firstIndex(where: { $0.id == id }) else { return }
+        if case .downloading = tasks[index].status { return }
+        tasks.remove(at: index)
+    }
+
+    func retry(id: Int) {
+        guard let index = tasks.firstIndex(where: { $0.id == id }) else { return }
+        if case .failed = tasks[index].status {
+            tasks[index].status = .queued
+            startProcessingIfNeeded()
+        }
+    }
+
+    /// Clears finished and failed tasks from the list.
+    func clearCompleted() {
+        tasks.removeAll { !$0.isActive }
+    }
+
+    // MARK: - Processing
+
+    private func startProcessingIfNeeded() {
+        guard !isProcessing else { return }
+        isProcessing = true
+        Task { await processQueue() }
+    }
+
+    private func processQueue() async {
+        defer { isProcessing = false }
+        while let index = tasks.firstIndex(where: { if case .queued = $0.status { return true } else { return false } }) {
+            let task = tasks[index]
+            tasks[index].status = .downloading(progress: 0)
+            do {
+                try await download(task)
+                updateStatus(id: task.id, to: .finished)
+                logger.info("Queue: finished download for ROM \(task.id) - \(task.name)")
+            } catch {
+                updateStatus(id: task.id, to: .failed(error.localizedDescription))
+                logger.error("Queue: download failed for ROM \(task.id): \(error)")
+            }
+        }
+    }
+
+    private func updateStatus(id: Int, to status: DownloadTask.Status) {
+        guard let index = tasks.firstIndex(where: { $0.id == id }) else { return }
+        tasks[index].status = status
+    }
+
+    private func download(_ task: DownloadTask) async throws {
+        let rom = task.rom
+        // Resolve the concrete files to download from the server details.
+        let details = try await apiClient.getRomDetails(id: rom.id)
+        var files: [RomFileInfo] = []
+        if !details.fsName.isEmpty {
+            files.append(RomFileInfo(
+                id: details.fsName,
+                fileName: details.fsName,
+                fileSizeBytes: Int64(details.fsSizeBytes),
+                fileExtension: (details.fsName as NSString).pathExtension
+            ))
+        }
+        for supplementary in details.files
+        where supplementary.fileName != details.fsName && !supplementary.fileName.isEmpty {
+            files.append(RomFileInfo(from: supplementary))
+        }
+        if files.isEmpty {
+            let fallbackName = rom.fileName ?? "\(rom.name).rom"
+            files = [RomFileInfo(
+                id: fallbackName,
+                fileName: fallbackName,
+                fileSizeBytes: Int64(rom.sizeBytes ?? 0),
+                fileExtension: (fallbackName as NSString).pathExtension
+            )]
+        }
+
+        let downloadService = LocalROMDownloadService(apiClient: apiClient)
+        _ = try await downloadService.downloadROM(rom: rom, files: files) { [weak self] downloaded, total in
+            guard let self else { return }
+            let progress = total > 0 ? min(max(Double(downloaded) / Double(total), 0), 1) : 0
+            Task { @MainActor in
+                self.updateStatus(id: rom.id, to: .downloading(progress: progress))
+            }
+        }
+    }
+}

--- a/romm/romm/Data/Services/LocalROMDownloadService.swift
+++ b/romm/romm/Data/Services/LocalROMDownloadService.swift
@@ -100,17 +100,24 @@ class LocalROMDownloadService: PLocalROMDownloadService {
             // Download file from server
             let localFileURL = romDirectoryURL.appendingPathComponent(fileInfo.fileName)
 
+            // Metadata sizes of files not started yet — used to fill in the grand
+            // total while the current file's real size is learned from URLSession.
+            let remainingMetadata = files[(index + 1)...].reduce(0) { $0 + $1.fileSizeBytes }
+
             do {
                 try await downloadFile(
                     fileName: fileInfo.fileName,
                     romId: rom.id,
                     to: localFileURL,
                     expectedSize: fileInfo.fileSizeBytes
-                ) { downloadedBytes in
-                    // Update progress for this file on main thread
+                ) { downloadedBytes, fileTotalBytes in
+                    // Prefer the authoritative size reported by URLSession; fall
+                    // back to the metadata size when the server omits Content-Length.
+                    let perFileTotal = fileTotalBytes > 0 ? fileTotalBytes : fileInfo.fileSizeBytes
                     let currentTotalBytes = totalDownloadedBytes + downloadedBytes
+                    let grandTotal = totalDownloadedBytes + perFileTotal + remainingMetadata
                     Task { @MainActor in
-                        progressHandler(currentTotalBytes, totalSize)
+                        progressHandler(currentTotalBytes, grandTotal)
                     }
                 }
 
@@ -182,7 +189,7 @@ class LocalROMDownloadService: PLocalROMDownloadService {
         romId: Int,
         to destinationURL: URL,
         expectedSize: Int64,
-        progressHandler: @escaping (Int64) -> Void
+        progressHandler: @escaping (Int64, Int64) -> Void
     ) async throws {
         let encodedFileName = encodePathComponent(fileName)
         // RomM 5.1 requires the filename in the path; RomM 5.0 used the bare
@@ -193,15 +200,15 @@ class LocalROMDownloadService: PLocalROMDownloadService {
 
         let tempFileURL: URL
         do {
-            tempFileURL = try await apiClient.downloadFile(path: newPath) { downloadedBytes, _ in
-                progressHandler(downloadedBytes)
+            tempFileURL = try await apiClient.downloadFile(path: newPath) { downloadedBytes, totalBytes in
+                progressHandler(downloadedBytes, totalBytes)
             }
         } catch let error {
             if case APIClientError.invalidResponse(404, _) = error {
                 print("📥 /content/{filename} returned 404 — falling back to legacy /content (RomM 5.0)")
                 do {
-                    tempFileURL = try await apiClient.downloadFile(path: legacyPath) { downloadedBytes, _ in
-                        progressHandler(downloadedBytes)
+                    tempFileURL = try await apiClient.downloadFile(path: legacyPath) { downloadedBytes, totalBytes in
+                        progressHandler(downloadedBytes, totalBytes)
                     }
                 } catch {
                     throw LocalROMDownloadError.downloadFailed(error.localizedDescription)
@@ -224,7 +231,7 @@ class LocalROMDownloadService: PLocalROMDownloadService {
         if expectedSize > 0, actualSize <= 0 {
             throw LocalROMDownloadError.fileValidationFailed("Downloaded file is empty")
         }
-        progressHandler(actualSize)
+        progressHandler(actualSize, actualSize)
     }
 
     private func encodePathComponent(_ value: String) -> String {

--- a/romm/romm/Domain/Models/DownloadTask.swift
+++ b/romm/romm/Domain/Models/DownloadTask.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A single ROM download tracked by the queue.
+struct DownloadTask: Identifiable {
+    /// The ROM id — also used to de-duplicate (one active download per ROM).
+    let id: Int
+    let rom: Rom
+    let name: String
+    let platformSlug: String?
+    var status: Status
+
+    enum Status: Equatable {
+        case queued
+        case downloading(progress: Double?) // 0...1, or nil when size is unknown
+        case finished
+        case failed(String)
+    }
+
+    var isActive: Bool {
+        switch status {
+        case .queued, .downloading: return true
+        case .finished, .failed: return false
+        }
+    }
+}

--- a/romm/romm/Domain/UseCases/LocalROMs/DownloadROMUseCase.swift
+++ b/romm/romm/Domain/UseCases/LocalROMs/DownloadROMUseCase.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+protocol PDownloadROMUseCase {
+    /// Resolves the concrete files for a ROM from the server details and
+    /// downloads them to local storage, reporting progress as
+    /// (downloaded, total) bytes.
+    func execute(
+        rom: Rom,
+        progressHandler: @escaping (Int64, Int64) -> Void
+    ) async throws -> DownloadedROM
+}
+
+/// Owns the "resolve which files a ROM consists of, then download them"
+/// orchestration so the download queue stays a thin state coordinator and the
+/// data access lives in the domain layer.
+final class DownloadROMUseCase: PDownloadROMUseCase {
+
+    private let apiClient: PRommAPIClient
+    private let downloadService: PLocalROMDownloadService
+
+    init(
+        apiClient: PRommAPIClient = RommAPIClient.shared,
+        downloadService: PLocalROMDownloadService? = nil
+    ) {
+        self.apiClient = apiClient
+        self.downloadService = downloadService ?? LocalROMDownloadService(apiClient: apiClient)
+    }
+
+    func execute(
+        rom: Rom,
+        progressHandler: @escaping (Int64, Int64) -> Void
+    ) async throws -> DownloadedROM {
+        let files = try await resolveFiles(for: rom)
+        return try await downloadService.downloadROM(
+            rom: rom,
+            files: files,
+            progressHandler: progressHandler
+        )
+    }
+
+    /// Builds the file list from the server ROM details, falling back to a
+    /// single file derived from the ROM itself when the details carry none.
+    private func resolveFiles(for rom: Rom) async throws -> [RomFileInfo] {
+        let details = try await apiClient.getRomDetails(id: rom.id)
+        var files: [RomFileInfo] = []
+        if !details.fsName.isEmpty {
+            files.append(RomFileInfo(
+                id: details.fsName,
+                fileName: details.fsName,
+                fileSizeBytes: Int64(details.fsSizeBytes),
+                fileExtension: (details.fsName as NSString).pathExtension
+            ))
+        }
+        for supplementary in details.files
+        where supplementary.fileName != details.fsName && !supplementary.fileName.isEmpty {
+            files.append(RomFileInfo(from: supplementary))
+        }
+        if files.isEmpty {
+            let fallbackName = rom.fileName ?? "\(rom.name).rom"
+            files = [RomFileInfo(
+                id: fallbackName,
+                fileName: fallbackName,
+                fileSizeBytes: Int64(rom.sizeBytes ?? 0),
+                fileExtension: (fallbackName as NSString).pathExtension
+            )]
+        }
+        return files
+    }
+}

--- a/romm/romm/Localizable.xcstrings
+++ b/romm/romm/Localizable.xcstrings
@@ -100,6 +100,61 @@
         }
       }
     },
+    "Download Failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download fehlgeschlagen"
+          }
+        }
+      }
+    },
+    "Downloaded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladen"
+          }
+        }
+      }
+    },
+    "Downloading… %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird geladen … %@"
+          }
+        }
+      }
+    },
+    "Open In…" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In App öffnen …"
+          }
+        }
+      }
+    },
+    "Send to Device" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An Gerät senden"
+          }
+        }
+      }
+    },
     "Dynamic library not found: %@" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/romm/romm/UI/Devices/LocalDevice/LocalDeviceDetailView.swift
+++ b/romm/romm/UI/Devices/LocalDevice/LocalDeviceDetailView.swift
@@ -3,7 +3,10 @@ import SwiftUI
 struct LocalDeviceDetailView: View {
     @State private var viewModel = LocalDeviceDetailViewModel()
     @State private var showingDeviceManagement = false
+    @State private var showingDownloadQueue = false
     @State private var isStorageExpanded = false
+
+    private let downloadQueue = DownloadQueueManager.shared
 
     private var device: LocalDevice {
         LocalDeviceManager.shared.currentDevice
@@ -22,12 +25,26 @@ struct LocalDeviceDetailView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
+                    showingDownloadQueue = true
+                } label: {
+                    downloadQueueIcon
+                }
+                .accessibilityLabel("Download Queue")
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
                     showingDeviceManagement = true
                 } label: {
                     Image(systemName: "server.rack")
                 }
                 .accessibilityLabel("Manage Devices")
             }
+        }
+        .sheet(isPresented: $showingDownloadQueue) {
+            DownloadQueueView()
+        }
+        .onChange(of: downloadQueue.finishedCount) { _, _ in
+            Task { await viewModel.loadDownloadedROMsAsync() }
         }
         .sheet(isPresented: $showingDeviceManagement) {
             NavigationStack {
@@ -57,6 +74,21 @@ struct LocalDeviceDetailView: View {
         } message: {
             Text(viewModel.error ?? "")
         }
+    }
+
+    private var downloadQueueIcon: some View {
+        let count = downloadQueue.activeCount
+        return Image(systemName: "arrow.down.circle")
+            .overlay(alignment: .topTrailing) {
+                if count > 0 {
+                    Text("\(count)")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(4)
+                        .background(Circle().fill(Color.red))
+                        .offset(x: 8, y: -8)
+                }
+            }
     }
 
     private var emptyStateView: some View {

--- a/romm/romm/UI/Downloads/DownloadQueueView.swift
+++ b/romm/romm/UI/Downloads/DownloadQueueView.swift
@@ -109,11 +109,19 @@ struct DownloadQueueView: View {
                 .foregroundColor(.secondary)
         case .downloading(let progress):
             VStack(alignment: .leading, spacing: 3) {
-                ProgressView(value: progress)
-                    .tint(.accentColor)
-                Text("\(Int(progress * 100))%")
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
+                if let progress {
+                    ProgressView(value: progress)
+                        .tint(.accentColor)
+                    Text("\(Int(progress * 100))%")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                } else {
+                    ProgressView()
+                        .tint(.accentColor)
+                    Text("Downloading…")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
             }
         case .finished:
             Text("Downloaded")

--- a/romm/romm/UI/Downloads/DownloadQueueView.swift
+++ b/romm/romm/UI/Downloads/DownloadQueueView.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+/// Shows the current download queue: active (queued / downloading) items and
+/// completed (finished / failed) ones. Presented as a sheet from the Downloads tab.
+struct DownloadQueueView: View {
+    private let queue = DownloadQueueManager.shared
+    @Environment(\.dismiss) private var dismiss
+
+    private var activeTasks: [DownloadTask] { queue.tasks.filter { $0.isActive } }
+    private var completedTasks: [DownloadTask] { queue.tasks.filter { !$0.isActive } }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if queue.tasks.isEmpty {
+                    emptyState
+                } else {
+                    List {
+                        if !activeTasks.isEmpty {
+                            Section("In Progress") {
+                                ForEach(activeTasks) { task in
+                                    row(for: task)
+                                }
+                            }
+                        }
+                        if !completedTasks.isEmpty {
+                            Section("Completed") {
+                                ForEach(completedTasks) { task in
+                                    row(for: task)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Downloads")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if !completedTasks.isEmpty {
+                        Button("Clear") { queue.clearCompleted() }
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "arrow.down.circle")
+                .font(.system(size: 56))
+                .foregroundColor(.secondary)
+            Text("No Downloads")
+                .font(.title3).fontWeight(.semibold)
+            Text("ROMs you download will appear here while they transfer.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+        }
+    }
+
+    @ViewBuilder
+    private func row(for task: DownloadTask) -> some View {
+        HStack(spacing: 12) {
+            if let slug = task.platformSlug {
+                Image(slug)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 40, height: 40)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            } else {
+                Image(systemName: "gamecontroller")
+                    .frame(width: 40, height: 40)
+                    .foregroundColor(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(task.name)
+                    .font(.subheadline.weight(.medium))
+                    .lineLimit(1)
+                statusLine(for: task)
+            }
+
+            Spacer()
+
+            trailing(for: task)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            if !isDownloading(task) {
+                Button(role: .destructive) {
+                    queue.remove(id: task.id)
+                } label: {
+                    Label("Remove", systemImage: "trash")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func statusLine(for task: DownloadTask) -> some View {
+        switch task.status {
+        case .queued:
+            Text("Queued")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        case .downloading(let progress):
+            VStack(alignment: .leading, spacing: 3) {
+                ProgressView(value: progress)
+                    .tint(.accentColor)
+                Text("\(Int(progress * 100))%")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        case .finished:
+            Text("Downloaded")
+                .font(.caption)
+                .foregroundColor(.green)
+        case .failed(let message):
+            Text(message)
+                .font(.caption)
+                .foregroundColor(.red)
+                .lineLimit(2)
+        }
+    }
+
+    @ViewBuilder
+    private func trailing(for task: DownloadTask) -> some View {
+        switch task.status {
+        case .queued:
+            Image(systemName: "clock")
+                .foregroundColor(.secondary)
+        case .downloading:
+            ProgressView()
+        case .finished:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(.green)
+        case .failed:
+            Button {
+                queue.retry(id: task.id)
+            } label: {
+                Image(systemName: "arrow.clockwise.circle.fill")
+                    .foregroundColor(.accentColor)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func isDownloading(_ task: DownloadTask) -> Bool {
+        if case .downloading = task.status { return true }
+        return false
+    }
+}

--- a/romm/romm/UI/Downloads/DownloadQueueView.swift
+++ b/romm/romm/UI/Downloads/DownloadQueueView.swift
@@ -112,9 +112,12 @@ struct DownloadQueueView: View {
                 if let progress {
                     ProgressView(value: progress)
                         .tint(.accentColor)
+                        .animation(.easeOut(duration: 0.4), value: progress)
                     Text("\(Int(progress * 100))%")
                         .font(.caption2)
                         .foregroundColor(.secondary)
+                        .contentTransition(.numericText())
+                        .animation(.easeOut(duration: 0.4), value: progress)
                 } else {
                     ProgressView()
                         .tint(.accentColor)

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -381,8 +381,12 @@ struct RomDetailView: View {
                         Text("Queued").font(.headline)
                     case .downloading(let progress):
                         ProgressView().progressViewStyle(.circular).tint(.white)
-                        Text("Downloading… \(Int((progress * 100).rounded()))%")
-                            .font(.headline)
+                        if let progress {
+                            Text("Downloading… \(Int((progress * 100).rounded()))%")
+                                .font(.headline)
+                        } else {
+                            Text("Downloading…").font(.headline)
+                        }
                     case .downloaded:
                         Label("Downloaded", systemImage: "checkmark.circle.fill")
                             .font(.headline)

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -18,7 +18,6 @@ struct RomDetailView: View {
     @State private var selectedTab: DetailTab = .details
     @State private var dominantColor: Color? = nil
     @State private var isHashesExpanded: Bool = false
-    @State private var showingActionSheet = false
     @State private var showingSFTPUpload = false
     @State private var showingCollectionPicker = false
     @State private var showingFullScreenPDF = false
@@ -73,9 +72,6 @@ struct RomDetailView: View {
         )
     }
 
-    private var downloadPercentText: String {
-        "\(Int((viewModel.downloadProgress * 100).rounded()))%"
-    }
 
     var body: some View {
         ScrollView {
@@ -161,9 +157,6 @@ struct RomDetailView: View {
                             }
                         }
                     }
-                    .confirmationDialog("Actions", isPresented: $showingActionSheet, titleVisibility: .visible) {
-                        actionSheetButtons
-                    }
                     .sheet(item: Binding(
                         get: { viewModel.shareItem },
                         set: { viewModel.shareItem = $0 }
@@ -245,8 +238,14 @@ struct RomDetailView: View {
                 }
                 viewModel.refreshDownloadState(romId: rom.id)
             }
+            .toast(
+                isPresented: $viewModel.showAddedToast,
+                message: "Added to downloads",
+                type: .success,
+                duration: 2.0
+            )
     }
-    
+
     @ViewBuilder
     private var titleBlock: some View {
         VStack(spacing: 12) {
@@ -369,25 +368,28 @@ struct RomDetailView: View {
                 .accessibility(hint: Text(viewModel.romCollectionsCount > 0 ? "Manage ROM collections" : "Add this ROM to a collection"))
             }
             
-            // Primary action: download to this device.
+            // Primary action: queue a download to this device.
             // Playing happens in the Downloads tab (ROMCardRow), not here.
+            let downloadState = viewModel.downloadButtonState(forRomId: currentSelectedRom.id)
             Button(action: {
-                guard !viewModel.isDownloadingROM, !viewModel.isDownloaded else { return }
-                Task {
-                    await viewModel.downloadROM(rom: currentSelectedRom)
-                }
+                viewModel.downloadROM(rom: currentSelectedRom)
             }) {
                 HStack(spacing: 8) {
-                    if viewModel.isDownloadingROM {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .tint(.white)
-                        Text("Downloading… \(downloadPercentText)")
+                    switch downloadState {
+                    case .queued:
+                        ProgressView().progressViewStyle(.circular).tint(.white)
+                        Text("Queued").font(.headline)
+                    case .downloading(let progress):
+                        ProgressView().progressViewStyle(.circular).tint(.white)
+                        Text("Downloading… \(Int((progress * 100).rounded()))%")
                             .font(.headline)
-                    } else if viewModel.isDownloaded {
+                    case .downloaded:
                         Label("Downloaded", systemImage: "checkmark.circle.fill")
                             .font(.headline)
-                    } else {
+                    case .failed:
+                        Label("Retry Download", systemImage: "arrow.clockwise.circle.fill")
+                            .font(.headline)
+                    case .idle:
                         Label("Download", systemImage: "arrow.down.circle.fill")
                             .font(.headline)
                     }
@@ -396,13 +398,18 @@ struct RomDetailView: View {
                 .padding(.vertical, 14)
                 .background(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(viewModel.isDownloaded ? Color.green : Color.accentColor)
+                        .fill(downloadState == .downloaded ? Color.green : Color.accentColor)
                 )
                 .foregroundColor(.white)
                 .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
             }
-            .disabled(viewModel.isDownloadingROM || viewModel.isDownloaded)
-            .accessibility(hint: Text(viewModel.isDownloaded ? "Already downloaded to this device" : "Download this ROM to this device"))
+            .disabled({
+                switch downloadState {
+                case .idle, .failed: return false
+                case .queued, .downloading, .downloaded: return true
+                }
+            }())
+            .accessibility(hint: Text(downloadState == .downloaded ? "Already downloaded to this device" : "Download this ROM to this device"))
 
             // Secondary actions: open the downloaded file in another app, or send it to a device.
             HStack(spacing: 12) {
@@ -727,23 +734,6 @@ struct RomDetailView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.top, 8)
-    }
-    
-    @ViewBuilder
-    private var actionSheetButtons: some View {
-        Button(viewModel.actualFavoriteStatus ? "Remove from Favorites" : "Add to Favorites") {
-            viewModel.toggleFavorite(originalRom: rom)
-        }
-        
-        Button(viewModel.romCollectionsCount > 0 ? "Manage Collections (\(viewModel.romCollectionsCount))" : "Add to Collection") {
-            showingCollectionPicker = true
-        }
-        
-        Button("Set as Default") {
-            // TODO: Implement set as default
-        }
-        
-        Button("Cancel", role: .cancel) {}
     }
     
     private func extractDominantColor(from image: Image) {

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -380,11 +380,18 @@ struct RomDetailView: View {
                         ProgressView().progressViewStyle(.circular).tint(.white)
                         Text("Queued").font(.headline)
                     case .downloading(let progress):
-                        ProgressView().progressViewStyle(.circular).tint(.white)
                         if let progress {
-                            Text("Downloading… \(Int((progress * 100).rounded()))%")
+                            ProgressView(value: progress)
+                                .progressViewStyle(.linear)
+                                .tint(.white)
+                                .frame(maxWidth: 140)
+                                .animation(.easeOut(duration: 0.4), value: progress)
+                            Text("\(Int((progress * 100).rounded()))%")
                                 .font(.headline)
+                                .contentTransition(.numericText())
+                                .animation(.easeOut(duration: 0.4), value: progress)
                         } else {
+                            ProgressView().progressViewStyle(.circular).tint(.white)
                             Text("Downloading…").font(.headline)
                         }
                     case .downloaded:

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -19,7 +19,6 @@ struct RomDetailView: View {
     @State private var dominantColor: Color? = nil
     @State private var isHashesExpanded: Bool = false
     @State private var showingActionSheet = false
-    @State private var showingShareSheet = false
     @State private var showingSFTPUpload = false
     @State private var showingCollectionPicker = false
     @State private var showingFullScreenPDF = false
@@ -73,7 +72,11 @@ struct RomDetailView: View {
             platformSlug: rom.platformSlug // Keep original platform slug
         )
     }
-    
+
+    private var downloadPercentText: String {
+        "\(Int((viewModel.downloadProgress * 100).rounded()))%"
+    }
+
     var body: some View {
         ScrollView {
                 VStack(spacing: 0) {
@@ -161,8 +164,13 @@ struct RomDetailView: View {
                     .confirmationDialog("Actions", isPresented: $showingActionSheet, titleVisibility: .visible) {
                         actionSheetButtons
                     }
-                    .sheet(isPresented: $showingShareSheet) {
-                        ShareSheet(activityItems: ["Check out this ROM: \(rom.name)"])
+                    .sheet(item: Binding(
+                        get: { viewModel.shareItem },
+                        set: { viewModel.shareItem = $0 }
+                    ), onDismiss: {
+                        viewModel.cleanupShareTemp()
+                    }) { item in
+                        ShareSheet(activityItems: item.urls)
                     }
                     .sheet(isPresented: $showingSFTPUpload) {
                         SFTPUploadView(rom: currentSelectedRom)
@@ -187,11 +195,6 @@ struct RomDetailView: View {
                             )
                         }
                     }
-                    .fullScreenCover(item: $viewModel.launchDecision, onDismiss: {
-                        viewModel.emulatorPresentationDidEnd()
-                    }) { decision in
-                        EmulatorRouterView(decision: decision)
-                    }
                     .alert("Error", isPresented: .constant(viewModel.errorMessage != nil)) {
                         Button("OK") {
                             viewModel.clearError()
@@ -199,10 +202,13 @@ struct RomDetailView: View {
                     } message: {
                         Text(viewModel.errorMessage ?? "")
                     }
-                    .alert("Experimental Feature", isPresented: $viewModel.showingEmulatorFeatureHint) {
+                    .alert("Download Failed", isPresented: Binding(
+                        get: { viewModel.downloadError != nil },
+                        set: { if !$0 { viewModel.downloadError = nil } }
+                    )) {
                         Button("OK", role: .cancel) { }
                     } message: {
-                        Text("The in-app emulator is an experimental feature. Enable it under Settings → Experimental Features.")
+                        Text(viewModel.downloadError ?? "")
                     }
                 }
             }
@@ -237,6 +243,7 @@ struct RomDetailView: View {
                 Task {
                     await viewModel.loadRomDetails(romId: rom.id)
                 }
+                viewModel.refreshDownloadState(romId: rom.id)
             }
     }
     
@@ -362,55 +369,73 @@ struct RomDetailView: View {
                 .accessibility(hint: Text(viewModel.romCollectionsCount > 0 ? "Manage ROM collections" : "Add this ROM to a collection"))
             }
             
-            // Play Button (TestFlight & Debug only)
-            if Bundle.main.isTestFlightBuild || Bundle.main.isDebugBuild {
-                Button(action: {
-                    guard !viewModel.isLaunchingEmulator else { return }
-                    Task {
-                        await viewModel.launchEmulator(rom: currentSelectedRom)
-                    }
-                }) {
-                    HStack(spacing: 8) {
-                        if viewModel.isLaunchingEmulator {
-                            ProgressView()
-                                .progressViewStyle(.circular)
-                                .tint(.white)
-                            Text("Starting…")
-                                .font(.headline)
-                        } else {
-                            Label("Play", systemImage: "play.circle.fill")
-                                .font(.headline)
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(Color.green)
-                    )
-                    .foregroundColor(.white)
-                    .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
-                }
-                .opacity(viewModel.canPlayEmulator ? 1.0 : 0.6)
-                .disabled(!viewModel.canPlayEmulator || viewModel.isLaunchingEmulator)
-                .accessibility(hint: Text("Play this ROM in the emulator"))
-            }
-
-            // Download Button
+            // Primary action: download to this device.
+            // Playing happens in the Downloads tab (ROMCardRow), not here.
             Button(action: {
-                showingSFTPUpload = true
+                guard !viewModel.isDownloadingROM, !viewModel.isDownloaded else { return }
+                Task {
+                    await viewModel.downloadROM(rom: currentSelectedRom)
+                }
             }) {
-                Label("Download", systemImage: "arrow.down.circle.fill")
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(Color.accentColor)
-                    )
-                    .foregroundColor(.white)
-                    .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
+                HStack(spacing: 8) {
+                    if viewModel.isDownloadingROM {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .tint(.white)
+                        Text("Downloading… \(downloadPercentText)")
+                            .font(.headline)
+                    } else if viewModel.isDownloaded {
+                        Label("Downloaded", systemImage: "checkmark.circle.fill")
+                            .font(.headline)
+                    } else {
+                        Label("Download", systemImage: "arrow.down.circle.fill")
+                            .font(.headline)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(viewModel.isDownloaded ? Color.green : Color.accentColor)
+                )
+                .foregroundColor(.white)
+                .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
             }
-            .accessibility(hint: Text("Upload this ROM to an SFTP device"))
+            .disabled(viewModel.isDownloadingROM || viewModel.isDownloaded)
+            .accessibility(hint: Text(viewModel.isDownloaded ? "Already downloaded to this device" : "Download this ROM to this device"))
+
+            // Secondary actions: open the downloaded file in another app, or send it to a device.
+            HStack(spacing: 12) {
+                if viewModel.isDownloaded {
+                    Button(action: {
+                        viewModel.prepareOpenIn(romId: rom.id)
+                    }) {
+                        Label("Open In…", systemImage: "square.and.arrow.up")
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(Color(.systemGray6).opacity(0.3))
+                            )
+                            .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 4)
+                    }
+                    .accessibility(hint: Text("Open this ROM in another app such as RetroArch or Delta"))
+                }
+
+                Button(action: {
+                    showingSFTPUpload = true
+                }) {
+                    Label("Send to Device", systemImage: "arrow.up.forward.app")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .fill(Color(.systemGray6).opacity(0.3))
+                        )
+                        .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 4)
+                }
+                .accessibility(hint: Text("Send this ROM to another device over SFTP"))
+            }
         }
         .padding(.bottom, 24)
     }

--- a/romm/romm/UI/RomDetail/RomDetailViewModel.swift
+++ b/romm/romm/UI/RomDetail/RomDetailViewModel.swift
@@ -8,6 +8,13 @@
 import Foundation
 import Observation
 
+/// Wrapper so the "Open In…" share sheet can be presented via `.sheet(item:)`.
+struct ShareURLsItem: Identifiable {
+    let id = UUID()
+    let urls: [URL]
+    let tempDirectory: URL?
+}
+
 @Observable
 @MainActor
 class RomDetailViewModel {
@@ -34,6 +41,13 @@ class RomDetailViewModel {
     var launchDecision: LaunchDecision? = nil
     var isLaunchingEmulator: Bool = false
 
+    // Local download (playing happens in the Downloads tab)
+    var isDownloaded: Bool = false
+    var isDownloadingROM: Bool = false
+    var downloadProgress: Double = 0 // 0...1
+    var downloadError: String? = nil
+    var shareItem: ShareURLsItem? = nil
+
     private let logger = Logger.viewModel
 
     private let apiClient: PRommAPIClient
@@ -45,6 +59,8 @@ class RomDetailViewModel {
     private let platformEngineSupport: PPlatformEngineSupport
     private let launchEmulatorUseCase: PLaunchEmulatorUseCase
     private let updateLastPlayedUseCase: PUpdateLastPlayedUseCase
+    private let getDownloadedROMUseCase: PGetDownloadedROMUseCase
+    private let getROMShareFilesUseCase: PGetROMShareFilesUseCase
 
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared,
          apiClient: PRommAPIClient = RommAPIClient.shared) {
@@ -57,6 +73,8 @@ class RomDetailViewModel {
         self.platformEngineSupport = factory.makePlatformEngineSupport()
         self.launchEmulatorUseCase = factory.makeLaunchEmulatorUseCase()
         self.updateLastPlayedUseCase = factory.makeUpdateLastPlayedUseCase()
+        self.getDownloadedROMUseCase = factory.makeGetDownloadedROMUseCase()
+        self.getROMShareFilesUseCase = factory.makeGetROMShareFilesUseCase()
     }
     
     func loadRomDetails(romId: Int) async {
@@ -333,5 +351,90 @@ class RomDetailViewModel {
 
     func emulatorPresentationDidEnd() {
         isLaunchingEmulator = false
+    }
+
+    // MARK: - Local Download
+
+    /// Refreshes whether this ROM is already downloaded to the device.
+    func refreshDownloadState(romId: Int) {
+        isDownloaded = (try? getDownloadedROMUseCase.execute(romId: romId)) != nil
+    }
+
+    /// Downloads all files of the ROM to local device storage with progress.
+    func downloadROM(rom: Rom) async {
+        guard !isDownloadingROM, !isDownloaded else { return }
+
+        isDownloadingROM = true
+        downloadProgress = 0
+        downloadError = nil
+
+        do {
+            // Resolve the concrete files to download from the server details.
+            let details = try await apiClient.getRomDetails(id: rom.id)
+            var files: [RomFileInfo] = []
+            if !details.fsName.isEmpty {
+                files.append(RomFileInfo(
+                    id: details.fsName,
+                    fileName: details.fsName,
+                    fileSizeBytes: Int64(details.fsSizeBytes),
+                    fileExtension: (details.fsName as NSString).pathExtension
+                ))
+            }
+            for supplementary in details.files
+            where supplementary.fileName != details.fsName && !supplementary.fileName.isEmpty {
+                files.append(RomFileInfo(from: supplementary))
+            }
+            if files.isEmpty {
+                let fallbackName = rom.fileName ?? "\(rom.name).rom"
+                files = [RomFileInfo(
+                    id: fallbackName,
+                    fileName: fallbackName,
+                    fileSizeBytes: Int64(rom.sizeBytes ?? 0),
+                    fileExtension: (fallbackName as NSString).pathExtension
+                )]
+            }
+
+            let downloadService = LocalROMDownloadService(apiClient: apiClient)
+            _ = try await downloadService.downloadROM(rom: rom, files: files) { [weak self] downloaded, total in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.downloadProgress = total > 0
+                        ? min(max(Double(downloaded) / Double(total), 0), 1)
+                        : 0
+                }
+            }
+
+            isDownloaded = true
+            downloadProgress = 1
+            logger.info("Downloaded ROM \(rom.id) - \(rom.name) to device")
+        } catch {
+            downloadError = error.localizedDescription
+            logger.error("ROM download failed for \(rom.id): \(error)")
+        }
+
+        isDownloadingROM = false
+    }
+
+    /// Prepares the downloaded ROM files for the iOS share sheet ("Open In…").
+    func prepareOpenIn(romId: Int) {
+        do {
+            let resolved = try getDownloadedROMUseCase.execute(romId: romId)
+            let result = getROMShareFilesUseCase.execute(rom: resolved.rom)
+            guard !result.files.isEmpty else {
+                downloadError = "No files available to open."
+                return
+            }
+            shareItem = ShareURLsItem(urls: result.files, tempDirectory: result.tempDirectory)
+        } catch {
+            downloadError = error.localizedDescription
+        }
+    }
+
+    /// Cleans up the temporary directory created for sharing.
+    func cleanupShareTemp() {
+        if let dir = shareItem?.tempDirectory {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        shareItem = nil
     }
 }

--- a/romm/romm/UI/RomDetail/RomDetailViewModel.swift
+++ b/romm/romm/UI/RomDetail/RomDetailViewModel.swift
@@ -43,10 +43,33 @@ class RomDetailViewModel {
 
     // Local download (playing happens in the Downloads tab)
     var isDownloaded: Bool = false
-    var isDownloadingROM: Bool = false
-    var downloadProgress: Double = 0 // 0...1
     var downloadError: String? = nil
     var shareItem: ShareURLsItem? = nil
+    var showAddedToast: Bool = false
+
+    /// Shared, app-wide download queue. Downloads keep running after this screen
+    /// is dismissed; the queue is viewable from the Downloads tab.
+    let downloadQueue = DownloadQueueManager.shared
+
+    /// Combined button state from on-disk status and the live queue.
+    enum DownloadButtonState: Equatable {
+        case idle
+        case queued
+        case downloading(Double) // 0...1
+        case downloaded
+        case failed
+    }
+
+    func downloadButtonState(forRomId id: Int) -> DownloadButtonState {
+        if isDownloaded { return .downloaded }
+        switch downloadQueue.status(forRomId: id) {
+        case .queued: return .queued
+        case .downloading(let progress): return .downloading(progress)
+        case .finished: return .downloaded
+        case .failed: return .failed
+        case nil: return .idle
+        }
+    }
 
     private let logger = Logger.viewModel
 
@@ -360,59 +383,13 @@ class RomDetailViewModel {
         isDownloaded = (try? getDownloadedROMUseCase.execute(romId: romId)) != nil
     }
 
-    /// Downloads all files of the ROM to local device storage with progress.
-    func downloadROM(rom: Rom) async {
-        guard !isDownloadingROM, !isDownloaded else { return }
-
-        isDownloadingROM = true
-        downloadProgress = 0
-        downloadError = nil
-
-        do {
-            // Resolve the concrete files to download from the server details.
-            let details = try await apiClient.getRomDetails(id: rom.id)
-            var files: [RomFileInfo] = []
-            if !details.fsName.isEmpty {
-                files.append(RomFileInfo(
-                    id: details.fsName,
-                    fileName: details.fsName,
-                    fileSizeBytes: Int64(details.fsSizeBytes),
-                    fileExtension: (details.fsName as NSString).pathExtension
-                ))
-            }
-            for supplementary in details.files
-            where supplementary.fileName != details.fsName && !supplementary.fileName.isEmpty {
-                files.append(RomFileInfo(from: supplementary))
-            }
-            if files.isEmpty {
-                let fallbackName = rom.fileName ?? "\(rom.name).rom"
-                files = [RomFileInfo(
-                    id: fallbackName,
-                    fileName: fallbackName,
-                    fileSizeBytes: Int64(rom.sizeBytes ?? 0),
-                    fileExtension: (fallbackName as NSString).pathExtension
-                )]
-            }
-
-            let downloadService = LocalROMDownloadService(apiClient: apiClient)
-            _ = try await downloadService.downloadROM(rom: rom, files: files) { [weak self] downloaded, total in
-                guard let self else { return }
-                Task { @MainActor in
-                    self.downloadProgress = total > 0
-                        ? min(max(Double(downloaded) / Double(total), 0), 1)
-                        : 0
-                }
-            }
-
-            isDownloaded = true
-            downloadProgress = 1
-            logger.info("Downloaded ROM \(rom.id) - \(rom.name) to device")
-        } catch {
-            downloadError = error.localizedDescription
-            logger.error("ROM download failed for \(rom.id): \(error)")
-        }
-
-        isDownloadingROM = false
+    /// Adds the ROM to the shared download queue and shows a brief confirmation.
+    /// The actual transfer runs in `DownloadQueueManager`, so the user can leave
+    /// this screen and watch progress from the Downloads tab.
+    func downloadROM(rom: Rom) {
+        guard !isDownloaded else { return }
+        downloadQueue.enqueue(rom: rom)
+        showAddedToast = true
     }
 
     /// Prepares the downloaded ROM files for the iOS share sheet ("Open In…").

--- a/romm/romm/UI/RomDetail/RomDetailViewModel.swift
+++ b/romm/romm/UI/RomDetail/RomDetailViewModel.swift
@@ -55,7 +55,7 @@ class RomDetailViewModel {
     enum DownloadButtonState: Equatable {
         case idle
         case queued
-        case downloading(Double) // 0...1
+        case downloading(Double?) // 0...1, or nil when size is unknown
         case downloaded
         case failed
     }


### PR DESCRIPTION
Reworks the ROM detail actions to be download-focused (playing stays in the Downloads tab) and adds a shared background download queue.

- Download now enqueues into a serial queue with an "Added to downloads" toast, so you can leave the screen while it transfers.
- Downloads tab gets a queue bar button (with an active-count badge) showing in-progress and completed downloads, plus retry for failures.
- Progress uses the real transfer size from URLSession and animates the fill; falls back to an indeterminate spinner when the server streams without a byte count.
- Open In… / Send to Device for downloaded ROMs; removed the dead Actions dialog.