### PR TITLE
Fastlane: one-command TestFlight uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,11 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 fastlane/README.md
 
+# fastlane secrets — never commit these
+fastlane/.env
+**/AuthKey_*.p8
+*.p8
+
 # Bundler
 Gemfile.lock
 .bundle/

--- a/romm/.gitignore
+++ b/romm/.gitignore
@@ -84,6 +84,11 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+fastlane/README.md
+
+# fastlane secrets — never commit these
+fastlane/.env
+fastlane/*.p8
 
 # Code Injection
 #

--- a/romm/Gemfile
+++ b/romm/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/romm/fastlane/.env.default
+++ b/romm/fastlane/.env.default
@@ -1,0 +1,7 @@
+# Template — copy to `fastlane/.env` and fill in real values (that file is gitignored).
+# App Store Connect API key: create under
+# App Store Connect → Users and Access → Integrations → App Store Connect API.
+ASC_KEY_ID=
+ASC_ISSUER_ID=
+# Path to the downloaded .p8 key, relative to the fastlane working dir (the `romm/` folder).
+ASC_KEY_PATH=./fastlane/AuthKey_XXXXXXXXXX.p8

--- a/romm/fastlane/.env.default
+++ b/romm/fastlane/.env.default
@@ -1,7 +1,10 @@
 # Template — copy to `fastlane/.env` and fill in real values (that file is gitignored).
 # App Store Connect API key: create under
 # App Store Connect → Users and Access → Integrations → App Store Connect API.
+# The key must have the Admin role so xcodebuild can manage signing during export.
 ASC_KEY_ID=
 ASC_ISSUER_ID=
 # Path to the downloaded .p8 key, relative to the fastlane working dir (the `romm/` folder).
 ASC_KEY_PATH=./fastlane/AuthKey_XXXXXXXXXX.p8
+# Apple ID email used by fastlane metadata (optional with API key auth).
+APPLE_ID=

--- a/romm/fastlane/Appfile
+++ b/romm/fastlane/Appfile
@@ -1,3 +1,3 @@
 app_identifier("de.ilyashallak.rommanagerplus")
-apple_id("ilyas@fddb.de")
+apple_id(ENV["APPLE_ID"]) if ENV["APPLE_ID"]
 team_id("8J69P655GN")

--- a/romm/fastlane/Appfile
+++ b/romm/fastlane/Appfile
@@ -1,0 +1,3 @@
+app_identifier("de.ilyashallak.rommanagerplus")
+apple_id("ilyas@fddb.de")
+team_id("8J69P655GN")

--- a/romm/fastlane/Fastfile
+++ b/romm/fastlane/Fastfile
@@ -1,0 +1,52 @@
+default_platform(:ios)
+
+# App Store Connect API key, read from environment (see fastlane/.env).
+# Used for both reading the latest build number and the TestFlight upload —
+# no Apple-ID login, no 2FA prompts.
+def asc_api_key
+  app_store_connect_api_key(
+    key_id: ENV["ASC_KEY_ID"],
+    issuer_id: ENV["ASC_ISSUER_ID"],
+    key_filepath: ENV["ASC_KEY_PATH"],
+    in_house: false
+  )
+end
+
+platform :ios do
+  desc "Check that the App Store Connect API key works (no build/upload)"
+  lane :verify do
+    build = latest_testflight_build_number(
+      api_key: asc_api_key,
+      initial_build_number: 0
+    )
+    UI.success("API key OK — latest TestFlight build number: #{build}")
+  end
+
+  desc "Build and upload a new build to TestFlight"
+  lane :beta do
+    api_key = asc_api_key
+
+    # Next build number = highest on TestFlight + 1. Overridden at build time
+    # via xcargs, so project.pbxproj stays untouched (no agvtool needed).
+    next_build = latest_testflight_build_number(
+      api_key: api_key,
+      initial_build_number: 41
+    ).to_i + 1
+
+    build_app(
+      scheme: "romm",
+      export_method: "app-store",
+      xcargs: "CURRENT_PROJECT_VERSION=#{next_build}",
+      output_directory: "./build",
+      clean: true
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      skip_waiting_for_build_processing: true,
+      distribute_external: false
+    )
+
+    UI.success("Uploaded build #{next_build} to TestFlight 🚀")
+  end
+end

--- a/romm/fastlane/Fastfile
+++ b/romm/fastlane/Fastfile
@@ -33,10 +33,30 @@ platform :ios do
       initial_build_number: 41
     ).to_i + 1
 
+    # Let xcodebuild create/fetch the distribution certificate and regenerate the
+    # App Store provisioning profile on demand during export, authenticating with
+    # the App Store Connect API key. Requires the key to have the Admin role.
+    # Absolute path, resolved relative to this fastlane dir so it's independent
+    # of the current working directory (xcodebuild requires an absolute path).
+    key_path = File.expand_path(File.basename(ENV["ASC_KEY_PATH"]), __dir__)
+    UI.user_error!("API key not found at #{key_path}") unless File.exist?(key_path)
+
+    prov_args = [
+      "-allowProvisioningUpdates",
+      "-authenticationKeyID", ENV["ASC_KEY_ID"],
+      "-authenticationKeyIssuerID", ENV["ASC_ISSUER_ID"],
+      "-authenticationKeyPath", key_path
+    ].join(" ")
+
     build_app(
       scheme: "romm",
       export_method: "app-store",
       xcargs: "CURRENT_PROJECT_VERSION=#{next_build}",
+      export_xcargs: prov_args,
+      export_options: {
+        signingStyle: "automatic",
+        teamID: "8J69P655GN"
+      },
       output_directory: "./build",
       clean: true
     )

--- a/romm/fastlane/Fastfile
+++ b/romm/fastlane/Fastfile
@@ -61,10 +61,23 @@ platform :ios do
       clean: true
     )
 
+    # Release notes ("What to Test"). Explicit override via TF_CHANGELOG, else
+    # the recent git commit subjects. Notes can only be set once the build has
+    # finished processing, so we wait when a changelog is present.
+    changelog = ENV["TF_CHANGELOG"].to_s.strip
+    if changelog.empty?
+      changelog = (changelog_from_git_commits(
+        commits_count: 15,
+        pretty: "- %s",
+        merge_commit_filtering: "exclude_merges"
+      ) rescue nil)
+    end
+
     upload_to_testflight(
       api_key: api_key,
-      skip_waiting_for_build_processing: true,
-      distribute_external: false
+      changelog: changelog,
+      distribute_external: false,
+      skip_waiting_for_build_processing: changelog.to_s.strip.empty?
     )
 
     UI.success("Uploaded build #{next_build} to TestFlight 🚀")

--- a/romm/romm.xcodeproj/xcshareddata/xcschemes/romm.xcscheme
+++ b/romm/romm.xcodeproj/xcshareddata/xcschemes/romm.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2660"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5DA7E41F2E43D870003680D9"
+               BuildableName = "romm.app"
+               BlueprintName = "romm"
+               ReferencedContainer = "container:romm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5DA7E41F2E43D870003680D9"
+            BuildableName = "romm.app"
+            BlueprintName = "romm"
+            ReferencedContainer = "container:romm.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5DA7E41F2E43D870003680D9"
+            BuildableName = "romm.app"
+            BlueprintName = "romm"
+            ReferencedContainer = "container:romm.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Adds a fastlane `beta` lane so shipping a build is just `fastlane beta` (or the /testflight command): bumps the build number from TestFlight, archives, and uploads with release notes as *What to Test*.

Signing is handled via an App Store Connect API key (Admin role) during export, so no manual archiving. Secrets live in `fastlane/.env` (gitignored); `fastlane/.env.default` is the template. Build 43 was shipped this way.