### PR TITLE
Play button back on the ROM detail page

### DIFF
--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -13,6 +13,9 @@ struct RomDetailView: View {
     @State private var viewModel = RomDetailViewModel()
 
     @EnvironmentObject private var appData: AppData
+    /// Observed so the Play button appears as soon as the in-app emulator is
+    /// switched on in Settings, without needing a fresh push of this screen.
+    @ObservedObject private var experimentalSettings = ExperimentalFeatureSettings.shared
     @State private var downloadButtonFrame: CGRect = .zero
     /// Mirrors the native tab-bar minimize (which has no readable state): true
     /// once the scroll view has moved down far enough that the bar collapses.
@@ -27,7 +30,7 @@ struct RomDetailView: View {
     @State private var showingCollectionPicker = false
     @State private var showingFullScreenPDF = false
     @State private var selectedGameDataTab: GameDataTabType = .states
-    
+
     enum DetailTab: String, CaseIterable {
         case details = "DETAILS"
         case manual = "MANUAL"
@@ -241,6 +244,15 @@ struct RomDetailView: View {
                     print(scrollOffset)
                 }
             }
+            .fullScreenCover(item: $viewModel.launchDecision, onDismiss: {
+                viewModel.emulatorPresentationDidEnd()
+                OrientationLock.set(.portrait, rotateTo: .portrait)
+                // A session may have written a new save state or battery save.
+                Task { await viewModel.loadRomDetails(romId: rom.id) }
+            }) { decision in
+                EmulatorRouterView(decision: decision)
+                    .ignoresSafeArea()
+            }
             .onAppear {
                 Task {
                     await viewModel.loadRomDetails(romId: rom.id)
@@ -377,71 +389,107 @@ struct RomDetailView: View {
                 .accessibility(hint: Text(viewModel.romCollectionsCount > 0 ? "Manage ROM collections" : "Add this ROM to a collection"))
             }
             
-            // Primary action: queue a download to this device.
-            // Playing happens in the Downloads tab (ROMCardRow), not here.
+            // Primary action: queue a download to this device. Once the ROM is on
+            // the device a compact Play button joins the same row, so users don't
+            // have to detour through the Downloads tab to start a game.
             let downloadState = viewModel.downloadButtonState(forRomId: currentSelectedRom.id)
-            Button(action: {
-                appData.launchDownloadFlight(
-                    coverURL: currentSelectedRom.urlCover,
-                    from: downloadButtonFrame,
-                    // No public API exposes the tab-bar's minimized state, so
-                    // derive it from the live scroll offset (see onScrollGeometryChange).
-                    tabBarMinimized: tabBarMinimized
-                )
-                viewModel.downloadROM(rom: currentSelectedRom)
-            }) {
-                HStack(spacing: 8) {
-                    switch downloadState {
-                    case .queued:
-                        ProgressView().progressViewStyle(.circular).tint(.white)
-                        Text("Queued").font(.headline)
-                    case .downloading(let progress):
-                        if let progress {
-                            ProgressView(value: progress)
-                                .progressViewStyle(.linear)
-                                .tint(.white)
-                                .frame(maxWidth: 140)
-                                .animation(.easeOut(duration: 0.4), value: progress)
-                            Text("\(Int((progress * 100).rounded()))%")
-                                .font(.headline)
-                                .contentTransition(.numericText())
-                                .animation(.easeOut(duration: 0.4), value: progress)
-                        } else {
+            HStack(spacing: 12) {
+                Button(action: {
+                    appData.launchDownloadFlight(
+                        coverURL: currentSelectedRom.urlCover,
+                        from: downloadButtonFrame,
+                        // No public API exposes the tab-bar's minimized state, so
+                        // derive it from the live scroll offset (see onScrollGeometryChange).
+                        tabBarMinimized: tabBarMinimized
+                    )
+                    viewModel.downloadROM(rom: currentSelectedRom)
+                }) {
+                    HStack(spacing: 8) {
+                        switch downloadState {
+                        case .queued:
                             ProgressView().progressViewStyle(.circular).tint(.white)
-                            Text("Downloading…").font(.headline)
+                            Text("Queued").font(.headline)
+                        case .downloading(let progress):
+                            if let progress {
+                                ProgressView(value: progress)
+                                    .progressViewStyle(.linear)
+                                    .tint(.white)
+                                    .frame(maxWidth: 140)
+                                    .animation(.easeOut(duration: 0.4), value: progress)
+                                Text("\(Int((progress * 100).rounded()))%")
+                                    .font(.headline)
+                                    .contentTransition(.numericText())
+                                    .animation(.easeOut(duration: 0.4), value: progress)
+                            } else {
+                                ProgressView().progressViewStyle(.circular).tint(.white)
+                                Text("Downloading…").font(.headline)
+                            }
+                        case .downloaded:
+                            Label("Downloaded", systemImage: "checkmark.circle.fill")
+                                .font(.headline)
+                        case .failed:
+                            Label("Retry Download", systemImage: "arrow.clockwise.circle.fill")
+                                .font(.headline)
+                        case .idle:
+                            Label("Download", systemImage: "arrow.down.circle.fill")
+                                .font(.headline)
                         }
-                    case .downloaded:
-                        Label("Downloaded", systemImage: "checkmark.circle.fill")
-                            .font(.headline)
-                    case .failed:
-                        Label("Retry Download", systemImage: "arrow.clockwise.circle.fill")
-                            .font(.headline)
-                    case .idle:
-                        Label("Download", systemImage: "arrow.down.circle.fill")
-                            .font(.headline)
                     }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(downloadState == .downloaded ? Color.green : Color.accentColor)
+                    )
+                    .foregroundColor(.white)
+                    .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .background(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(downloadState == .downloaded ? Color.green : Color.accentColor)
-                )
-                .foregroundColor(.white)
-                .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
-            }
-            .disabled({
-                switch downloadState {
-                case .idle, .failed: return false
-                case .queued, .downloading, .downloaded: return true
+                .disabled({
+                    switch downloadState {
+                    case .idle, .failed: return false
+                    case .queued, .downloading, .downloaded: return true
+                    }
+                }())
+                .accessibility(hint: Text(downloadState == .downloaded ? "Already downloaded to this device" : "Download this ROM to this device"))
+                .onGeometryChange(for: CGRect.self) { proxy in
+                    proxy.frame(in: .global)
+                } action: { newFrame in
+                    downloadButtonFrame = newFrame
                 }
-            }())
-            .accessibility(hint: Text(downloadState == .downloaded ? "Already downloaded to this device" : "Download this ROM to this device"))
-            .onGeometryChange(for: CGRect.self) { proxy in
-                proxy.frame(in: .global)
-            } action: { newFrame in
-                downloadButtonFrame = newFrame
+
+                // Only offered for a ROM that is already on the device, on a
+                // platform we can emulate, and with the in-app emulator switched
+                // on, so it never leads to a dead end.
+                if downloadState == .downloaded
+                    && viewModel.canPlayEmulator
+                    && experimentalSettings.isEmulatorEnabled {
+                    Button(action: {
+                        Task { await viewModel.launchEmulator(rom: currentSelectedRom) }
+                    }) {
+                        Group {
+                            if viewModel.isLaunchingEmulator {
+                                ProgressView().progressViewStyle(.circular).tint(.white)
+                            } else {
+                                Image(systemName: "play.fill")
+                                    .font(.headline)
+                            }
+                        }
+                        .frame(width: 52)
+                        .padding(.vertical, 14)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .fill(Color.accentColor)
+                        )
+                        .foregroundColor(.white)
+                        .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
+                    }
+                    .disabled(viewModel.isLaunchingEmulator)
+                    .accessibilityLabel("Play")
+                    .accessibility(hint: Text("Play this ROM on this device"))
+                    .transition(.scale.combined(with: .opacity))
+                }
             }
+            .animation(.easeOut(duration: 0.25), value: downloadState == .downloaded)
 
             // Secondary actions: open the downloaded file in another app, or send it to a device.
             HStack(spacing: 12) {

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -30,6 +30,15 @@ struct RomDetailView: View {
     @State private var showingCollectionPicker = false
     @State private var showingFullScreenPDF = false
     @State private var selectedGameDataTab: GameDataTabType = .states
+    /// Shown instead of booting straight away when the ROM has save states, so
+    /// the user gets the resume/new-game choice, same as in the Downloads tab.
+    @State private var showingPreLaunch = false
+    /// Slot picked in the pre-launch sheet; read by the emulator cover builder.
+    @State private var pendingResumeSlot: Int?
+    /// Distinguishes "user picked a slot" from "user cancelled" once the
+    /// pre-launch sheet has dismissed.
+    @State private var shouldLaunchAfterPreLaunch = false
+    private let saveStore: PSaveStore = DefaultDependencyFactory.shared.saveStore
 
     enum DetailTab: String, CaseIterable {
         case details = "DETAILS"
@@ -246,12 +255,33 @@ struct RomDetailView: View {
             }
             .fullScreenCover(item: $viewModel.launchDecision, onDismiss: {
                 viewModel.emulatorPresentationDidEnd()
+                pendingResumeSlot = nil
                 OrientationLock.set(.portrait, rotateTo: .portrait)
                 // A session may have written a new save state or battery save.
                 Task { await viewModel.loadRomDetails(romId: rom.id) }
             }) { decision in
-                EmulatorRouterView(decision: decision)
+                EmulatorRouterView(decision: decision, resumeSlot: pendingResumeSlot)
                     .ignoresSafeArea()
+            }
+            .sheet(isPresented: $showingPreLaunch, onDismiss: {
+                // Boot only once the sheet is fully gone. Presenting the emulator's
+                // full screen cover while the sheet is still dismissing can swallow
+                // the presentation entirely.
+                guard shouldLaunchAfterPreLaunch else { return }
+                shouldLaunchAfterPreLaunch = false
+                Task { await viewModel.launchEmulator(rom: currentSelectedRom) }
+            }) {
+                PreLaunchSheet(
+                    romName: currentSelectedRom.name,
+                    romId: rom.id,
+                    saveStore: saveStore
+                ) { resumeSlot in
+                    pendingResumeSlot = resumeSlot
+                    shouldLaunchAfterPreLaunch = true
+                    showingPreLaunch = false
+                }
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
             .onAppear {
                 Task {
@@ -463,9 +493,7 @@ struct RomDetailView: View {
                 if downloadState == .downloaded
                     && viewModel.canPlayEmulator
                     && experimentalSettings.isEmulatorEnabled {
-                    Button(action: {
-                        Task { await viewModel.launchEmulator(rom: currentSelectedRom) }
-                    }) {
+                    Button(action: { startPlay() }) {
                         Group {
                             if viewModel.isLaunchingEmulator {
                                 ProgressView().progressViewStyle(.circular).tint(.white)
@@ -527,6 +555,18 @@ struct RomDetailView: View {
         .padding(.bottom, 24)
     }
     
+    /// Routes a Play tap: offer resume when save states exist, otherwise boot
+    /// straight into a fresh session.
+    private func startPlay() {
+        let states = (try? saveStore.listStates(romId: rom.id)) ?? []
+        if states.isEmpty {
+            pendingResumeSlot = nil
+            Task { await viewModel.launchEmulator(rom: currentSelectedRom) }
+        } else {
+            showingPreLaunch = true
+        }
+    }
+
     @ViewBuilder
     private var stickyTabNavigation: some View {
         HStack(spacing: 0) {


### PR DESCRIPTION
Some users missed the play button on the detail page, so it is back. Once a ROM is downloaded, a compact play button joins the download button in the same row. It only appears when the platform is one we can emulate and the in-app emulator is switched on, so it never leads to a dead end.

Second commit adds the resume step: with save states present the button opens the same sheet the Downloads tab uses, otherwise it boots straight through.

One file. A good chunk of the diff is re-indentation from wrapping the download button in an HStack, `git diff -w` is about 90 lines.

Built and run on device.