### PR TITLE
Make save-state slots 0-based in both emulators

### DIFF
--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
@@ -88,7 +88,7 @@ private struct LibretroMenuSheet: View {
     let onResume: () -> Void
     let onQuit: () -> Void
 
-    @SwiftUI.State private var selectedSlot: Int = 1
+    @SwiftUI.State private var selectedSlot: Int = 0
     @SwiftUI.State private var statusMessage: String?
     @SwiftUI.State private var refreshTick: Int = 0
     @SwiftUI.State private var showQuitConfirmation = false
@@ -108,7 +108,9 @@ private struct LibretroMenuSheet: View {
         self._aspectRatio = SwiftUI.State(initialValue: aspectRatioPreference.psx)
     }
 
-    private let slots = Array(1...20)
+    // 0-based to match the save-state storage / cloud-sync layer
+    // (files are `slot0.state`…`slot20.state`); slot 0 is a real, usable slot.
+    private let slots = Array(0...20)
 
     var body: some View {
         NavigationStack {

--- a/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
+++ b/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
@@ -5,7 +5,7 @@ struct EmulatorMenuSheet: View {
     let onResume: () -> Void
     let onQuit: () -> Void
 
-    @SwiftUI.State private var selectedSlot: Int = 1
+    @SwiftUI.State private var selectedSlot: Int = 0
     @SwiftUI.State private var statusMessage: String?
     @SwiftUI.State private var refreshTick: Int = 0
     @SwiftUI.State private var showQuitConfirmation = false


### PR DESCRIPTION
Libretro listed slots 1…20 and hid slot 0, and both in-game menus defaulted the selection to slot 1 — while save-state storage and cloud-sync are 0-based (slot0.state is a real slot). Now both emulators list 0…20 and default to slot 0, consistent with the file system.