### PR TITLE
feat(ui): keep tab bar visible with scroll-minimize, fly cover into Downloads tab

### DIFF
--- a/romm/romm/UI/App/MainTabView.swift
+++ b/romm/romm/UI/App/MainTabView.swift
@@ -40,12 +40,35 @@ struct MainTabView: View {
                     LocalDeviceDetailView()
                 }
             }
+            .badge(DownloadQueueManager.shared.activeCount)
 
             Tab("Search", systemImage: "magnifyingglass", value: AppTab.search, role: .search) {
                 NavigationStack {
                     SearchView()
                 }
             }
+        }
+        .tabBarMinimizeOnScrollDown()
+        .overlay {
+            if let flight = appData.downloadFlight {
+                DownloadFlightOverlay(flight: flight) {
+                    appData.finishDownloadFlight(flight.id)
+                }
+                .id(flight.id)
+            }
+        }
+    }
+}
+
+private extension View {
+    /// Keeps the tab bar visible and lets it minimize (slide down) as the user
+    /// scrolls content down — the native iOS 26 behavior. No-op on older OSes.
+    @ViewBuilder
+    func tabBarMinimizeOnScrollDown() -> some View {
+        if #available(iOS 26.0, *) {
+            self.tabBarMinimizeBehavior(.onScrollDown)
+        } else {
+            self
         }
     }
 }

--- a/romm/romm/UI/Collection/CollectionDetailView.swift
+++ b/romm/romm/UI/Collection/CollectionDetailView.swift
@@ -118,7 +118,6 @@ struct CollectionDetailView: View {
                 }
             }
         }
-        .toolbar(.hidden, for: .tabBar)
         .task {
             // Guard: Only load if not already loaded or loading
             // This prevents unnecessary reloading when navigating back

--- a/romm/romm/UI/Platforms/PlatformDetailView.swift
+++ b/romm/romm/UI/Platforms/PlatformDetailView.swift
@@ -163,7 +163,6 @@ struct PlatformDetailView: View {
                 }
             }
         }
-        .toolbar(.hidden, for: .tabBar)
         .sheet(isPresented: $showingSortSheet) {
             let currentRoms = getCurrentRoms()
             let filterOptions = getAvailableFilterOptions(from: currentRoms)

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -11,7 +11,12 @@ import SafariServices
 struct RomDetailView: View {
     let rom: Rom
     @State private var viewModel = RomDetailViewModel()
-    
+
+    @EnvironmentObject private var appData: AppData
+    @State private var downloadButtonFrame: CGRect = .zero
+    /// Mirrors the native tab-bar minimize (which has no readable state): true
+    /// once the scroll view has moved down far enough that the bar collapses.
+    @State private var tabBarMinimized: Bool = false
     @Environment(\.dismiss) private var dismiss
     @State private var scrollOffset: CGFloat = 0
     @State private var showTitle: Bool = false
@@ -220,10 +225,14 @@ struct RomDetailView: View {
                 .ignoresSafeArea(edges: .top)
             }
             .coordinateSpace(name: CoordinateSpaces.scrollView)
+            .onScrollGeometryChange(for: Bool.self) { geo in
+                geo.contentOffset.y > 40
+            } action: { _, minimized in
+                tabBarMinimized = minimized
+            }
             .ignoresSafeArea(edges: .top)
             .navigationBarTitle(showTitle ? rom.name : "", displayMode: .inline)
             .navigationBarBackButtonHidden(false)
-            .toolbar(.hidden, for: .tabBar)
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
                 scrollOffset = value
                 // Show title when content view reaches navbar (around 300px up from original position)
@@ -372,6 +381,13 @@ struct RomDetailView: View {
             // Playing happens in the Downloads tab (ROMCardRow), not here.
             let downloadState = viewModel.downloadButtonState(forRomId: currentSelectedRom.id)
             Button(action: {
+                appData.launchDownloadFlight(
+                    coverURL: currentSelectedRom.urlCover,
+                    from: downloadButtonFrame,
+                    // No public API exposes the tab-bar's minimized state, so
+                    // derive it from the live scroll offset (see onScrollGeometryChange).
+                    tabBarMinimized: tabBarMinimized
+                )
                 viewModel.downloadROM(rom: currentSelectedRom)
             }) {
                 HStack(spacing: 8) {
@@ -421,6 +437,11 @@ struct RomDetailView: View {
                 }
             }())
             .accessibility(hint: Text(downloadState == .downloaded ? "Already downloaded to this device" : "Download this ROM to this device"))
+            .onGeometryChange(for: CGRect.self) { proxy in
+                proxy.frame(in: .global)
+            } action: { newFrame in
+                downloadButtonFrame = newFrame
+            }
 
             // Secondary actions: open the downloaded file in another app, or send it to a device.
             HStack(spacing: 12) {

--- a/romm/romm/UI/Shared/AppData.swift
+++ b/romm/romm/UI/Shared/AppData.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import CoreGraphics
 
 enum AppTab: Hashable {
     case home
@@ -14,6 +15,18 @@ enum AppTab: Hashable {
     case collections
     case downloads
     case search
+}
+
+/// A one-shot "cover flies into the Downloads tab" animation request.
+/// `start` is the source frame in global (screen) coordinates. `tabBarMinimized`
+/// is a snapshot of the tab-bar state at launch (there's no public API to query
+/// it, so the source derives it from its scroll position) — the cover flies to
+/// the collapsed pill in the leading corner when true, else to the Downloads icon.
+struct DownloadFlight: Identifiable, Equatable {
+    let id: UUID
+    let coverURL: String?
+    let start: CGRect
+    let tabBarMinimized: Bool
 }
 
 @MainActor
@@ -24,8 +37,26 @@ class AppData: ObservableObject {
     @Published var currentConfiguration: AppConfiguration?
     @Published var isLoading: Bool = false
     @Published var selectedTab: AppTab = .home
+    /// Active cover-fly-to-Downloads animation, or `nil` when idle.
+    @Published var downloadFlight: DownloadFlight?
 
     init() {}
+
+    /// Kick off the cover-fly animation from the given global source frame.
+    func launchDownloadFlight(coverURL: String?, from start: CGRect, tabBarMinimized: Bool) {
+        guard start != .zero else { return }
+        downloadFlight = DownloadFlight(
+            id: UUID(),
+            coverURL: coverURL,
+            start: start,
+            tabBarMinimized: tabBarMinimized
+        )
+    }
+
+    /// Clear the flight once its animation has landed.
+    func finishDownloadFlight(_ id: UUID) {
+        if downloadFlight?.id == id { downloadFlight = nil }
+    }
 
     // Update methods for AppViewModel to call
     func updateUser(_ user: User?) {

--- a/romm/romm/UI/Shared/DownloadFlightOverlay.swift
+++ b/romm/romm/UI/Shared/DownloadFlightOverlay.swift
@@ -1,0 +1,140 @@
+//
+//  DownloadFlightOverlay.swift
+//  romm
+//
+//  Cosmetic feedback for "download queued": a ROM cover thumbnail flies in a
+//  downward arc from the Download button toward the Downloads tab, shrinking and
+//  fading as it arrives so it dissolves into the tab icon. One-shot, then the
+//  overlay removes itself. Purely visual, non-interactive.
+//
+
+import SwiftUI
+import UIKit
+
+struct DownloadFlightOverlay: View {
+    let flight: DownloadFlight
+    let onFinished: () -> Void
+
+    private let duration: TimeInterval = 0.6
+
+    /// Drives the whole flight (0 → 1). Animated once on appear; it holds at 1
+    /// (fully transparent) afterwards — no reset, so nothing re-appears.
+    @State private var t: CGFloat = 0
+    /// Removes the cover from the tree the instant the animation lands, so a
+    /// late image decode or re-render can never flash it back in.
+    @State private var finished = false
+
+    var body: some View {
+        GeometryReader { geo in
+            let start = CGPoint(x: flight.start.midX, y: flight.start.midY)
+            let end = landingPoint(screen: geo.size)
+
+            if !finished {
+                CachedKFImage(urlString: flight.coverURL) { image in
+                    image.resizable().aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color.accentColor)
+                        .overlay(
+                            Image(systemName: "arrow.down.circle.fill")
+                                .foregroundStyle(.white)
+                        )
+                }
+                .frame(width: 64, height: 86)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(.white.opacity(0.25), lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.35), radius: 10, y: 4)
+                .modifier(FlightEffect(t: t, start: start, end: end))
+                .onAppear {
+                    withAnimation(.easeInOut(duration: duration)) {
+                        t = 1
+                    } completion: {
+                        finished = true
+                        onFinished()
+                    }
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .ignoresSafeArea()
+    }
+
+    /// Where the cover should land. Vertical position comes from the live
+    /// tab-bar frame when available (accurate for both states); horizontal
+    /// position follows the snapshotted tab-bar state: minimized → the collapsed
+    /// pill in the leading corner, expanded → the Downloads icon (right of center).
+    private func landingPoint(screen: CGSize) -> CGPoint {
+        let y = tabBarFrame?.midY ?? (screen.height - bottomSafeInset - 22)
+        let leadingInset = keyWindow?.safeAreaInsets.left ?? 0
+        let x = flight.tabBarMinimized
+            ? leadingInset + 46          // collapsed pill sits in the leading corner
+            : screen.width * 0.62        // Downloads icon slot in the expanded bar
+        return CGPoint(x: x, y: y)
+    }
+
+    /// The active window's tab bar frame in window (global) coordinates, if any.
+    private var tabBarFrame: CGRect? {
+        guard let window = keyWindow,
+              let bar = Self.findTabBar(in: window) else { return nil }
+        return (bar.superview ?? window).convert(bar.frame, to: window)
+    }
+
+    private static func findTabBar(in view: UIView) -> UITabBar? {
+        if let bar = view as? UITabBar { return bar }
+        for sub in view.subviews {
+            if let found = findTabBar(in: sub) { return found }
+        }
+        return nil
+    }
+
+    private var keyWindow: UIWindow? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+
+    /// Bottom safe-area inset of the active window (fallback tab-bar band).
+    private var bottomSafeInset: CGFloat {
+        keyWindow?.safeAreaInsets.bottom ?? 0
+    }
+}
+
+/// Animatable modifier so position (along a bezier arc), scale, and opacity are
+/// all resampled every frame from a single progress value `t`.
+private struct FlightEffect: ViewModifier, Animatable {
+    var t: CGFloat
+    let start: CGPoint
+    let end: CGPoint
+
+    var animatableData: CGFloat {
+        get { t }
+        set { t = newValue }
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(1.0 - 0.85 * t)
+            .opacity(opacity)
+            .position(position)
+    }
+
+    /// Quadratic bezier with a control point lifted above the travel line so the
+    /// cover arcs up before dropping toward the tab bar.
+    private var position: CGPoint {
+        let control = CGPoint(x: (start.x + end.x) / 2, y: min(start.y, end.y) - 140)
+        let mt = 1 - t
+        return CGPoint(
+            x: mt * mt * start.x + 2 * mt * t * control.x + t * t * end.x,
+            y: mt * mt * start.y + 2 * mt * t * control.y + t * t * end.y
+        )
+    }
+
+    /// Opaque during the flight, easing to fully transparent as it arrives.
+    private var opacity: Double {
+        t <= 0.55 ? 1 : Double(max(0, 1 - (t - 0.55) / 0.45))
+    }
+}


### PR DESCRIPTION
Tab bar now minimizes on scroll-down (iOS 26) instead of being hidden on detail/list screens. Downloading a ROM animates its cover into the Downloads tab, with the target adapting to the collapsed pill when the bar is scrolled. Downloads tab gets an active-download count badge.

Cherry-pick of ace4011 onto current main.