### PR TITLE
Resume from save state on launch

### DIFF
--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
@@ -18,6 +18,10 @@ struct PlatformROMsListView: View {
     @State private var romPendingDelete: DownloadedROM?
     @State private var romPendingSync: DownloadedROM?
     @State private var detailRom: DownloadedROM?
+    /// ROM awaiting a resume/new-game choice in the pre-launch sheet.
+    @State private var romPendingLaunch: DownloadedROM?
+    /// Slot chosen in the pre-launch sheet; read by the emulator cover builder.
+    @State private var pendingResumeSlot: Int?
     private let factory: PDependencyFactory
     private let launchUseCase: PLaunchEmulatorUseCase
     private let updateLastPlayedUseCase: PUpdateLastPlayedUseCase
@@ -44,9 +48,13 @@ struct PlatformROMsListView: View {
                     hasSaveGame: hasSaveGame(romId: rom.id),
                     hasSaveState: hasSaveState(romId: rom.id),
                     onPlay: {
-                        if isPlatformSupported(rom.platformSlug) && launchingRomId == nil {
+                        guard isPlatformSupported(rom.platformSlug), launchingRomId == nil else { return }
+                        if hasSaveState(romId: rom.id) {
+                            // Offer resume vs. new game before booting the core.
+                            romPendingLaunch = rom
+                        } else {
                             launchingRomId = rom.id
-                            Task { await launch(rom: rom) }
+                            Task { await launch(rom: rom, resumeSlot: nil) }
                         }
                     },
                     onSync: { romPendingSync = rom },
@@ -71,10 +79,24 @@ struct PlatformROMsListView: View {
         }
         .fullScreenCover(item: $launchDecision, onDismiss: {
             launchingRomId = nil
+            pendingResumeSlot = nil
             OrientationLock.set(.portrait, rotateTo: .portrait)
         }) { decision in
-            EmulatorRouterView(decision: decision)
+            EmulatorRouterView(decision: decision, resumeSlot: pendingResumeSlot)
                 .ignoresSafeArea()
+        }
+        .sheet(item: $romPendingLaunch) { rom in
+            PreLaunchSheet(
+                romName: rom.name,
+                romId: rom.id,
+                saveStore: saveStore
+            ) { resumeSlot in
+                romPendingLaunch = nil
+                launchingRomId = rom.id
+                Task { await launch(rom: rom, resumeSlot: resumeSlot) }
+            }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
         }
         .confirmationDialog(
             "Delete ROM?",
@@ -109,7 +131,7 @@ struct PlatformROMsListView: View {
         return false
     }
 
-    private func launch(rom: DownloadedROM) async {
+    private func launch(rom: DownloadedROM, resumeSlot: Int?) async {
         let start = Date()
         let result = await launchUseCase.execute(rom: rom.toRom())
         let elapsed = Date().timeIntervalSince(start)
@@ -118,6 +140,8 @@ struct PlatformROMsListView: View {
             try? await Task.sleep(nanoseconds: UInt64((minVisible - elapsed) * 1_000_000_000))
         }
         if case .success(let decision) = result {
+            // Set the slot before the decision so the cover builder reads it.
+            pendingResumeSlot = resumeSlot
             launchDecision = decision
             Task { [updateLastPlayedUseCase] in
                 try? await updateLastPlayedUseCase.execute(romId: rom.id)

--- a/romm/romm/UI/Emulator/EmulatorRouterView.swift
+++ b/romm/romm/UI/Emulator/EmulatorRouterView.swift
@@ -9,15 +9,19 @@ import SwiftUI
 
 struct EmulatorRouterView: View {
     let decision: LaunchDecision
+    /// Save-state slot to auto-load once the core is running, chosen in the
+    /// pre-launch sheet. `nil` starts a fresh session. The web emulator has no
+    /// save-state support, so it ignores this.
+    var resumeSlot: Int? = nil
 
     var body: some View {
         switch decision {
         case .web(let rom):
             EmulatorView(rom: rom)
         case .native(let rom, let gameType):
-            NativeEmulatorView(rom: rom, gameType: gameType)
+            NativeEmulatorView(rom: rom, gameType: gameType, resumeSlot: resumeSlot)
         case .libretro(let rom, let core):
-            LibretroEmulatorView(rom: rom, core: core)
+            LibretroEmulatorView(rom: rom, core: core, resumeSlot: resumeSlot)
         }
     }
 }

--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
@@ -8,7 +8,10 @@ struct LibretroEmulatorView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
 
-    init(rom: Rom, core: LibretroCore, factory: PDependencyFactory = DefaultDependencyFactory.shared) {
+    private let resumeSlot: Int?
+
+    init(rom: Rom, core: LibretroCore, resumeSlot: Int? = nil, factory: PDependencyFactory = DefaultDependencyFactory.shared) {
+        self.resumeSlot = resumeSlot
         let vm = factory.makeLibretroEmulatorViewModel(rom: rom, core: core)
         self._viewModel = SwiftUI.State(wrappedValue: vm)
     }
@@ -39,7 +42,7 @@ struct LibretroEmulatorView: View {
         .onAppear {
             OrientationLock.set([.portrait, .landscapeLeft, .landscapeRight])
             viewModel.onMenuRequested = { showMenu = true }
-            viewModel.bootstrap()
+            viewModel.bootstrap(resumeSlot: resumeSlot)
         }
         .onDisappear { viewModel.teardown() }
         .onChange(of: scenePhase) { _, phase in

--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
@@ -94,20 +94,11 @@ final class LibretroEmulatorViewModel {
             )
             s.onMenuRequested = { [weak self] in self?.onMenuRequested?() }
             session = s
-            s.start()
+            // The session sequences the resume-load after the core is up and
+            // performs it while paused (see LibretroSession.start).
+            s.start(resumeSlot: resumeSlot)
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 1_200_000_000)
-                // The core needs a moment of run-loop time after retro_load_game
-                // before it can accept a serialized state, so resume only after
-                // the loading overlay has been shown.
-                if let slot = resumeSlot {
-                    do {
-                        try s.loadState(slot: slot)
-                        logger.info("Resumed ROM \(rom.id) from save state slot \(slot)")
-                    } catch {
-                        logger.error("Failed to resume from slot \(slot): \(error)")
-                    }
-                }
                 withAnimation(.easeOut(duration: 0.3)) {
                     isLoading = false
                 }

--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
@@ -43,7 +43,12 @@ final class LibretroEmulatorViewModel {
         self.factory = factory
     }
 
-    func bootstrap() {
+    /// Save-state slot to auto-load once the core is running (chosen in the
+    /// pre-launch sheet), or `nil` for a fresh start.
+    private var resumeSlot: Int?
+
+    func bootstrap(resumeSlot: Int? = nil) {
+        self.resumeSlot = resumeSlot
         isLoading = true
         Task { @MainActor in
             let missing = await biosSync.missingMandatory(for: core)
@@ -92,6 +97,17 @@ final class LibretroEmulatorViewModel {
             s.start()
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 1_200_000_000)
+                // The core needs a moment of run-loop time after retro_load_game
+                // before it can accept a serialized state, so resume only after
+                // the loading overlay has been shown.
+                if let slot = resumeSlot {
+                    do {
+                        try s.loadState(slot: slot)
+                        logger.info("Resumed ROM \(rom.id) from save state slot \(slot)")
+                    } catch {
+                        logger.error("Failed to resume from slot \(slot): \(error)")
+                    }
+                }
                 withAnimation(.easeOut(duration: 0.3)) {
                     isLoading = false
                 }

--- a/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Audio.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Audio.swift
@@ -49,6 +49,17 @@ extension LibretroFrontend {
         try? AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
     }
 
+    /// Drops any buffered samples by collapsing the read cursor onto the write
+    /// cursor. Called right after loading a save state: the ring still holds the
+    /// audio produced before the load (e.g. the boot/intro that ran while the
+    /// core warmed up), and playing it out would leave sound permanently lagging
+    /// the picture.
+    func flushAudio() {
+        Self.audioRingLock.lock()
+        Self.audioReadIdx = Self.audioWriteIdx
+        Self.audioRingLock.unlock()
+    }
+
     func pauseAudio() {
         audioEngine.pause()
     }

--- a/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
@@ -47,14 +47,31 @@ final class LibretroSession: NSObject {
 
     // MARK: - Lifecycle
 
-    func start() {
+    /// - Parameter resumeSlot: Save-state slot to auto-load once the core is
+    ///   running, or `nil` to start fresh. The load is sequenced after the core
+    ///   is loaded and performed while paused — the same safe path the in-game
+    ///   menu uses. Loading into a running core makes pcsx_rearmed reject
+    ///   `retro_unserialize`, so this must not race the boot.
+    func start(resumeSlot: Int? = nil) {
         let videoView = viewController.videoView
         frontend.videoSink = videoView
 
         Task { [weak self] in
-            await self?.cloudSync?.pullBeforeLaunch()
-            self?.stageBatteryForCore()
-            self?.startCore()
+            guard let self else { return }
+            await self.cloudSync?.pullBeforeLaunch()
+            self.stageBatteryForCore()
+            self.startCore()
+            guard let slot = resumeSlot else { return }
+            // Give the core a few frames so its serialize size is initialized,
+            // then load while paused.
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            self.frontend.pause()
+            do {
+                try self.loadState(slot: slot)
+            } catch {
+                print("[Libretro] resume from slot \(slot) failed: \(error.localizedDescription)")
+            }
+            self.frontend.resume()
         }
     }
 
@@ -167,6 +184,8 @@ final class LibretroSession: NSObject {
         guard frontend.loadStateData(data) else {
             throw LibretroFrontend.FrontendError.symbolMissing("retro_unserialize")
         }
+        // Discard audio queued before the jump so sound doesn't trail the picture.
+        frontend.flushAudio()
     }
 
     func undoSave(slot: Int) throws {

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -104,13 +104,26 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
 
     // MARK: - Lifecycle
 
-    func start() {
+    /// - Parameter resumeSlot: Save-state slot to auto-load once emulation is
+    ///   live, or `nil` to start fresh. Sequenced after `startEmulation()` and
+    ///   loaded while paused, mirroring the in-game menu's load path.
+    func start(resumeSlot: Int? = nil) {
         Task { [weak self] in
-            await self?.cloudSync?.pullBeforeLaunch()
-            self?.loadBatteryIfAvailable()
-            self?.viewController.startEmulation()
-            self?.attachExternalControllers()
-            self?.observeControllerConnections()
+            guard let self else { return }
+            await self.cloudSync?.pullBeforeLaunch()
+            self.loadBatteryIfAvailable()
+            self.viewController.startEmulation()
+            self.attachExternalControllers()
+            self.observeControllerConnections()
+            guard let slot = resumeSlot else { return }
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            self.viewController.pauseEmulation()
+            do {
+                try self.loadState(slot: slot)
+            } catch {
+                print("[Native] resume from slot \(slot) failed: \(error.localizedDescription)")
+            }
+            self.viewController.resumeEmulation()
         }
     }
 

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorView.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorView.swift
@@ -7,7 +7,10 @@ struct NativeEmulatorView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
 
-    init(rom: Rom, gameType: DeltaGameType, factory: PDependencyFactory = DefaultDependencyFactory.shared) {
+    private let resumeSlot: Int?
+
+    init(rom: Rom, gameType: DeltaGameType, resumeSlot: Int? = nil, factory: PDependencyFactory = DefaultDependencyFactory.shared) {
+        self.resumeSlot = resumeSlot
         self._viewModel = SwiftUI.State(wrappedValue: NativeEmulatorViewModel(
             rom: rom, gameType: gameType,
             getDownloadedROM: factory.makeGetDownloadedROMUseCase(),
@@ -36,7 +39,7 @@ struct NativeEmulatorView: View {
         .animation(.easeOut(duration: 0.25), value: viewModel.isLoading)
         .onAppear {
             OrientationLock.set([.portrait, .landscapeLeft, .landscapeRight])
-            viewModel.bootstrap()
+            viewModel.bootstrap(resumeSlot: resumeSlot)
             viewModel.session?.onMenuRequested = { showMenu = true }
         }
         .onDisappear {

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
@@ -72,19 +72,11 @@ final class NativeEmulatorViewModel {
                 romId: rom.id, saveStates: saveStates,
                 cloudSync: cloudSync
             )
-            session?.start()
+            // The session sequences the resume-load after emulation is live and
+            // performs it while paused (see NativeEmulatorSession.start).
+            session?.start(resumeSlot: resumeSlot)
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 1_200_000_000)
-                // Load the chosen save state only after the core has had run-loop
-                // time — DeltaCore rejects a state load before emulation is live.
-                if let slot = resumeSlot {
-                    do {
-                        try session?.loadState(slot: slot)
-                        logger.info("Resumed ROM \(rom.id) from save state slot \(slot)")
-                    } catch {
-                        logger.error("Failed to resume from slot \(slot): \(error)")
-                    }
-                }
                 withAnimation(.easeOut(duration: 0.3)) {
                     isLoading = false
                 }

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
@@ -41,7 +41,12 @@ final class NativeEmulatorViewModel {
         self.factory = factory
     }
 
-    func bootstrap() {
+    /// Save-state slot to auto-load once the core is running (chosen in the
+    /// pre-launch sheet), or `nil` for a fresh start.
+    private var resumeSlot: Int?
+
+    func bootstrap(resumeSlot: Int? = nil) {
+        self.resumeSlot = resumeSlot
         isLoading = true
         do {
             let resolved = try getDownloadedROM.execute(romId: rom.id)
@@ -70,6 +75,16 @@ final class NativeEmulatorViewModel {
             session?.start()
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 1_200_000_000)
+                // Load the chosen save state only after the core has had run-loop
+                // time — DeltaCore rejects a state load before emulation is live.
+                if let slot = resumeSlot {
+                    do {
+                        try session?.loadState(slot: slot)
+                        logger.info("Resumed ROM \(rom.id) from save state slot \(slot)")
+                    } catch {
+                        logger.error("Failed to resume from slot \(slot): \(error)")
+                    }
+                }
                 withAnimation(.easeOut(duration: 0.3)) {
                     isLoading = false
                 }

--- a/romm/romm/UI/Emulator/PreLaunch/PreLaunchSheet.swift
+++ b/romm/romm/UI/Emulator/PreLaunch/PreLaunchSheet.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+import UIKit
+
+/// Shown before launching a ROM that already has save states. Lets the player
+/// continue from the most recent snapshot, pick a specific slot, or start a
+/// fresh session. When a ROM has no save states the caller skips this sheet and
+/// launches directly, so the sheet always has at least one entry to show.
+struct PreLaunchSheet: View {
+    let romName: String
+    let romId: Int
+    let saveStore: PSaveStore
+    /// Called with the slot to resume from, or `nil` to start without loading a
+    /// save state. The caller is responsible for dismissing the sheet.
+    let onLaunch: (Int?) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    private var states: [SaveStateEntry] {
+        let list = (try? saveStore.listStates(romId: romId)) ?? []
+        return list.sorted { $0.modifiedAt > $1.modifiedAt }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    if let newest = states.first {
+                        continueCard(for: newest)
+                    }
+
+                    newGameButton
+
+                    if states.count > 1 {
+                        otherStatesSection
+                    }
+                }
+                .padding(16)
+            }
+            .navigationTitle(romName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Continue (most recent state)
+
+    private func continueCard(for entry: SaveStateEntry) -> some View {
+        Button {
+            onLaunch(entry.slot)
+        } label: {
+            VStack(alignment: .leading, spacing: 12) {
+                thumbnail(for: entry.slot)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 180)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Continue")
+                            .font(.headline)
+                        Text("Slot \(entry.slot) • \(entry.modifiedAt.formatted(date: .abbreviated, time: .shortened))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Image(systemName: "play.fill")
+                        .font(.title3)
+                }
+                .foregroundColor(.primary)
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.accentColor.opacity(0.12))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(Color.accentColor.opacity(0.35), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - New game
+
+    private var newGameButton: some View {
+        Button {
+            onLaunch(nil)
+        } label: {
+            HStack {
+                Image(systemName: "gamecontroller")
+                Text("New Game")
+                    .fontWeight(.medium)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(.secondarySystemBackground))
+            )
+            .foregroundColor(.primary)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Other save states
+
+    private var otherStatesSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Other Save States")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            ForEach(states.dropFirst()) { entry in
+                Button {
+                    onLaunch(entry.slot)
+                } label: {
+                    HStack(spacing: 12) {
+                        thumbnail(for: entry.slot)
+                            .frame(width: 64, height: 48)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Slot \(entry.slot)")
+                                .font(.subheadline.weight(.medium))
+                            Text(entry.modifiedAt.formatted(date: .abbreviated, time: .shortened))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(.secondarySystemBackground))
+                    )
+                    .foregroundColor(.primary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Thumbnail
+
+    @ViewBuilder
+    private func thumbnail(for slot: Int) -> some View {
+        if let data = try? saveStore.readThumbnail(romId: romId, slot: slot),
+           let image = UIImage(data: data) {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+        } else {
+            ZStack {
+                Rectangle().fill(Color(.tertiarySystemBackground))
+                Image(systemName: "photo")
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tapping Play on a ROM that already has save states now opens a small sheet first: continue from the latest snapshot, pick another slot, or start a new game. ROMs without save states launch directly as before.

The chosen slot is loaded once the core is up, done while paused so pcsx_rearmed accepts it, and the audio buffer is flushed so sound stays in sync. Works for both libretro (PSX/PCE/Genesis) and Delta cores. Tested on device.