### PR TITLE
Downloads: clearer unavailable state and last-sync badge

### DIFF
--- a/romm/romm/Data/Services/CloudSaveSyncSettings.swift
+++ b/romm/romm/Data/Services/CloudSaveSyncSettings.swift
@@ -1,11 +1,26 @@
 import Foundation
 
+/// How a sync was triggered: automatically by the app (on launch / after a
+/// local save) or manually by the user via the sync sheet.
+enum SyncTrigger: String {
+    case automatic
+    case manual
+}
+
+/// Lightweight record of the most recent sync for a single ROM.
+struct SyncMetadata: Equatable {
+    let date: Date
+    let trigger: SyncTrigger
+}
+
 final class CloudSaveSyncSettings: ObservableObject {
     static let shared = CloudSaveSyncSettings()
 
     private let userDefaults = UserDefaults.standard
     private enum Keys {
         static let enabled = "cloud_save_sync_enabled"
+        static let lastSyncDatePrefix = "cloud_save_sync_last_date_"
+        static let lastSyncTriggerPrefix = "cloud_save_sync_last_trigger_"
     }
 
     @Published var isEnabled: Bool {
@@ -14,5 +29,24 @@ final class CloudSaveSyncSettings: ObservableObject {
 
     private init() {
         self.isEnabled = userDefaults.bool(forKey: Keys.enabled)
+    }
+
+    // MARK: - Per-ROM sync metadata
+
+    /// Persists the most recent sync for a ROM so the UI can show when and how
+    /// it last happened. Called both by the automatic session sync and the
+    /// manual sync sheet.
+    func recordSync(romId: Int, trigger: SyncTrigger, date: Date = Date()) {
+        userDefaults.set(date.timeIntervalSince1970, forKey: Keys.lastSyncDatePrefix + "\(romId)")
+        userDefaults.set(trigger.rawValue, forKey: Keys.lastSyncTriggerPrefix + "\(romId)")
+    }
+
+    func lastSync(romId: Int) -> SyncMetadata? {
+        let dateKey = Keys.lastSyncDatePrefix + "\(romId)"
+        guard userDefaults.object(forKey: dateKey) != nil else { return nil }
+        let timestamp = userDefaults.double(forKey: dateKey)
+        guard timestamp > 0 else { return nil }
+        let trigger = SyncTrigger(rawValue: userDefaults.string(forKey: Keys.lastSyncTriggerPrefix + "\(romId)") ?? "") ?? .automatic
+        return SyncMetadata(date: Date(timeIntervalSince1970: timestamp), trigger: trigger)
     }
 }

--- a/romm/romm/Data/Services/CloudSaveSyncSettings.swift
+++ b/romm/romm/Data/Services/CloudSaveSyncSettings.swift
@@ -1,18 +1,5 @@
 import Foundation
 
-/// How a sync was triggered: automatically by the app (on launch / after a
-/// local save) or manually by the user via the sync sheet.
-enum SyncTrigger: String {
-    case automatic
-    case manual
-}
-
-/// Lightweight record of the most recent sync for a single ROM.
-struct SyncMetadata: Equatable {
-    let date: Date
-    let trigger: SyncTrigger
-}
-
 final class CloudSaveSyncSettings: ObservableObject {
     static let shared = CloudSaveSyncSettings()
 

--- a/romm/romm/Data/Services/CloudSaveSyncSettings.swift
+++ b/romm/romm/Data/Services/CloudSaveSyncSettings.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class CloudSaveSyncSettings: ObservableObject {
+final class CloudSaveSyncSettings: ObservableObject, PCloudSaveSyncStore {
     static let shared = CloudSaveSyncSettings()
 
     private let userDefaults = UserDefaults.standard

--- a/romm/romm/Domain/Models/SyncMetadata.swift
+++ b/romm/romm/Domain/Models/SyncMetadata.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// How a sync was triggered: automatically by the app (on launch / after a
+/// local save) or manually by the user via the sync sheet.
+enum SyncTrigger: String {
+    case automatic
+    case manual
+}
+
+/// Lightweight record of the most recent sync for a single ROM.
+struct SyncMetadata: Equatable {
+    let date: Date
+    let trigger: SyncTrigger
+}

--- a/romm/romm/Domain/RepositoryProtocols/PCloudSaveSyncStore.swift
+++ b/romm/romm/Domain/RepositoryProtocols/PCloudSaveSyncStore.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol PCloudSaveSyncStore {
+    func recordSync(romId: Int, trigger: SyncTrigger, date: Date)
+    func lastSync(romId: Int) -> SyncMetadata?
+}

--- a/romm/romm/Domain/UseCases/Saves/SyncMetadataUseCases.swift
+++ b/romm/romm/Domain/UseCases/Saves/SyncMetadataUseCases.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+protocol PRecordSyncUseCase {
+    func execute(romId: Int, trigger: SyncTrigger)
+}
+
+protocol PGetLastSyncUseCase {
+    func execute(romId: Int) -> SyncMetadata?
+}
+
+final class RecordSyncUseCase: PRecordSyncUseCase {
+    private let store: PCloudSaveSyncStore
+    init(store: PCloudSaveSyncStore) { self.store = store }
+    func execute(romId: Int, trigger: SyncTrigger) {
+        store.recordSync(romId: romId, trigger: trigger, date: Date())
+    }
+}
+
+final class GetLastSyncUseCase: PGetLastSyncUseCase {
+    private let store: PCloudSaveSyncStore
+    init(store: PCloudSaveSyncStore) { self.store = store }
+    func execute(romId: Int) -> SyncMetadata? {
+        store.lastSync(romId: romId)
+    }
+}

--- a/romm/romm/Extensions/Date+RelativeFormatting.swift
+++ b/romm/romm/Extensions/Date+RelativeFormatting.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Date {
+    /// Returns a short relative string (e.g. "2 min. ago") using
+    /// `RelativeDateTimeFormatter` with abbreviated units style.
+    func relativeAbbreviated() -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: self, relativeTo: Date())
+    }
+}

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -95,6 +95,8 @@ protocol PDependencyFactory {
     func makeUpdateSaveUseCase() -> PUpdateSaveUseCase
     func makeUploadStateUseCase() -> PUploadStateUseCase
     func makeUpdateStateUseCase() -> PUpdateStateUseCase
+    func makeRecordSyncUseCase() -> PRecordSyncUseCase
+    func makeGetLastSyncUseCase() -> PGetLastSyncUseCase
 
     // Local ROM Use Cases
     func makeGetROMShareFilesUseCase() -> PGetROMShareFilesUseCase
@@ -396,6 +398,7 @@ class DefaultDependencyFactory: PDependencyFactory {
     }
 
     lazy var saveStore: PSaveStore = LocalSaveStoreRepository()
+    lazy var cloudSaveSyncStore: PCloudSaveSyncStore = CloudSaveSyncSettings.shared
     lazy var savesRepository: PSavesRepository = SavesRepository()
     lazy var statesRepository: PStatesRepository = StatesRepository()
     lazy var fileSystemService: PFileSystemService = DefaultFileSystemService()
@@ -466,6 +469,14 @@ class DefaultDependencyFactory: PDependencyFactory {
         UpdateStateUseCase(repository: statesRepository)
     }
 
+    func makeRecordSyncUseCase() -> PRecordSyncUseCase {
+        RecordSyncUseCase(store: cloudSaveSyncStore)
+    }
+
+    func makeGetLastSyncUseCase() -> PGetLastSyncUseCase {
+        GetLastSyncUseCase(store: cloudSaveSyncStore)
+    }
+
     // MARK: - Local ROM Use Cases
 
     func makeGetROMShareFilesUseCase() -> PGetROMShareFilesUseCase {
@@ -485,7 +496,9 @@ class DefaultDependencyFactory: PDependencyFactory {
             updateSaveUseCase: makeUpdateSaveUseCase(),
             uploadStateUseCase: makeUploadStateUseCase(),
             updateStateUseCase: makeUpdateStateUseCase(),
-            saveStore: saveStore
+            saveStore: saveStore,
+            recordSyncUseCase: makeRecordSyncUseCase(),
+            getLastSyncUseCase: makeGetLastSyncUseCase()
         )
     }
 

--- a/romm/romm/UI/DI/MockDependencyFactory.swift
+++ b/romm/romm/UI/DI/MockDependencyFactory.swift
@@ -321,6 +321,7 @@ class MockDependencyFactory: PDependencyFactory {
     }
 
     lazy var saveStore: PSaveStore = LocalSaveStoreRepository()
+    lazy var cloudSaveSyncStore: PCloudSaveSyncStore = CloudSaveSyncSettings.shared
 
     func makeGetDownloadedROMUseCase() -> PGetDownloadedROMUseCase {
         GetDownloadedROMUseCase(localROMRepository: localROMRepository)
@@ -381,6 +382,8 @@ class MockDependencyFactory: PDependencyFactory {
     func makeUpdateSaveUseCase() -> PUpdateSaveUseCase { UpdateSaveUseCase(repository: savesRepository) }
     func makeUploadStateUseCase() -> PUploadStateUseCase { UploadStateUseCase(repository: statesRepository) }
     func makeUpdateStateUseCase() -> PUpdateStateUseCase { UpdateStateUseCase(repository: statesRepository) }
+    func makeRecordSyncUseCase() -> PRecordSyncUseCase { RecordSyncUseCase(store: cloudSaveSyncStore) }
+    func makeGetLastSyncUseCase() -> PGetLastSyncUseCase { GetLastSyncUseCase(store: cloudSaveSyncStore) }
 
     func makeGetROMShareFilesUseCase() -> PGetROMShareFilesUseCase {
         GetROMShareFilesUseCase(localROMRepository: localROMRepository)
@@ -397,7 +400,9 @@ class MockDependencyFactory: PDependencyFactory {
             updateSaveUseCase: makeUpdateSaveUseCase(),
             uploadStateUseCase: makeUploadStateUseCase(),
             updateStateUseCase: makeUpdateStateUseCase(),
-            saveStore: saveStore
+            saveStore: saveStore,
+            recordSyncUseCase: makeRecordSyncUseCase(),
+            getLastSyncUseCase: makeGetLastSyncUseCase()
         )
     }
 

--- a/romm/romm/UI/Devices/LocalDevice/LocalDeviceDetailViewModel.swift
+++ b/romm/romm/UI/Devices/LocalDevice/LocalDeviceDetailViewModel.swift
@@ -15,10 +15,12 @@ class LocalDeviceDetailViewModel {
 
     private let repository: PLocalROMRepository
     private let getPlatformsUseCase: GetPlatformsUseCase
+    private let getLastSyncUseCase: PGetLastSyncUseCase
 
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
         self.repository = factory.localROMRepository
         self.getPlatformsUseCase = factory.makeGetPlatformsUseCase()
+        self.getLastSyncUseCase = factory.makeGetLastSyncUseCase()
     }
 
     func displayName(forPlatformName platformName: String) -> String {
@@ -139,6 +141,6 @@ class LocalDeviceDetailViewModel {
     // MARK: - Sync metadata
 
     func lastSync(romId: Int) -> SyncMetadata? {
-        CloudSaveSyncSettings.shared.lastSync(romId: romId)
+        getLastSyncUseCase.execute(romId: romId)
     }
 }

--- a/romm/romm/UI/Devices/LocalDevice/LocalDeviceDetailViewModel.swift
+++ b/romm/romm/UI/Devices/LocalDevice/LocalDeviceDetailViewModel.swift
@@ -135,4 +135,10 @@ class LocalDeviceDetailViewModel {
     var hasDownloadedROMs: Bool {
         !downloadedROMs.isEmpty
     }
+
+    // MARK: - Sync metadata
+
+    func lastSync(romId: Int) -> SyncMetadata? {
+        CloudSaveSyncSettings.shared.lastSync(romId: romId)
+    }
 }

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
@@ -47,6 +47,7 @@ struct PlatformROMsListView: View {
                     isDisabled: launchingRomId != nil && launchingRomId != rom.id,
                     hasSaveGame: hasSaveGame(romId: rom.id),
                     hasSaveState: hasSaveState(romId: rom.id),
+                    lastSync: CloudSaveSyncSettings.shared.lastSync(romId: rom.id),
                     onPlay: {
                         guard isPlatformSupported(rom.platformSlug), launchingRomId == nil else { return }
                         if hasSaveState(romId: rom.id) {

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
@@ -47,7 +47,7 @@ struct PlatformROMsListView: View {
                     isDisabled: launchingRomId != nil && launchingRomId != rom.id,
                     hasSaveGame: hasSaveGame(romId: rom.id),
                     hasSaveState: hasSaveState(romId: rom.id),
-                    lastSync: CloudSaveSyncSettings.shared.lastSync(romId: rom.id),
+                    lastSync: viewModel.lastSync(romId: rom.id),
                     onPlay: {
                         guard isPlatformSupported(rom.platformSlug), launchingRomId == nil else { return }
                         if hasSaveState(romId: rom.id) {

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ROMCardRow.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ROMCardRow.swift
@@ -7,6 +7,7 @@ struct ROMCardRow: View {
     let isDisabled: Bool
     let hasSaveGame: Bool
     let hasSaveState: Bool
+    let lastSync: SyncMetadata?
     let onPlay: () -> Void
     let onSync: () -> Void
     let onDetails: () -> Void
@@ -61,6 +62,10 @@ struct ROMCardRow: View {
                                 SaveBadge(icon: "bookmark.fill", title: "Save state", tint: .purple)
                             }
                         }
+                    }
+
+                    if let lastSync {
+                        SyncStatusLine(meta: lastSync)
                     }
                 }
 
@@ -129,6 +134,35 @@ struct ROMCardRow: View {
         }
         .padding(.vertical, 4)
         .opacity(isLaunching ? 0.7 : 1)
+    }
+}
+
+struct SyncStatusLine: View {
+    let meta: SyncMetadata
+
+    private var tint: Color { meta.trigger == .automatic ? .green : .orange }
+
+    private var relative: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: meta.date, relativeTo: Date())
+    }
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.caption2)
+            Text("Synced \(relative)")
+                .font(.caption2)
+            Text(meta.trigger == .automatic ? "Auto" : "Manual")
+                .font(.caption2.weight(.semibold))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(Capsule().fill(tint.opacity(0.15)))
+                .foregroundColor(tint)
+        }
+        .foregroundColor(.secondary)
+        .lineLimit(1)
     }
 }
 

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ROMCardRow.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ROMCardRow.swift
@@ -142,11 +142,7 @@ struct SyncStatusLine: View {
 
     private var tint: Color { meta.trigger == .automatic ? .green : .orange }
 
-    private var relative: String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: meta.date, relativeTo: Date())
-    }
+    private var relative: String { meta.date.relativeAbbreviated() }
 
     var body: some View {
         HStack(spacing: 5) {

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ROMCardRow.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ROMCardRow.swift
@@ -80,7 +80,7 @@ struct ROMCardRow: View {
                     .frame(maxWidth: .infinity, minHeight: 36)
                     .background(Color.green.opacity(0.85))
                     .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                } else {
+                } else if isPlayable {
                     CardActionButton(
                         title: "Play",
                         systemImage: "play.fill",
@@ -88,8 +88,18 @@ struct ROMCardRow: View {
                         filled: true,
                         action: onPlay
                     )
-                    .disabled(!isPlayable || isDisabled)
-                    .opacity((!isPlayable || isDisabled) ? 0.5 : 1)
+                    .disabled(isDisabled)
+                    .opacity(isDisabled ? 0.5 : 1)
+                } else {
+                    // Platform has no on-device core — show a distinct, calm
+                    // "unavailable" state instead of a greyed-out Play button so
+                    // it reads as an intentional limitation, not a broken button.
+                    CardActionLabel(
+                        title: "Not playable",
+                        systemImage: "play.slash.fill",
+                        tint: Color(.tertiaryLabel)
+                    )
+                    .accessibilityLabel("Not playable on this device")
                 }
 
                 Button(action: onDetails) {
@@ -104,6 +114,17 @@ struct ROMCardRow: View {
                     filled: false,
                     action: onSync
                 )
+            }
+
+            if !isPlayable {
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "info.circle")
+                        .font(.caption)
+                    Text("This system can't be emulated on your device yet, so it can't be played here. You can still sync saves and view details.")
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .foregroundColor(.secondary)
             }
         }
         .padding(.vertical, 4)

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveSheet.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveSheet.swift
@@ -32,6 +32,9 @@ struct SyncSaveSheet: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     List {
+                        if let meta = viewModel.lastSyncMeta {
+                            syncStatusHeader(meta)
+                        }
                         serverSection
                         localSection
                     }
@@ -72,6 +75,32 @@ struct SyncSaveSheet: View {
     }
 
     // MARK: - Sections
+
+    @ViewBuilder
+    private func syncStatusHeader(_ meta: SyncMetadata) -> some View {
+        Section {
+            HStack(spacing: 12) {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.title3)
+                    .foregroundStyle(meta.trigger == .automatic ? .green : .orange)
+                    .frame(width: 24)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Last synced \(SyncSaveSheet.relativeString(meta.date))")
+                        .font(.subheadline.weight(.semibold))
+                    Text(meta.trigger == .automatic ? "Automatic, on launch or save" : "Manual sync")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    static func relativeString(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
 
     @ViewBuilder
     private var serverSection: some View {

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveSheet.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveSheet.swift
@@ -85,7 +85,7 @@ struct SyncSaveSheet: View {
                     .foregroundStyle(meta.trigger == .automatic ? .green : .orange)
                     .frame(width: 24)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Last synced \(SyncSaveSheet.relativeString(meta.date))")
+                    Text("Last synced \(meta.date.relativeAbbreviated())")
                         .font(.subheadline.weight(.semibold))
                     Text(meta.trigger == .automatic ? "Automatic, on launch or save" : "Manual sync")
                         .font(.caption)
@@ -94,12 +94,6 @@ struct SyncSaveSheet: View {
             }
             .padding(.vertical, 2)
         }
-    }
-
-    static func relativeString(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
     }
 
     @ViewBuilder

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveViewModel.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveViewModel.swift
@@ -18,6 +18,9 @@ final class SyncSaveViewModel {
     var isUploadingBattery = false
     var errorMessage: String?
     var pendingUpload: PendingUpload?
+    var lastSyncMeta: SyncMetadata?
+
+    private let syncSettings = CloudSaveSyncSettings.shared
 
     private let listSavesUseCase: PListServerSavesUseCase
     private let listStatesUseCase: PListServerStatesUseCase
@@ -70,6 +73,12 @@ final class SyncSaveViewModel {
         localStates = (try? saveStore.listStates(romId: rom.id)) ?? []
         localBatteryDate = saveStore.batteryModifiedAt(romId: rom.id)
         hasLocalBattery = localBatteryDate != nil
+        lastSyncMeta = syncSettings.lastSync(romId: rom.id)
+    }
+
+    private func recordManualSync() {
+        syncSettings.recordSync(romId: rom.id, trigger: .manual)
+        lastSyncMeta = syncSettings.lastSync(romId: rom.id)
     }
 
     // MARK: - Download
@@ -89,6 +98,7 @@ final class SyncSaveViewModel {
                 let slot = slotFromFileName(state.fileName) ?? 0
                 try saveStore.writeState(romId: rom.id, slot: slot, data: data)
                 localStates = (try? saveStore.listStates(romId: rom.id)) ?? []
+                recordManualSync()
             } catch {
                 errorMessage = "Download failed: \(error.localizedDescription)"
             }
@@ -109,6 +119,7 @@ final class SyncSaveViewModel {
                 guard !data.isEmpty else { errorMessage = "Server returned empty file."; return }
                 try saveStore.writeBattery(romId: rom.id, data: data)
                 hasLocalBattery = true
+                recordManualSync()
             } catch {
                 errorMessage = "Download failed: \(error.localizedDescription)"
             }
@@ -154,6 +165,7 @@ final class SyncSaveViewModel {
                         let uploaded = try await uploadStateUseCase.execute(romId: rom.id, emulator: nil, fileName: fileName, fileData: data, screenshotData: thumbnail)
                         serverStates.append(uploaded)
                     }
+                    recordManualSync()
                 } catch {
                     errorMessage = "Upload failed: \(error.localizedDescription)"
                 }
@@ -172,6 +184,7 @@ final class SyncSaveViewModel {
                         let uploaded = try await uploadSaveUseCase.execute(romId: rom.id, emulator: nil, slot: nil, fileName: fileName, fileData: data, screenshotData: nil)
                         serverSaves.append(uploaded)
                     }
+                    recordManualSync()
                 } catch {
                     errorMessage = "Upload failed: \(error.localizedDescription)"
                 }

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveViewModel.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveViewModel.swift
@@ -20,7 +20,8 @@ final class SyncSaveViewModel {
     var pendingUpload: PendingUpload?
     var lastSyncMeta: SyncMetadata?
 
-    private let syncSettings = CloudSaveSyncSettings.shared
+    private let recordSyncUseCase: PRecordSyncUseCase
+    private let getLastSyncUseCase: PGetLastSyncUseCase
 
     private let listSavesUseCase: PListServerSavesUseCase
     private let listStatesUseCase: PListServerStatesUseCase
@@ -42,7 +43,9 @@ final class SyncSaveViewModel {
         updateSaveUseCase: PUpdateSaveUseCase,
         uploadStateUseCase: PUploadStateUseCase,
         updateStateUseCase: PUpdateStateUseCase,
-        saveStore: PSaveStore
+        saveStore: PSaveStore,
+        recordSyncUseCase: PRecordSyncUseCase,
+        getLastSyncUseCase: PGetLastSyncUseCase
     ) {
         self.rom = rom
         self.listSavesUseCase = listSavesUseCase
@@ -54,6 +57,8 @@ final class SyncSaveViewModel {
         self.uploadStateUseCase = uploadStateUseCase
         self.updateStateUseCase = updateStateUseCase
         self.saveStore = saveStore
+        self.recordSyncUseCase = recordSyncUseCase
+        self.getLastSyncUseCase = getLastSyncUseCase
     }
 
     // MARK: - Load
@@ -73,13 +78,12 @@ final class SyncSaveViewModel {
         localStates = (try? saveStore.listStates(romId: rom.id)) ?? []
         localBatteryDate = saveStore.batteryModifiedAt(romId: rom.id)
         hasLocalBattery = localBatteryDate != nil
-        lastSyncMeta = syncSettings.lastSync(romId: rom.id)
+        lastSyncMeta = getLastSyncUseCase.execute(romId: rom.id)
     }
 
     private func recordManualSync() {
-        let now = Date()
-        syncSettings.recordSync(romId: rom.id, trigger: .manual, date: now)
-        lastSyncMeta = SyncMetadata(date: now, trigger: .manual)
+        recordSyncUseCase.execute(romId: rom.id, trigger: .manual)
+        lastSyncMeta = SyncMetadata(date: Date(), trigger: .manual)
     }
 
     // MARK: - Download

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveViewModel.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/SyncSaveViewModel.swift
@@ -77,8 +77,9 @@ final class SyncSaveViewModel {
     }
 
     private func recordManualSync() {
-        syncSettings.recordSync(romId: rom.id, trigger: .manual)
-        lastSyncMeta = syncSettings.lastSync(romId: rom.id)
+        let now = Date()
+        syncSettings.recordSync(romId: rom.id, trigger: .manual, date: now)
+        lastSyncMeta = SyncMetadata(date: now, trigger: .manual)
     }
 
     // MARK: - Download

--- a/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
+++ b/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
@@ -28,6 +28,7 @@ final class CloudSaveSyncService {
     private let updateStateUseCase: PUpdateStateUseCase
     private let downloadStateUseCase: PDownloadStateUseCase
     private let settings: CloudSaveSyncSettings
+    private let recordSyncUseCase: PRecordSyncUseCase
 
     private var serverBatteryId: Int?
     private var serverStateIdBySlot: [Int: Int] = [:]
@@ -43,7 +44,8 @@ final class CloudSaveSyncService {
         uploadStateUseCase: PUploadStateUseCase,
         updateStateUseCase: PUpdateStateUseCase,
         downloadStateUseCase: PDownloadStateUseCase,
-        settings: CloudSaveSyncSettings = .shared
+        settings: CloudSaveSyncSettings = .shared,
+        recordSyncUseCase: PRecordSyncUseCase? = nil
     ) {
         self.config = config
         self.saveStore = saveStore
@@ -56,6 +58,7 @@ final class CloudSaveSyncService {
         self.updateStateUseCase = updateStateUseCase
         self.downloadStateUseCase = downloadStateUseCase
         self.settings = settings
+        self.recordSyncUseCase = recordSyncUseCase ?? RecordSyncUseCase(store: settings)
     }
 
     var isEnabled: Bool { settings.isEnabled }
@@ -69,7 +72,7 @@ final class CloudSaveSyncService {
         guard isEnabled else { return }
         await pullBattery()
         await pullStates()
-        settings.recordSync(romId: config.romId, trigger: .automatic)
+        recordSyncUseCase.execute(romId: config.romId, trigger: .automatic)
     }
 
     private func pullBattery() async {
@@ -222,7 +225,7 @@ final class CloudSaveSyncService {
 
     private func recordBatteryId(_ id: Int) { serverBatteryId = id }
     private func recordStateId(slot: Int, id: Int) { serverStateIdBySlot[slot] = id }
-    private func recordAutoSync() { settings.recordSync(romId: config.romId, trigger: .automatic) }
+    private func recordAutoSync() { recordSyncUseCase.execute(romId: config.romId, trigger: .automatic) }
 
     // MARK: - Filename helpers
 

--- a/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
+++ b/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
@@ -69,6 +69,7 @@ final class CloudSaveSyncService {
         guard isEnabled else { return }
         await pullBattery()
         await pullStates()
+        settings.recordSync(romId: config.romId, trigger: .automatic)
     }
 
     private func pullBattery() async {
@@ -177,6 +178,7 @@ final class CloudSaveSyncService {
                     )
                 }
                 await self.recordBatteryId(result.id)
+                await self.recordAutoSync()
                 print("[CloudSync] battery pushed id=\(result.id)")
             } catch {
                 print("[CloudSync] battery push failed: \(error.localizedDescription)")
@@ -210,6 +212,7 @@ final class CloudSaveSyncService {
                     )
                 }
                 await self.recordStateId(slot: slot, id: result.id)
+                await self.recordAutoSync()
                 print("[CloudSync] state slot \(slot) pushed id=\(result.id)")
             } catch {
                 print("[CloudSync] state slot \(slot) push failed: \(error.localizedDescription)")
@@ -219,6 +222,7 @@ final class CloudSaveSyncService {
 
     private func recordBatteryId(_ id: Int) { serverBatteryId = id }
     private func recordStateId(slot: Int, id: Int) { serverStateIdBySlot[slot] = id }
+    private func recordAutoSync() { settings.recordSync(romId: config.romId, trigger: .automatic) }
 
     // MARK: - Filename helpers
 

--- a/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
+++ b/romm/romm/UI/Emulator/CloudSync/CloudSaveSyncService.swift
@@ -29,6 +29,7 @@ final class CloudSaveSyncService {
     private let downloadStateUseCase: PDownloadStateUseCase
     private let settings: CloudSaveSyncSettings
     private let recordSyncUseCase: PRecordSyncUseCase
+    private let logger = Logger.sync
 
     private var serverBatteryId: Int?
     private var serverStateIdBySlot: [Int: Int] = [:]
@@ -90,9 +91,9 @@ final class CloudSaveSyncService {
             // Preserve server mtime so subsequent local-vs-server compares are
             // not skewed by device clock drift after the write-to-disk timestamp.
             try? saveStore.setBatteryModifiedAt(romId: config.romId, date: match.updatedAt)
-            print("[CloudSync] battery pulled (\(data.count) bytes)")
+            logger.info("Battery pulled (\(data.count) bytes)")
         } catch {
-            print("[CloudSync] battery pull failed: \(error.localizedDescription)")
+            logger.error("Battery pull failed: \(error.localizedDescription)")
         }
     }
 
@@ -133,7 +134,7 @@ final class CloudSaveSyncService {
                 realSlots.insert(nextSlot)
             }
             if overflow > 0 {
-                print("[CloudSync] \(overflow) server state(s) skipped: no free slot (max \(maxSlot + 1))")
+                logger.warning("\(overflow) server state(s) skipped: no free slot (max \(maxSlot + 1))")
             }
 
             for s in states {
@@ -146,10 +147,10 @@ final class CloudSaveSyncService {
                 let data = try await downloadStateUseCase.execute(id: s.id)
                 try saveStore.writeState(romId: config.romId, slot: slot, data: data)
                 try? saveStore.setStateModifiedAt(romId: config.romId, slot: slot, date: s.updatedAt)
-                print("[CloudSync] state slot \(slot) pulled (\(data.count) bytes)")
+                logger.info("State slot \(slot) pulled (\(data.count) bytes)")
             }
         } catch {
-            print("[CloudSync] states pull failed: \(error.localizedDescription)")
+            logger.error("States pull failed: \(error.localizedDescription)")
         }
     }
 
@@ -182,9 +183,9 @@ final class CloudSaveSyncService {
                 }
                 await self.recordBatteryId(result.id)
                 await self.recordAutoSync()
-                print("[CloudSync] battery pushed id=\(result.id)")
+                logger.info("Battery pushed id=\(result.id)")
             } catch {
-                print("[CloudSync] battery push failed: \(error.localizedDescription)")
+                logger.error("Battery push failed: \(error.localizedDescription)")
             }
         }
     }
@@ -216,9 +217,9 @@ final class CloudSaveSyncService {
                 }
                 await self.recordStateId(slot: slot, id: result.id)
                 await self.recordAutoSync()
-                print("[CloudSync] state slot \(slot) pushed id=\(result.id)")
+                logger.info("State slot \(slot) pushed id=\(result.id)")
             } catch {
-                print("[CloudSync] state slot \(slot) push failed: \(error.localizedDescription)")
+                logger.error("State slot \(slot) push failed: \(error.localizedDescription)")
             }
         }
     }


### PR DESCRIPTION
ROM cards on unplayable platforms now show a distinct "Not playable" label with a short explanation instead of a dimmed Play button. Cards for any ROM also show when and how (auto/manual) the last sync happened, and the sync sheet surfaces the same info as a status header.

Backport of two commits from `feature/sync-meta-display`, cherry-picked onto main with no conflicts.