### PR TITLE
feat(saves): battery save export + .srm support

### DIFF
--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveSheet.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveSheet.swift
@@ -53,6 +53,9 @@ struct SyncSaveSheet: View {
             } message: {
                 Text(viewModel.errorMessage ?? "")
             }
+            .sheet(item: $viewModel.exportItem, onDismiss: { viewModel.cleanupExportTemp() }) { item in
+                ShareSheet(activityItems: [item.url])
+            }
             .confirmationDialog(
                 "Already on Server",
                 isPresented: Binding(
@@ -101,7 +104,9 @@ struct SyncSaveSheet: View {
                         sizeBytes: save.fileSizeBytes,
                         isBusy: viewModel.downloadingSaveIds.contains(save.id),
                         actionIcon: "arrow.down.circle.fill",
-                        action: { viewModel.downloadServerSave(save) }
+                        action: { viewModel.downloadServerSave(save) },
+                        exportBusy: viewModel.exportingServerSaveIds.contains(save.id),
+                        onExport: { viewModel.exportServerSave(save) }
                     )
                 }
             }
@@ -138,7 +143,9 @@ struct SyncSaveSheet: View {
                         sizeBytes: nil,
                         isBusy: viewModel.isUploadingBattery,
                         actionIcon: "icloud.and.arrow.up",
-                        action: { viewModel.uploadLocalBattery() }
+                        action: { viewModel.uploadLocalBattery() },
+                        exportBusy: false,
+                        onExport: { viewModel.exportLocalBattery() }
                     )
                 }
             }
@@ -149,7 +156,11 @@ struct SyncSaveSheet: View {
 
     // MARK: - Row helper
 
-    private func syncRow(icon: String, tint: Color, label: String, date: Date?, sizeBytes: Int?, isBusy: Bool, actionIcon: String, action: @escaping () -> Void) -> some View {
+    private func syncRow(
+        icon: String, tint: Color, label: String, date: Date?, sizeBytes: Int?,
+        isBusy: Bool, actionIcon: String, action: @escaping () -> Void,
+        exportBusy: Bool = false, onExport: (() -> Void)? = nil
+    ) -> some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
                 .foregroundStyle(tint)
@@ -173,12 +184,26 @@ struct SyncSaveSheet: View {
             if isBusy {
                 ProgressView().scaleEffect(0.8)
             } else {
-                Button(action: action) {
-                    Image(systemName: actionIcon)
-                        .font(.title3)
-                        .foregroundStyle(.tint)
+                HStack(spacing: 4) {
+                    if let onExport {
+                        if exportBusy {
+                            ProgressView().scaleEffect(0.8)
+                        } else {
+                            Button(action: onExport) {
+                                Image(systemName: "square.and.arrow.up")
+                                    .font(.title3)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    Button(action: action) {
+                        Image(systemName: actionIcon)
+                            .font(.title3)
+                            .foregroundStyle(.tint)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
             }
         }
         .padding(.vertical, 2)

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveViewModel.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveViewModel.swift
@@ -19,6 +19,11 @@ final class SyncSaveViewModel {
     var errorMessage: String?
     var pendingUpload: PendingUpload?
 
+    // Export
+    var exportItem: ExportSaveItem?
+    var exportingServerSaveIds: Set<Int> = []
+    private var exportTempURL: URL?
+
     private let listSavesUseCase: PListServerSavesUseCase
     private let listStatesUseCase: PListServerStatesUseCase
     private let downloadSaveUseCase: PDownloadSaveUseCase
@@ -179,6 +184,64 @@ final class SyncSaveViewModel {
         }
     }
 
+    // MARK: - Export
+
+    /// Export local battery save via share sheet as .srm (RetroArch/libretro format).
+    /// .srm and .sav are identical raw SRAM images — only the extension differs.
+    func exportLocalBattery() {
+        guard let data = try? saveStore.readBattery(romId: rom.id), !data.isEmpty else {
+            errorMessage = "No local battery save found."
+            return
+        }
+        presentExport(data: data, baseName: rom.name)
+    }
+
+    /// Download a server battery save and export it via share sheet as .srm.
+    func exportServerSave(_ save: SaveSchema) {
+        guard !exportingServerSaveIds.contains(save.id) else { return }
+        if save.missingFromFs {
+            errorMessage = "File missing on server — upload it again."
+            return
+        }
+        exportingServerSaveIds.insert(save.id)
+        Task {
+            defer { exportingServerSaveIds.remove(save.id) }
+            do {
+                let data = try await downloadSaveUseCase.execute(id: save.id)
+                guard !data.isEmpty else { errorMessage = "Server returned empty file."; return }
+                presentExport(data: data, baseName: save.fileNameNoExt)
+            } catch {
+                errorMessage = "Export failed: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func cleanupExportTemp() {
+        if let url = exportTempURL {
+            try? FileManager.default.removeItem(at: url)
+            exportTempURL = nil
+        }
+        exportItem = nil
+    }
+
+    private func presentExport(data: Data, baseName: String) {
+        cleanupExportTemp()
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let safeName = baseName
+            .components(separatedBy: .init(charactersIn: "/\\:*?\"<>|"))
+            .joined(separator: "_")
+        let fileURL = tmpDir.appendingPathComponent("\(safeName).srm")
+        do {
+            try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+            try data.write(to: fileURL, options: .atomic)
+            exportTempURL = tmpDir
+            exportItem = ExportSaveItem(url: fileURL)
+        } catch {
+            errorMessage = "Could not prepare export: \(error.localizedDescription)"
+        }
+    }
+
     // MARK: - Helpers
 
     func slotFromFileName(_ name: String) -> Int? {
@@ -186,4 +249,11 @@ final class SyncSaveViewModel {
         guard stem.hasPrefix("slot") else { return nil }
         return Int(stem.dropFirst("slot".count))
     }
+}
+
+// MARK: - Export model
+
+struct ExportSaveItem: Identifiable {
+    let id = UUID()
+    let url: URL
 }


### PR DESCRIPTION
Adds a share-sheet export button for battery saves in the Sync Save sheet (local and server-side). Tap the share icon on any battery save row to export via iOS Files, AirDrop, etc.

The exported file uses the `.srm` extension (RetroArch/libretro format). `.srm` and `.sav` are identical raw SRAM images, so no conversion is needed — just a rename. Importing from a server that stores saves as `.srm` also works transparently.

Changed: `SyncSaveSheet.swift`, `SyncSaveViewModel.swift`