### PR TITLE
Controller input for the libretro emulator

### DIFF
--- a/romm/romm/Data/Preferences/UserDefaultsEmulatorMenuShortcutPreferenceStore.swift
+++ b/romm/romm/Data/Preferences/UserDefaultsEmulatorMenuShortcutPreferenceStore.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+final class UserDefaultsEmulatorMenuShortcutPreferenceStore: PEmulatorMenuShortcutPreference {
+    private let key = "emulator.menuShortcut.preference"
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    var current: EmulatorMenuShortcut {
+        get {
+            guard let raw = userDefaults.string(forKey: key),
+                  let shortcut = EmulatorMenuShortcut(rawValue: raw) else { return .none }
+            return shortcut
+        }
+        set {
+            userDefaults.set(newValue.rawValue, forKey: key)
+        }
+    }
+}

--- a/romm/romm/Domain/Models/EmulatorMenuShortcut.swift
+++ b/romm/romm/Domain/Models/EmulatorMenuShortcut.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Optional button combination that opens the in-game menu from a physical
+/// controller. Deliberately a small fixed set instead of a free remapper: the
+/// touch menu button stays available in every case, this is only a convenience
+/// for players whose gamepad case covers the screen.
+enum EmulatorMenuShortcut: String, CaseIterable, Codable, Sendable {
+    case none
+    case l3r3
+    case l1r1
+}
+
+/// User preference for the controller menu shortcut. `none` is the default so
+/// no gameplay button combination is claimed unless the user opts in.
+protocol PEmulatorMenuShortcutPreference: AnyObject {
+    var current: EmulatorMenuShortcut { get set }
+}

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -115,6 +115,7 @@ protocol PDependencyFactory {
     var enginePreference: PEmulatorEnginePreference { get }
     var libretroAspectRatioPreference: PLibretroAspectRatioPreference { get }
     var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference { get }
+    var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference { get }
     func makePlatformEngineSupport() -> PPlatformEngineSupport
 
     // SFTP ViewModels
@@ -383,6 +384,7 @@ class DefaultDependencyFactory: PDependencyFactory {
     lazy var enginePreference: PEmulatorEnginePreference = UserDefaultsEmulatorEnginePreferenceStore()
     lazy var libretroAspectRatioPreference: PLibretroAspectRatioPreference = UserDefaultsLibretroAspectRatioPreferenceStore()
     lazy var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference = UserDefaultsEmulatorScreenPositionPreferenceStore()
+    lazy var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference = UserDefaultsEmulatorMenuShortcutPreferenceStore()
 
     func makePlatformEngineSupport() -> PPlatformEngineSupport {
         PlatformEngineSupport()
@@ -522,6 +524,7 @@ class DefaultDependencyFactory: PDependencyFactory {
             biosSync: makeBIOSSyncUseCase(),
             aspectRatioPreference: libretroAspectRatioPreference,
             screenPositionPreference: emulatorScreenPositionPreference,
+            menuShortcutPreference: emulatorMenuShortcutPreference,
             factory: self
         )
     }

--- a/romm/romm/UI/DI/MockDependencyFactory.swift
+++ b/romm/romm/UI/DI/MockDependencyFactory.swift
@@ -34,6 +34,7 @@ class MockDependencyFactory: PDependencyFactory {
     lazy var enginePreference: PEmulatorEnginePreference = UserDefaultsEmulatorEnginePreferenceStore()
     lazy var libretroAspectRatioPreference: PLibretroAspectRatioPreference = InMemoryLibretroAspectRatioPreference()
     lazy var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference = InMemoryEmulatorScreenPositionPreference()
+    lazy var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference = UserDefaultsEmulatorMenuShortcutPreferenceStore()
     
     init(
         authRepository: PAuthRepository? = nil,
@@ -374,6 +375,7 @@ class MockDependencyFactory: PDependencyFactory {
             biosSync: makeBIOSSyncUseCase(),
             aspectRatioPreference: libretroAspectRatioPreference,
             screenPositionPreference: emulatorScreenPositionPreference,
+            menuShortcutPreference: emulatorMenuShortcutPreference,
             factory: self
         )
     }

--- a/romm/romm/UI/Emulator/Libretro/LibretroControllerInput.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroControllerInput.swift
@@ -9,14 +9,27 @@ import GameController
 /// is RETRO_DEVICE_ID_JOYPAD_B (index 0) and the right face button is
 /// RETRO_DEVICE_ID_JOYPAD_A (index 8), so physical A/B and X/Y are
 /// cross-mapped from the Xbox-style GCController naming to the SNES layout.
+///
+/// Writes go straight to `buttonState` from the handler, exactly like the touch
+/// path in LibretroTouchControllerView. The core reads that array from the
+/// emulation thread; that is a pre-existing, deliberate arrangement here and
+/// this class does not add synchronisation of its own.
 @MainActor
 final class LibretroControllerInput {
 
     private weak var frontend: LibretroFrontend?
+    private let menuShortcutPreference: PEmulatorMenuShortcutPreference?
     var onMenuRequested: (() -> Void)?
 
-    init(frontend: LibretroFrontend) {
+    /// Digital buttons currently held, used to detect the menu shortcut combo.
+    private var pressedButtons: Set<LibretroABI.JoypadButton> = []
+    /// Guards the combo so it fires once per press instead of on every event
+    /// while the buttons stay held.
+    private var comboLatched = false
+
+    init(frontend: LibretroFrontend, menuShortcutPreference: PEmulatorMenuShortcutPreference? = nil) {
         self.frontend = frontend
+        self.menuShortcutPreference = menuShortcutPreference
     }
 
     // MARK: - Connect / Disconnect
@@ -24,65 +37,103 @@ final class LibretroControllerInput {
     /// Installs value-changed handlers on the given controller's extended gamepad.
     /// Safe to call with nil (no-op) so callers don't need an extra guard.
     func attach(to controller: GCController?) {
-        guard let pad = controller?.extendedGamepad else { return }
+        guard let controller, let pad = controller.extendedGamepad else { return }
+
+        // Pin handler delivery to the main queue. This is GameController's
+        // default, but making it explicit is what lets the handlers below write
+        // buttonState synchronously without an actor hop.
+        controller.handlerQueue = .main
 
         // D-Pad
-        pad.dpad.up.valueChangedHandler    = { [weak self] _, _, pressed in self?.send(.up,     pressed: pressed) }
-        pad.dpad.down.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.down,   pressed: pressed) }
-        pad.dpad.left.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.left,   pressed: pressed) }
-        pad.dpad.right.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.right,  pressed: pressed) }
+        pad.dpad.up.valueChangedHandler    = handler(for: .up)
+        pad.dpad.down.valueChangedHandler  = handler(for: .down)
+        pad.dpad.left.valueChangedHandler  = handler(for: .left)
+        pad.dpad.right.valueChangedHandler = handler(for: .right)
 
         // Face buttons (SNES/libretro layout: bottom = B, right = A, left = Y, top = X)
         // GCController uses Xbox names: buttonA = bottom, buttonB = right,
         // buttonX = left, buttonY = top.
-        pad.buttonA.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.b, pressed: pressed) }
-        pad.buttonB.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.a, pressed: pressed) }
-        pad.buttonX.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.y, pressed: pressed) }
-        pad.buttonY.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.x, pressed: pressed) }
+        pad.buttonA.valueChangedHandler = handler(for: .b)
+        pad.buttonB.valueChangedHandler = handler(for: .a)
+        pad.buttonX.valueChangedHandler = handler(for: .y)
+        pad.buttonY.valueChangedHandler = handler(for: .x)
 
         // Shoulders
-        pad.leftShoulder.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.l,  pressed: pressed) }
-        pad.rightShoulder.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.r,  pressed: pressed) }
+        pad.leftShoulder.valueChangedHandler  = handler(for: .l)
+        pad.rightShoulder.valueChangedHandler = handler(for: .r)
 
-        // Triggers — treated as digital buttons, value ignored.
-        pad.leftTrigger.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.l2, pressed: pressed) }
-        pad.rightTrigger.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.r2, pressed: pressed) }
+        // Triggers, treated as digital buttons, analog value ignored.
+        pad.leftTrigger.valueChangedHandler  = handler(for: .l2)
+        pad.rightTrigger.valueChangedHandler = handler(for: .r2)
 
-        // Thumbstick clicks (optional on some gamepads, hence pressedChangedHandler)
-        pad.leftThumbstickButton?.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.l3, pressed: pressed) }
-        pad.rightThumbstickButton?.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.r3, pressed: pressed) }
+        // Thumbstick clicks are absent on some gamepads, hence the optional chain.
+        pad.leftThumbstickButton?.valueChangedHandler  = handler(for: .l3)
+        pad.rightThumbstickButton?.valueChangedHandler = handler(for: .r3)
 
-        // Start / Select
-        // buttonMenu is always present; buttonOptions is absent on some controllers
-        // (e.g. Apple TV Remote) so we fall back to nil-safe access.
-        pad.buttonMenu.pressedChangedHandler = { [weak self] _, _, pressed in
-            guard pressed else { return }
-            // Menu button opens the in-game overlay instead of sending Start
-            // to the core, consistent with the native Delta path.
-            Task { @MainActor [weak self] in self?.onMenuRequested?() }
-        }
-        pad.buttonOptions?.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.select, pressed: pressed) }
-
-        // buttonHome is not part of GCExtendedGamepad and cannot be captured on
-        // iOS without the entitlement, so .start has no physical mapping unless
-        // buttonOptions is absent. On controllers without buttonOptions we
-        // reserve no game button for Select rather than silently break a game
-        // button; the user can always use the in-game menu to pause/quit.
+        // Start / Select. buttonMenu is always present on an extended gamepad and
+        // carries Start, which most PS1 titles need to get past their title
+        // screen. buttonOptions is absent on some controllers, those simply have
+        // no Select. The in-game menu is reached via the on-screen menu button
+        // that appears whenever the touch controls hide, or via the optional
+        // shortcut combo below.
+        pad.buttonMenu.valueChangedHandler = handler(for: .start)
+        pad.buttonOptions?.valueChangedHandler = handler(for: .select)
     }
 
     /// Removes all handlers from the controller and clears any latched buttons.
     func detach(from controller: GCController?) {
         clearHandlers(on: controller?.extendedGamepad)
+        pressedButtons.removeAll()
+        comboLatched = false
         frontend?.clearAllButtons()
     }
 
     // MARK: - Private helpers
 
-    // nonisolated so GCController's background-thread handlers can call it
-    // without a data-race warning. The actual state write is bounced to MainActor.
-    nonisolated private func send(_ button: LibretroABI.JoypadButton, pressed: Bool) {
-        Task { @MainActor [weak self] in
-            self?.frontend?.setButton(button, pressed: pressed)
+    /// Builds a handler that forwards one physical button to one libretro button.
+    /// `handlerQueue` is pinned to `.main` in `attach`, so the assumeIsolated is
+    /// sound and keeps the write on the same runloop turn as the input event.
+    private func handler(for button: LibretroABI.JoypadButton) -> GCControllerButtonValueChangedHandler {
+        return { [weak self] _, _, pressed in
+            MainActor.assumeIsolated {
+                self?.send(button, pressed: pressed)
+            }
+        }
+    }
+
+    private func send(_ button: LibretroABI.JoypadButton, pressed: Bool) {
+        frontend?.setButton(button, pressed: pressed)
+        if pressed {
+            pressedButtons.insert(button)
+        } else {
+            pressedButtons.remove(button)
+        }
+        updateMenuCombo()
+    }
+
+    /// Fires `onMenuRequested` once when every button of the configured combo is
+    /// held. The buttons keep going to the core as normal, the combo is purely
+    /// additive.
+    private func updateMenuCombo() {
+        let combo = comboButtons
+        guard !combo.isEmpty else {
+            comboLatched = false
+            return
+        }
+        guard combo.isSubset(of: pressedButtons) else {
+            comboLatched = false
+            return
+        }
+        guard !comboLatched else { return }
+        comboLatched = true
+        onMenuRequested?()
+    }
+
+    private var comboButtons: Set<LibretroABI.JoypadButton> {
+        switch menuShortcutPreference?.current ?? .none {
+        case .none: return []
+        case .l3r3: return [.l3, .r3]
+        case .l1r1: return [.l, .r]
         }
     }
 
@@ -102,7 +153,7 @@ final class LibretroControllerInput {
         pad.rightTrigger.valueChangedHandler  = nil
         pad.leftThumbstickButton?.valueChangedHandler  = nil
         pad.rightThumbstickButton?.valueChangedHandler = nil
-        pad.buttonMenu.pressedChangedHandler   = nil
+        pad.buttonMenu.valueChangedHandler     = nil
         pad.buttonOptions?.valueChangedHandler = nil
     }
 }

--- a/romm/romm/UI/Emulator/Libretro/LibretroControllerInput.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroControllerInput.swift
@@ -1,0 +1,108 @@
+import GameController
+
+/// Bridges a connected GCController to LibretroFrontend.buttonState.
+///
+/// Maps digital buttons and D-Pad only. Analog sticks are intentionally
+/// omitted, they may be added in a future iteration if needed.
+///
+/// Layout follows the SNES/libretro convention where the bottom face button
+/// is RETRO_DEVICE_ID_JOYPAD_B (index 0) and the right face button is
+/// RETRO_DEVICE_ID_JOYPAD_A (index 8), so physical A/B and X/Y are
+/// cross-mapped from the Xbox-style GCController naming to the SNES layout.
+@MainActor
+final class LibretroControllerInput {
+
+    private weak var frontend: LibretroFrontend?
+    var onMenuRequested: (() -> Void)?
+
+    init(frontend: LibretroFrontend) {
+        self.frontend = frontend
+    }
+
+    // MARK: - Connect / Disconnect
+
+    /// Installs value-changed handlers on the given controller's extended gamepad.
+    /// Safe to call with nil (no-op) so callers don't need an extra guard.
+    func attach(to controller: GCController?) {
+        guard let pad = controller?.extendedGamepad else { return }
+
+        // D-Pad
+        pad.dpad.up.valueChangedHandler    = { [weak self] _, _, pressed in self?.send(.up,     pressed: pressed) }
+        pad.dpad.down.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.down,   pressed: pressed) }
+        pad.dpad.left.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.left,   pressed: pressed) }
+        pad.dpad.right.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.right,  pressed: pressed) }
+
+        // Face buttons (SNES/libretro layout: bottom = B, right = A, left = Y, top = X)
+        // GCController uses Xbox names: buttonA = bottom, buttonB = right,
+        // buttonX = left, buttonY = top.
+        pad.buttonA.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.b, pressed: pressed) }
+        pad.buttonB.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.a, pressed: pressed) }
+        pad.buttonX.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.y, pressed: pressed) }
+        pad.buttonY.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.x, pressed: pressed) }
+
+        // Shoulders
+        pad.leftShoulder.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.l,  pressed: pressed) }
+        pad.rightShoulder.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.r,  pressed: pressed) }
+
+        // Triggers — treated as digital buttons, value ignored.
+        pad.leftTrigger.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.l2, pressed: pressed) }
+        pad.rightTrigger.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.r2, pressed: pressed) }
+
+        // Thumbstick clicks (optional on some gamepads, hence pressedChangedHandler)
+        pad.leftThumbstickButton?.valueChangedHandler  = { [weak self] _, _, pressed in self?.send(.l3, pressed: pressed) }
+        pad.rightThumbstickButton?.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.r3, pressed: pressed) }
+
+        // Start / Select
+        // buttonMenu is always present; buttonOptions is absent on some controllers
+        // (e.g. Apple TV Remote) so we fall back to nil-safe access.
+        pad.buttonMenu.pressedChangedHandler = { [weak self] _, _, pressed in
+            guard pressed else { return }
+            // Menu button opens the in-game overlay instead of sending Start
+            // to the core, consistent with the native Delta path.
+            Task { @MainActor [weak self] in self?.onMenuRequested?() }
+        }
+        pad.buttonOptions?.valueChangedHandler = { [weak self] _, _, pressed in self?.send(.select, pressed: pressed) }
+
+        // buttonHome is not part of GCExtendedGamepad and cannot be captured on
+        // iOS without the entitlement, so .start has no physical mapping unless
+        // buttonOptions is absent. On controllers without buttonOptions we
+        // reserve no game button for Select rather than silently break a game
+        // button; the user can always use the in-game menu to pause/quit.
+    }
+
+    /// Removes all handlers from the controller and clears any latched buttons.
+    func detach(from controller: GCController?) {
+        clearHandlers(on: controller?.extendedGamepad)
+        frontend?.clearAllButtons()
+    }
+
+    // MARK: - Private helpers
+
+    // nonisolated so GCController's background-thread handlers can call it
+    // without a data-race warning. The actual state write is bounced to MainActor.
+    nonisolated private func send(_ button: LibretroABI.JoypadButton, pressed: Bool) {
+        Task { @MainActor [weak self] in
+            self?.frontend?.setButton(button, pressed: pressed)
+        }
+    }
+
+    private func clearHandlers(on pad: GCExtendedGamepad?) {
+        guard let pad else { return }
+        pad.dpad.up.valueChangedHandler    = nil
+        pad.dpad.down.valueChangedHandler  = nil
+        pad.dpad.left.valueChangedHandler  = nil
+        pad.dpad.right.valueChangedHandler = nil
+        pad.buttonA.valueChangedHandler    = nil
+        pad.buttonB.valueChangedHandler    = nil
+        pad.buttonX.valueChangedHandler    = nil
+        pad.buttonY.valueChangedHandler    = nil
+        pad.leftShoulder.valueChangedHandler  = nil
+        pad.rightShoulder.valueChangedHandler = nil
+        pad.leftTrigger.valueChangedHandler   = nil
+        pad.rightTrigger.valueChangedHandler  = nil
+        pad.leftThumbstickButton?.valueChangedHandler  = nil
+        pad.rightThumbstickButton?.valueChangedHandler = nil
+        pad.buttonMenu.pressedChangedHandler   = nil
+        pad.buttonOptions?.valueChangedHandler = nil
+    }
+}

--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
@@ -21,6 +21,7 @@ final class LibretroEmulatorViewModel {
     private let biosSync: PBIOSSyncUseCase
     let aspectRatioPreference: PLibretroAspectRatioPreference
     let screenPositionPreference: PEmulatorScreenPositionPreference
+    private let menuShortcutPreference: PEmulatorMenuShortcutPreference?
     private let factory: PDependencyFactory
     private let logger = Logger.viewModel
 
@@ -33,6 +34,7 @@ final class LibretroEmulatorViewModel {
         biosSync: PBIOSSyncUseCase,
         aspectRatioPreference: PLibretroAspectRatioPreference,
         screenPositionPreference: PEmulatorScreenPositionPreference,
+        menuShortcutPreference: PEmulatorMenuShortcutPreference? = nil,
         factory: PDependencyFactory
     ) {
         self.rom = rom
@@ -43,6 +45,7 @@ final class LibretroEmulatorViewModel {
         self.biosSync = biosSync
         self.aspectRatioPreference = aspectRatioPreference
         self.screenPositionPreference = screenPositionPreference
+        self.menuShortcutPreference = menuShortcutPreference
         self.factory = factory
     }
 
@@ -93,6 +96,7 @@ final class LibretroEmulatorViewModel {
                 saveStates: saveStates,
                 aspectRatioPreference: aspectRatioPreference,
                 screenPositionPreference: screenPositionPreference,
+                menuShortcutPreference: menuShortcutPreference,
                 cloudSync: cloudSync
             )
             s.onMenuRequested = { [weak self] in self?.onMenuRequested?() }

--- a/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
@@ -33,6 +33,7 @@ final class LibretroSession: NSObject {
         saveStates: PEmulatorSaveStatesUseCase,
         aspectRatioPreference: PLibretroAspectRatioPreference,
         screenPositionPreference: PEmulatorScreenPositionPreference,
+        menuShortcutPreference: PEmulatorMenuShortcutPreference? = nil,
         cloudSync: CloudSaveSyncService? = nil
     ) {
         self.gameURL = gameURL
@@ -51,7 +52,10 @@ final class LibretroSession: NSObject {
         // controllerInput must be created before super.init() because stored
         // properties must be initialised before the instance escapes.
         // onMenuRequested is wired after super.init() once self is available.
-        self.controllerInput = LibretroControllerInput(frontend: LibretroFrontend.shared)
+        self.controllerInput = LibretroControllerInput(
+            frontend: LibretroFrontend.shared,
+            menuShortcutPreference: menuShortcutPreference
+        )
         super.init()
         self.viewController.controllerView.onMenuTapped = { [weak self] in
             self?.onMenuRequested?()
@@ -60,7 +64,7 @@ final class LibretroSession: NSObject {
             self?.onControlsHiddenChanged?(hidden)
         }
 
-        // Forward menu requests from the controller's Menu button.
+        // Forward menu requests from the optional controller shortcut combo.
         controllerInput.onMenuRequested = { [weak self] in
             self?.onMenuRequested?()
         }

--- a/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
@@ -21,6 +21,11 @@ final class LibretroSession: NSObject {
 
     let viewController: LibretroGameViewController
 
+    // MARK: - Physical controller input bridge
+    private let controllerInput: LibretroControllerInput
+    /// The controller currently wired to the input bridge, if any.
+    private var attachedController: GCController?
+
     init(
         gameURL: URL,
         core: LibretroCore,
@@ -43,6 +48,10 @@ final class LibretroSession: NSObject {
             aspectRatioPreference: aspectRatioPreference,
             screenPositionPreference: screenPositionPreference
         )
+        // controllerInput must be created before super.init() because stored
+        // properties must be initialised before the instance escapes.
+        // onMenuRequested is wired after super.init() once self is available.
+        self.controllerInput = LibretroControllerInput(frontend: LibretroFrontend.shared)
         super.init()
         self.viewController.controllerView.onMenuTapped = { [weak self] in
             self?.onMenuRequested?()
@@ -50,6 +59,28 @@ final class LibretroSession: NSObject {
         self.viewController.onControlsHiddenChanged = { [weak self] hidden in
             self?.onControlsHiddenChanged?(hidden)
         }
+
+        // Forward menu requests from the controller's Menu button.
+        controllerInput.onMenuRequested = { [weak self] in
+            self?.onMenuRequested?()
+        }
+
+        // Wire connect/disconnect so the input bridge stays in sync.
+        var names: [NSNotification.Name] = [.GCControllerDidConnect, .GCControllerDidDisconnect]
+        #if DEBUG
+        names.append(.emulatorSimulatedControllerChanged)
+        #endif
+        for name in names {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleControllerConnectionChanged),
+                name: name,
+                object: nil
+            )
+        }
+
+        // Attach to any controller that is already connected at launch.
+        attachControllerIfPresent()
     }
 
     // MARK: - Lifecycle
@@ -128,11 +159,33 @@ final class LibretroSession: NSObject {
     func pause() { frontend.pause() }
     func resume() { frontend.resume() }
 
+    // MARK: - Physical controller input
+
+    @objc private func handleControllerConnectionChanged() {
+        // Release every button that might be latched on the outgoing controller
+        // before re-evaluating; prevents permanently-stuck inputs across
+        // connect/disconnect events.
+        controllerInput.detach(from: attachedController)
+        attachedController = nil
+        attachControllerIfPresent()
+    }
+
+    private func attachControllerIfPresent() {
+        guard let controller = GCController.controllers().first else { return }
+        attachedController = controller
+        controllerInput.attach(to: controller)
+        print("[Libretro] physical controller attached: \(controller.vendorName ?? "unknown")")
+    }
+
     func reloadAspectRatio() {
         viewController.applyAspectConstraints()
     }
 
     func stop() {
+        // Detach the physical controller before tearing down the frontend so
+        // clearAllButtons() runs while the frontend is still live.
+        controllerInput.detach(from: attachedController)
+        attachedController = nil
         // Unwire the sink BEFORE tearing down the core: pcsx_rearmed can emit a
         // final video frame during retro_unload_game / retro_deinit, and after
         // dlclose() any CGImage backed by core memory would crash on render.
@@ -247,6 +300,10 @@ final class LibretroSession: NSObject {
 
     private func documentsDirectory() -> URL {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 

--- a/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
+++ b/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct EmulatorEngineSettingsView: View {
     @State private var selection: EmulatorEngine
+    @State private var menuShortcut: EmulatorMenuShortcut
     private let preference: PEmulatorEnginePreference
+    private let menuShortcutPreference: PEmulatorMenuShortcutPreference
 
     #if DEBUG
     @State private var simulateController = EmulatorControllerState.simulateConnected
@@ -10,7 +12,9 @@ struct EmulatorEngineSettingsView: View {
 
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
         self.preference = factory.enginePreference
+        self.menuShortcutPreference = factory.emulatorMenuShortcutPreference
         _selection = State(wrappedValue: factory.enginePreference.current)
+        _menuShortcut = State(wrappedValue: factory.emulatorMenuShortcutPreference.current)
     }
 
     var body: some View {
@@ -36,6 +40,17 @@ struct EmulatorEngineSettingsView: View {
 
             Section(footer: Text("When a physical controller is connected, the on-screen buttons hide and you can drag the game to reposition it — handy for gamepad cases that cover part of the screen. Set its size from the in-game menu.")) { EmptyView() }
 
+            Section(
+                header: Text("Controller"),
+                footer: Text("Optional button combination that opens the in-game menu from a physical controller. The on-screen menu button stays available either way.")
+            ) {
+                Picker("Menu shortcut", selection: $menuShortcut) {
+                    Text("Off").tag(EmulatorMenuShortcut.none)
+                    Text("L3 + R3").tag(EmulatorMenuShortcut.l3r3)
+                    Text("L1 + R1").tag(EmulatorMenuShortcut.l1r1)
+                }
+            }
+
             #if DEBUG
             Section(
                 header: Text("Debug"),
@@ -50,5 +65,6 @@ struct EmulatorEngineSettingsView: View {
         }
         .navigationTitle("Emulator")
         .onChange(of: selection) { _, new in preference.current = new }
+        .onChange(of: menuShortcut) { _, new in menuShortcutPreference.current = new }
     }
 }


### PR DESCRIPTION
Physical controllers did nothing in the libretro emulator. Connecting one hid the touch controls but no input ever reached the core, so PS1, PC Engine, Master System, Game Gear, SG-1000 and Sega CD were unplayable with a gamepad. Fixes #61 partly, the audio half of that issue is still open.

- New `LibretroControllerInput` bridges GCController to `LibretroFrontend.setButton`, digital buttons and D-Pad only
- Menu maps to Start, so PS1 titles get past their "PRESS START" screen, Options maps to Select
- Optional menu shortcut in Settings, off by default, L3+R3 or L1+R1
- Buttons are released when switching between touch and controller so nothing stays latched

Analog sticks are deliberately left out for now.

Not verified on hardware yet, the simulator has no controller. Worth checking on a PS1 title that Cross confirms and that Menu really arrives as Start.