### PR TITLE
fix(emulator): pre-select most recent save slot on menu open

### DIFF
--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
@@ -93,12 +93,16 @@ private struct LibretroMenuSheet: View {
     let onResume: () -> Void
     let onQuit: () -> Void
 
-    @SwiftUI.State private var selectedSlot: Int = 0
+    @SwiftUI.State private var selectedSlot: Int
     @SwiftUI.State private var statusMessage: String?
     @SwiftUI.State private var refreshTick: Int = 0
     @SwiftUI.State private var showQuitConfirmation = false
     @SwiftUI.State private var aspectRatio: LibretroAspectRatio
     @SwiftUI.State private var hapticsOnRelease: Bool = HapticsPreferences.onRelease
+
+    // 0-based to match the save-state storage / cloud-sync layer
+    // (files are `slot0.state`…`slot20.state`); slot 0 is a real, usable slot.
+    private let slots = Array(0...20)
 
     init(
         session: LibretroSession?,
@@ -111,11 +115,15 @@ private struct LibretroMenuSheet: View {
         self.onResume = onResume
         self.onQuit = onQuit
         self._aspectRatio = SwiftUI.State(initialValue: aspectRatioPreference.psx)
+        // Pre-select the most recently touched slot so existing saves are
+        // immediately visible and loadable after the 1→0 slot renumbering (PR #57).
+        let slots = Array(0...20)
+        let mostRecent = slots.compactMap { slot -> (slot: Int, date: Date)? in
+            guard let date = session?.stateModifiedAt(slot: slot) else { return nil }
+            return (slot, date)
+        }.max(by: { $0.date < $1.date })?.slot ?? 0
+        self._selectedSlot = SwiftUI.State(initialValue: mostRecent)
     }
-
-    // 0-based to match the save-state storage / cloud-sync layer
-    // (files are `slot0.state`…`slot20.state`); slot 0 is a real, usable slot.
-    private let slots = Array(0...20)
 
     var body: some View {
         NavigationStack {

--- a/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
+++ b/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
@@ -5,7 +5,7 @@ struct EmulatorMenuSheet: View {
     let onResume: () -> Void
     let onQuit: () -> Void
 
-    @SwiftUI.State private var selectedSlot: Int = 0
+    @SwiftUI.State private var selectedSlot: Int
     @SwiftUI.State private var statusMessage: String?
     @SwiftUI.State private var refreshTick: Int = 0
     @SwiftUI.State private var showQuitConfirmation = false
@@ -13,6 +13,19 @@ struct EmulatorMenuSheet: View {
     // Slots are 0-based to match the save-state storage / cloud-sync layer
     // (files are `slot0.state`…`slot20.state`). Slot 0 is a real, usable slot.
     private let slots = Array(0...20)
+
+    init(session: NativeEmulatorSession?, onResume: @escaping () -> Void, onQuit: @escaping () -> Void) {
+        self.session = session
+        self.onResume = onResume
+        self.onQuit = onQuit
+        // Pre-select the most recently touched slot so existing saves are
+        // immediately visible and loadable after the 1→0 slot renumbering (PR #57).
+        let mostRecent = slots.compactMap { slot -> (slot: Int, date: Date)? in
+            guard let date = session?.stateModifiedAt(slot: slot) else { return nil }
+            return (slot, date)
+        }.max(by: { $0.date < $1.date })?.slot ?? 0
+        self._selectedSlot = SwiftUI.State(initialValue: mostRecent)
+    }
 
     var body: some View {
         NavigationStack {

--- a/romm/rommTests/LocalSaveStoreTests.swift
+++ b/romm/rommTests/LocalSaveStoreTests.swift
@@ -38,4 +38,29 @@ struct LocalSaveStoreRepositoryTests {
         try store.deleteState(romId: 1, slot: 1)
         #expect(try store.readState(romId: 1, slot: 1) == nil)
     }
+
+    /// Regression: PR #57 changed the UI default slot from 1 to 0. Slot 0 must
+    /// be a valid, independently addressable slot — write/read/list must all work.
+    @Test func slotZeroIsAddressableIndependentlyFromSlotOne() throws {
+        let (store, _) = makeStore()
+        let data0 = Data([0xAA])
+        let data1 = Data([0xBB])
+        try store.writeState(romId: 5, slot: 0, data: data0)
+        try store.writeState(romId: 5, slot: 1, data: data1)
+        #expect(try store.readState(romId: 5, slot: 0) == data0)
+        #expect(try store.readState(romId: 5, slot: 1) == data1)
+        let slots = try store.listStates(romId: 5).map(\.slot).sorted()
+        #expect(slots == [0, 1])
+    }
+
+    /// Regression: states saved under the old 1-based default (slot 1) remain
+    /// readable after the switch to 0-based slots — slot 1 on disk is still slot 1.
+    @Test func prePRSlotOneStatesRemainReadableAtSlotOne() throws {
+        let (store, _) = makeStore()
+        let legacyData = Data([0xDE, 0xAD])
+        // Simulate a state written by the old 1-based UI (default slot 1).
+        try store.writeState(romId: 7, slot: 1, data: legacyData)
+        #expect(try store.readState(romId: 7, slot: 0) == nil, "slot 0 must be empty")
+        #expect(try store.readState(romId: 7, slot: 1) == legacyData, "legacy slot 1 must still be readable")
+    }
 }


### PR DESCRIPTION
PR #57 changed the in-game menu default from slot 1 to slot 0. Saves that existed before the switch (on-disk `1.dltastate`, or server states synced as `slot1.state` → local slot 1) were still there, but the menu opened on the empty slot 0 with Load disabled — making them effectively invisible.

Both `EmulatorMenuSheet` and `LibretroMenuSheet` now pick the most recently modified slot on init, falling back to 0 when no states exist. Two regression tests added to `LocalSaveStoreTests`.