### PR TITLE
Play on TV for the DeltaCore path

### DIFF
--- a/romm/romm.xcodeproj/xcshareddata/xcschemes/romm.xcscheme
+++ b/romm/romm.xcodeproj/xcshareddata/xcschemes/romm.xcscheme
@@ -28,6 +28,17 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5DA7E4322E43D872003680D9"
+               BuildableName = "rommTests.xctest"
+               BlueprintName = "rommTests"
+               ReferencedContainer = "container:romm.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/romm/romm/AppDelegate.swift
+++ b/romm/romm/AppDelegate.swift
@@ -15,7 +15,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         AppBootstrap.run()
         // A previous run may have been killed while the screen was blanked for
         // TV play, which would leave the panel dark at brightness 0.
-        PhoneScreenBlanker.recoverIfNeeded()
+        PhoneScreenBlanker.shared.recoverIfNeeded()
         return true
     }
 

--- a/romm/romm/Data/Preferences/UserDefaultsExternalDisplayPreferenceStore.swift
+++ b/romm/romm/Data/Preferences/UserDefaultsExternalDisplayPreferenceStore.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+final class UserDefaultsExternalDisplayPreferenceStore: PExternalDisplayPreference {
+    private let playOnTVKey = "externalDisplay.enabled"
+    private let autoDimKey = "externalDisplay.autoDimPhone"
+    private let blankedBrightnessKey = "phoneScreenBlanker.savedBrightness"
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    var isPlayOnTVEnabled: Bool {
+        get { boolOrTrue(playOnTVKey) }
+        set { userDefaults.set(newValue, forKey: playOnTVKey) }
+    }
+
+    var isAutoDimPhoneEnabled: Bool {
+        get { boolOrTrue(autoDimKey) }
+        set { userDefaults.set(newValue, forKey: autoDimKey) }
+    }
+
+    var blankedPhoneBrightness: Double? {
+        get {
+            guard userDefaults.object(forKey: blankedBrightnessKey) != nil else { return nil }
+            return userDefaults.double(forKey: blankedBrightnessKey)
+        }
+        set {
+            if let newValue {
+                userDefaults.set(newValue, forKey: blankedBrightnessKey)
+            } else {
+                userDefaults.removeObject(forKey: blankedBrightnessKey)
+            }
+        }
+    }
+
+    /// Both switches default to on, and `UserDefaults.bool` returns false for a
+    /// missing key. Once a TV is attached, a portrait phone screen with black bars
+    /// is never what the player wanted.
+    private func boolOrTrue(_ key: String) -> Bool {
+        guard userDefaults.object(forKey: key) != nil else { return true }
+        return userDefaults.bool(forKey: key)
+    }
+}

--- a/romm/romm/Data/Services/UIScreenBrightness.swift
+++ b/romm/romm/Data/Services/UIScreenBrightness.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+final class UIScreenBrightness: PScreenBrightness {
+    var level: Double {
+        get { MainActor.assumeIsolated { Double(UIScreen.main.brightness) } }
+        set { MainActor.assumeIsolated { UIScreen.main.brightness = CGFloat(newValue) } }
+    }
+}

--- a/romm/romm/Domain/Models/ExternalDisplayPolicy.swift
+++ b/romm/romm/Domain/Models/ExternalDisplayPolicy.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The two decisions behind Play on TV, as plain functions over plain values.
+///
+/// They used to sit inside a `UIWindow` owning class and, copied verbatim, in two
+/// SwiftUI views. Both are statements about a handful of booleans, which is
+/// exactly the part worth testing, and it was the one part that could only be
+/// checked by holding a controller in front of an actual television.
+enum ExternalDisplayPolicy {
+
+    /// Whether the app should paint the attached display itself.
+    ///
+    /// Outside a running game the answer is no on purpose: mirroring the library
+    /// UI is the sensible thing for a browsing user, and it is also what a viewer
+    /// expects when nothing is being played.
+    static func shouldRenderExternally(
+        isDisplayConnected: Bool,
+        isSessionRunning: Bool,
+        isPlayOnTVEnabled: Bool
+    ) -> Bool {
+        isDisplayConnected && isSessionRunning && isPlayOnTVEnabled
+    }
+
+    /// Whether the phone may dim itself.
+    ///
+    /// Hidden touch controls are the app's signal that a physical controller is
+    /// in use, so together with the game being on the TV it means nobody is
+    /// looking at the handset. An open menu is the counter case: it is operated by
+    /// touch, so dimming underneath it would be absurd.
+    static func shouldAutoDimPhone(
+        isRenderingExternally: Bool,
+        areTouchControlsHidden: Bool,
+        isMenuOpen: Bool,
+        isAutoDimPhoneEnabled: Bool
+    ) -> Bool {
+        isAutoDimPhoneEnabled && isRenderingExternally && areTouchControlsHidden && !isMenuOpen
+    }
+}

--- a/romm/romm/Domain/Models/ExternalDisplayPreference.swift
+++ b/romm/romm/Domain/Models/ExternalDisplayPreference.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+protocol PExternalDisplayPreference: AnyObject {
+    /// Draw the game on an attached display ourselves instead of letting the
+    /// system mirror the whole phone.
+    var isPlayOnTVEnabled: Bool { get set }
+
+    /// Let the handset go dark on its own once the game is on the TV and a
+    /// controller is in use.
+    var isAutoDimPhoneEnabled: Bool { get set }
+
+    /// Brightness captured before the phone screen was blanked. Not a setting the
+    /// user makes, but it has to outlive the process: brightness is system wide,
+    /// so a crash while blanked would otherwise leave a phone that looks broken.
+    /// `nil` means nothing is pending recovery.
+    var blankedPhoneBrightness: Double? { get set }
+}

--- a/romm/romm/Domain/RepositoryProtocols/PScreenBrightness.swift
+++ b/romm/romm/Domain/RepositoryProtocols/PScreenBrightness.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// The device's own screen brightness, 0…1.
+///
+/// Behind a protocol so the blanking logic can be exercised without a device,
+/// and so the UI layer stops reaching for `UIScreen.main` directly. Writing this
+/// changes a system wide setting that outlives the app, which is the reason the
+/// old value is persisted rather than merely held in memory.
+protocol PScreenBrightness: AnyObject {
+    var level: Double { get set }
+}

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -116,6 +116,8 @@ protocol PDependencyFactory {
     var libretroAspectRatioPreference: PLibretroAspectRatioPreference { get }
     var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference { get }
     var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference { get }
+    var externalDisplayPreference: PExternalDisplayPreference { get }
+    var screenBrightness: PScreenBrightness { get }
     func makePlatformEngineSupport() -> PPlatformEngineSupport
 
     // SFTP ViewModels
@@ -385,6 +387,8 @@ class DefaultDependencyFactory: PDependencyFactory {
     lazy var libretroAspectRatioPreference: PLibretroAspectRatioPreference = UserDefaultsLibretroAspectRatioPreferenceStore()
     lazy var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference = UserDefaultsEmulatorScreenPositionPreferenceStore()
     lazy var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference = UserDefaultsEmulatorMenuShortcutPreferenceStore()
+    lazy var externalDisplayPreference: PExternalDisplayPreference = UserDefaultsExternalDisplayPreferenceStore()
+    lazy var screenBrightness: PScreenBrightness = UIScreenBrightness()
 
     func makePlatformEngineSupport() -> PPlatformEngineSupport {
         PlatformEngineSupport()

--- a/romm/romm/UI/DI/InMemoryExternalDisplayPreference.swift
+++ b/romm/romm/UI/DI/InMemoryExternalDisplayPreference.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+final class InMemoryExternalDisplayPreference: PExternalDisplayPreference {
+    var isPlayOnTVEnabled: Bool = true
+    var isAutoDimPhoneEnabled: Bool = true
+    var blankedPhoneBrightness: Double?
+}

--- a/romm/romm/UI/DI/MockDependencyFactory.swift
+++ b/romm/romm/UI/DI/MockDependencyFactory.swift
@@ -35,6 +35,8 @@ class MockDependencyFactory: PDependencyFactory {
     lazy var libretroAspectRatioPreference: PLibretroAspectRatioPreference = InMemoryLibretroAspectRatioPreference()
     lazy var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference = InMemoryEmulatorScreenPositionPreference()
     lazy var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference = UserDefaultsEmulatorMenuShortcutPreferenceStore()
+    lazy var externalDisplayPreference: PExternalDisplayPreference = InMemoryExternalDisplayPreference()
+    lazy var screenBrightness: PScreenBrightness = UIScreenBrightness()
     
     init(
         authRepository: PAuthRepository? = nil,

--- a/romm/romm/UI/Emulator/ExternalDisplay/ExternalDisplayControls.swift
+++ b/romm/romm/UI/Emulator/ExternalDisplay/ExternalDisplayControls.swift
@@ -14,7 +14,7 @@ struct ExternalDisplayControls: View {
 
     @ObservedObject private var display = ExternalDisplayManager.shared
 
-    @SwiftUI.State private var playOnTV: Bool = ExternalDisplayPreferences.isEnabled
+    @SwiftUI.State private var playOnTV: Bool = ExternalDisplayManager.shared.isPlayOnTVEnabled
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -27,7 +27,7 @@ struct ExternalDisplayControls: View {
                     Toggle("", isOn: $playOnTV)
                         .labelsHidden()
                         .onChange(of: playOnTV) { _, newValue in
-                            display.setEnabled(newValue)
+                            display.setPlayOnTVEnabled(newValue)
                         }
                 } else {
                     Text("Not connected")

--- a/romm/romm/UI/Emulator/ExternalDisplay/ExternalDisplayManager.swift
+++ b/romm/romm/UI/Emulator/ExternalDisplay/ExternalDisplayManager.swift
@@ -2,8 +2,8 @@ import UIKit
 import Combine
 
 /// Owns the window we put on an external display (AirPlay or a USB-C/HDMI
-/// adapter) so a running game can be shown there directly instead of letting
-/// the system mirror the whole phone UI.
+/// adapter) so a running game can be shown there directly instead of letting the
+/// system mirror the whole phone UI.
 ///
 /// How the system side works: while AirPlaying or wired up, iOS offers the app a
 /// scene with the `windowExternalDisplayNonInteractive` role. As long as we
@@ -17,27 +17,21 @@ import Combine
 /// game is rendered at the TV's own resolution and aspect, so no portrait phone
 /// screen with black bars, and only the game picture has to be encoded instead
 /// of the entire animated UI.
+///
+/// Scope of this class: scene and window plumbing, plus the observable state the
+/// UI binds to. The *decision* lives in `ExternalDisplayPolicy` and the painting
+/// in a `PExternalRenderTarget`, so neither is entangled with UIKit lifecycle.
+///
+/// A singleton because UIKit instantiates `ExternalDisplaySceneDelegate` itself
+/// and hands it a scene, so there is no call site to inject into. The same reason
+/// `LibretroFrontend` is one. Its collaborators are injected, so it can be built
+/// and driven in a test without a display.
 @MainActor
 final class ExternalDisplayManager: ObservableObject {
 
-    static let shared = ExternalDisplayManager()
-
-    /// Fills the display whenever we own it. Exists independently of whether one
-    /// is attached, so a renderer wires itself up once and never thinks about
-    /// connection state again.
-    let contentView = ExternalDisplayContentView()
-
-    /// Layer the software blit renderer pushes its frames into. While no display
-    /// is attached the layer is not on screen and assigning `contents` is close
-    /// to free, which is why libretro can set it unconditionally per frame.
-    var videoLayer: CALayer { contentView.videoLayer }
-
-    /// For renderers that draw through a view of their own instead of a layer we
-    /// feed, which is how DeltaCore works: it hands a frame to every `GameView`
-    /// registered with its `VideoManager`.
-    func setContent(_ view: UIView?) {
-        contentView.setContent(view)
-    }
+    static let shared = ExternalDisplayManager(
+        preference: DefaultDependencyFactory.shared.externalDisplayPreference
+    )
 
     /// True while iOS has handed us an external display scene.
     @Published private(set) var isConnected = false
@@ -51,6 +45,13 @@ final class ExternalDisplayManager: ObservableObject {
     /// the only concrete thing we can show.
     @Published private(set) var displayResolution: String?
 
+    private let preference: PExternalDisplayPreference
+
+    /// Fills the display whenever we own it. Exists independently of whether one
+    /// is attached, so a render target can be handed it and forget about
+    /// connection state.
+    private let contentView = ExternalDisplayContentView()
+
     /// Set while an emulator session is on screen. Outside a session we leave
     /// the display alone, mirroring the library UI is the sensible default there.
     private var isSessionRunning = false
@@ -58,7 +59,12 @@ final class ExternalDisplayManager: ObservableObject {
     private weak var scene: UIWindowScene?
     private var window: UIWindow?
 
-    private init() {}
+    /// Weak: the running session owns its render target and outlives no session.
+    private weak var renderTarget: PExternalRenderTarget?
+
+    init(preference: PExternalDisplayPreference) {
+        self.preference = preference
+    }
 
     // MARK: - Scene lifecycle (called from ExternalDisplaySceneDelegate)
 
@@ -68,54 +74,84 @@ final class ExternalDisplayManager: ObservableObject {
         isConnected = true
         let px = scene.screen.nativeBounds.size
         displayResolution = "\(Int(px.width)) × \(Int(px.height))"
-        syncWindow()
+        sync()
     }
 
     func sceneDidDisconnect(_ scene: UIWindowScene) {
         guard self.scene === scene else { return }
         print("[ExternalDisplay] scene disconnected")
-        teardownWindow()
         self.scene = nil
         isConnected = false
-        isActive = false
         displayResolution = nil
+        sync()
     }
 
-    // MARK: - Session lifecycle (called from the emulator view controllers)
+    // MARK: - Session lifecycle (called from the emulator views)
 
     func beginSession() {
         isSessionRunning = true
-        syncWindow()
+        sync()
     }
 
     func endSession() {
         isSessionRunning = false
-        syncWindow()
+        sync()
+    }
+
+    /// Registered by the running emulator session. Setting it while we already
+    /// own the display starts it right away, which is the case when a game is
+    /// launched with a TV already attached.
+    func setRenderTarget(_ target: PExternalRenderTarget?) {
+        if let previous = renderTarget, previous !== target {
+            previous.stopRendering()
+        }
+        renderTarget = target
+        syncRendering()
     }
 
     // MARK: - User control
 
+    var isPlayOnTVEnabled: Bool { preference.isPlayOnTVEnabled }
+
     /// Lets the player hand the display back to plain mirroring and take it over
-    /// again, from the in-game menu.
-    func setEnabled(_ enabled: Bool) {
-        ExternalDisplayPreferences.isEnabled = enabled
-        syncWindow()
+    /// again, from the in-game menu or from Settings.
+    func setPlayOnTVEnabled(_ enabled: Bool) {
+        preference.isPlayOnTVEnabled = enabled
+        sync()
     }
 
-    var isEnabled: Bool { ExternalDisplayPreferences.isEnabled }
+    var isAutoDimPhoneEnabled: Bool { preference.isAutoDimPhoneEnabled }
+
+    func setAutoDimPhoneEnabled(_ enabled: Bool) {
+        preference.isAutoDimPhoneEnabled = enabled
+    }
 
     // MARK: - Window plumbing
 
-    /// Single place that decides whether our window should be up, so every entry
-    /// point above just changes state and calls this.
-    private func syncWindow() {
-        let shouldShow = isConnected && isSessionRunning && ExternalDisplayPreferences.isEnabled
-        if shouldShow {
+    /// Single place that acts on the policy's verdict, so every entry point above
+    /// just changes state and calls this.
+    private func sync() {
+        let shouldRender = ExternalDisplayPolicy.shouldRenderExternally(
+            isDisplayConnected: isConnected,
+            isSessionRunning: isSessionRunning,
+            isPlayOnTVEnabled: preference.isPlayOnTVEnabled
+        )
+        if shouldRender {
             setupWindow()
         } else {
             teardownWindow()
         }
         isActive = window != nil
+        syncRendering()
+    }
+
+    private func syncRendering() {
+        guard let renderTarget else { return }
+        if isActive {
+            renderTarget.startRendering(into: contentView)
+        } else {
+            renderTarget.stopRendering()
+        }
     }
 
     private func setupWindow() {
@@ -139,10 +175,8 @@ final class ExternalDisplayManager: ObservableObject {
 }
 
 /// The picture surface itself, kept apart from the window so it survives the
-/// display being handed back and forth between us and plain mirroring. Both
-/// renderers reach it: libretro assigns `CGImage`s to `videoLayer`, DeltaCore
-/// installs a view via `setContent`.
-final class ExternalDisplayContentView: UIView {
+/// display being handed back and forth between us and plain mirroring.
+final class ExternalDisplayContentView: UIView, PExternalDisplaySurface {
 
     let videoLayer: CALayer = {
         let layer = CALayer()
@@ -203,34 +237,5 @@ private final class ExternalDisplayViewController: UIViewController {
         contentView.frame = view.bounds
         contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.addSubview(contentView)
-    }
-}
-
-/// Persisted opt-out, kept next to the other lightweight emulator toggles
-/// (see `HapticsPreferences`) rather than going through the DI container, since
-/// only the manager reads it. Defaults to on: once a TV is attached, a portrait
-/// phone screen with black bars is never what the player wanted.
-enum ExternalDisplayPreferences {
-    private static let enabledKey = "externalDisplay.enabled"
-    private static let autoDimKey = "externalDisplay.autoDimPhone"
-
-    static var isEnabled: Bool {
-        get { boolOrTrue(enabledKey) }
-        set { UserDefaults.standard.set(newValue, forKey: enabledKey) }
-    }
-
-    /// Dim the handset on its own once the game is on the TV and a controller is
-    /// in use. On by default: in that situation nobody is looking at the phone,
-    /// and having to reach for a menu button to darken it defeats the point.
-    static var autoDimPhone: Bool {
-        get { boolOrTrue(autoDimKey) }
-        set { UserDefaults.standard.set(newValue, forKey: autoDimKey) }
-    }
-
-    /// `UserDefaults.bool` returns false for a missing key, which would make
-    /// both of these default to off.
-    private static func boolOrTrue(_ key: String) -> Bool {
-        guard UserDefaults.standard.object(forKey: key) != nil else { return true }
-        return UserDefaults.standard.bool(forKey: key)
     }
 }

--- a/romm/romm/UI/Emulator/ExternalDisplay/ExternalDisplayManager.swift
+++ b/romm/romm/UI/Emulator/ExternalDisplay/ExternalDisplayManager.swift
@@ -22,20 +22,22 @@ final class ExternalDisplayManager: ObservableObject {
 
     static let shared = ExternalDisplayManager()
 
-    /// Layer the renderers push their frames into. It exists independently of
-    /// whether a display is attached right now, so a renderer can wire it up
-    /// once in `viewDidLoad` and never think about connection state again. While
-    /// nothing is attached the layer is not in any hierarchy and assigning
-    /// `contents` is close to free.
-    let videoLayer: CALayer = {
-        let layer = CALayer()
-        layer.backgroundColor = UIColor.black.cgColor
-        // Nearest keeps the pixel art crisp when blown up to a TV, resizeAspect
-        // does the letterboxing for us whatever the panel's ratio is.
-        layer.magnificationFilter = .nearest
-        layer.contentsGravity = .resizeAspect
-        return layer
-    }()
+    /// Fills the display whenever we own it. Exists independently of whether one
+    /// is attached, so a renderer wires itself up once and never thinks about
+    /// connection state again.
+    let contentView = ExternalDisplayContentView()
+
+    /// Layer the software blit renderer pushes its frames into. While no display
+    /// is attached the layer is not on screen and assigning `contents` is close
+    /// to free, which is why libretro can set it unconditionally per frame.
+    var videoLayer: CALayer { contentView.videoLayer }
+
+    /// For renderers that draw through a view of their own instead of a layer we
+    /// feed, which is how DeltaCore works: it hands a frame to every `GameView`
+    /// registered with its `VideoManager`.
+    func setContent(_ view: UIView?) {
+        contentView.setContent(view)
+    }
 
     /// True while iOS has handed us an external display scene.
     @Published private(set) var isConnected = false
@@ -118,7 +120,7 @@ final class ExternalDisplayManager: ObservableObject {
 
     private func setupWindow() {
         guard window == nil, let scene else { return }
-        let controller = ExternalDisplayViewController(videoLayer: videoLayer)
+        let controller = ExternalDisplayViewController(contentView: contentView)
         let window = UIWindow(windowScene: scene)
         window.rootViewController = controller
         window.isHidden = false
@@ -136,14 +138,60 @@ final class ExternalDisplayManager: ObservableObject {
     }
 }
 
-/// Black full-bleed host for `videoLayer`. Non-interactive by definition of the
-/// scene role, so there is nothing to wire up beyond the layer's frame.
+/// The picture surface itself, kept apart from the window so it survives the
+/// display being handed back and forth between us and plain mirroring. Both
+/// renderers reach it: libretro assigns `CGImage`s to `videoLayer`, DeltaCore
+/// installs a view via `setContent`.
+final class ExternalDisplayContentView: UIView {
+
+    let videoLayer: CALayer = {
+        let layer = CALayer()
+        layer.backgroundColor = UIColor.black.cgColor
+        // Nearest keeps the pixel art crisp when blown up to a TV, resizeAspect
+        // does the letterboxing for us whatever the panel's ratio is.
+        layer.magnificationFilter = .nearest
+        layer.contentsGravity = .resizeAspect
+        return layer
+    }()
+
+    private weak var installedContent: UIView?
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .black
+        layer.addSublayer(videoLayer)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    func setContent(_ view: UIView?) {
+        installedContent?.removeFromSuperview()
+        installedContent = view
+        guard let view else { return }
+        view.frame = bounds
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        addSubview(view)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // No animation: this is re-framed on resize and an implicit fade would
+        // smear a live game picture.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        videoLayer.frame = bounds
+        CATransaction.commit()
+    }
+}
+
+/// Black full-bleed host for the content view. Non-interactive by definition of
+/// the scene role, so there is nothing to wire up beyond the layout.
 private final class ExternalDisplayViewController: UIViewController {
 
-    private let videoLayer: CALayer
+    private let contentView: ExternalDisplayContentView
 
-    init(videoLayer: CALayer) {
-        self.videoLayer = videoLayer
+    init(contentView: ExternalDisplayContentView) {
+        self.contentView = contentView
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -152,17 +200,9 @@ private final class ExternalDisplayViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .black
-        view.layer.addSublayer(videoLayer)
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        // No animation: the layer is re-framed on rotation/resize and an implicit
-        // fade would smear a live game picture.
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        videoLayer.frame = view.bounds
-        CATransaction.commit()
+        contentView.frame = view.bounds
+        contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(contentView)
     }
 }
 

--- a/romm/romm/UI/Emulator/ExternalDisplay/ExternalRenderTarget.swift
+++ b/romm/romm/UI/Emulator/ExternalDisplay/ExternalRenderTarget.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+/// The surface a renderer paints when the app owns an external display.
+///
+/// Two shapes, because the two emulator backends differ in kind: libretro
+/// produces a finished `CGImage` per frame, which is simply assigned to a layer,
+/// while DeltaCore hands its frames to views that render themselves.
+@MainActor
+protocol PExternalDisplaySurface: AnyObject {
+
+    /// For renderers that blit finished images.
+    var videoLayer: CALayer { get }
+
+    /// For renderers that bring their own view. Pass `nil` to clear.
+    func setContent(_ view: UIView?)
+}
+
+/// A renderer's end of the arrangement.
+///
+/// The display manager knows *when* the app owns the display, a render target
+/// knows *how* to paint. Keeping those apart is what lets a third backend be
+/// added later without touching scene and window handling, and it is why neither
+/// side has to reach for the other's internals any more.
+@MainActor
+protocol PExternalRenderTarget: AnyObject {
+
+    /// Called when the app takes the display over. May be called again after a
+    /// `stopRendering`, for instance when the player toggles Play on TV twice.
+    func startRendering(into surface: PExternalDisplaySurface)
+
+    /// Called when the display goes back to plain mirroring, or the session ends.
+    /// Must leave nothing of the renderer registered on the surface.
+    func stopRendering()
+}

--- a/romm/romm/UI/Emulator/ExternalDisplay/PhoneScreenBlanker.swift
+++ b/romm/romm/UI/Emulator/ExternalDisplay/PhoneScreenBlanker.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 import Combine
 
 /// Blanks the phone's own screen while a game runs on a TV, so the handset can
@@ -10,28 +10,39 @@ import Combine
 /// phones use, black pixels are switched off, so this lands very close to a
 /// dark screen in both looks and power draw.
 ///
-/// The brightness is a system-wide setting that survives the app, so the
-/// original value is persisted immediately. If the app is killed while blanked,
-/// `recoverIfNeeded()` puts it back on the next launch instead of leaving the
-/// user with a phone that seems broken.
+/// Deliberately mechanical: it does not decide *whether* dimming is appropriate,
+/// that is `ExternalDisplayPolicy`'s job and the caller's to apply. This only
+/// runs the countdown and moves the brightness.
+///
+/// A singleton for the same reason the display manager is one, the recovery path
+/// runs from `AppDelegate` before any view exists. Its collaborators are
+/// injected, so the countdown and the recovery can be tested without a device.
 @MainActor
 final class PhoneScreenBlanker: ObservableObject {
 
-    static let shared = PhoneScreenBlanker()
+    static let shared = PhoneScreenBlanker(
+        brightness: DefaultDependencyFactory.shared.screenBrightness,
+        preference: DefaultDependencyFactory.shared.externalDisplayPreference
+    )
 
     @Published private(set) var isBlanked = false
-
-    private static let savedBrightnessKey = "phoneScreenBlanker.savedBrightness"
 
     /// Grace period before dimming on its own. Long enough to reach the menu
     /// button after starting a game, short enough not to sit there glowing.
     private static let autoDimDelay: TimeInterval = 8
 
+    private let brightness: PScreenBrightness
+    private let preference: PExternalDisplayPreference
+
     private var autoDimTimer: Timer?
-    /// True while the conditions hold: game on the TV, controller in hand.
+    /// True while the caller says the conditions hold: game on the TV, controller
+    /// in hand, no menu open.
     private var autoDimAllowed = false
 
-    private init() {}
+    init(brightness: PScreenBrightness, preference: PExternalDisplayPreference) {
+        self.brightness = brightness
+        self.preference = preference
+    }
 
     // MARK: - Automatic dimming
 
@@ -57,7 +68,7 @@ final class PhoneScreenBlanker: ObservableObject {
 
     private func armAutoDim() {
         cancelAutoDim()
-        guard autoDimAllowed, ExternalDisplayPreferences.autoDimPhone else { return }
+        guard autoDimAllowed else { return }
         autoDimTimer = Timer.scheduledTimer(withTimeInterval: Self.autoDimDelay, repeats: false) { [weak self] _ in
             MainActor.assumeIsolated { self?.blank() }
         }
@@ -68,11 +79,16 @@ final class PhoneScreenBlanker: ObservableObject {
         autoDimTimer = nil
     }
 
+    // MARK: - Brightness
+
     func blank() {
         guard !isBlanked else { return }
-        let current = UIScreen.main.brightness
-        UserDefaults.standard.set(current, forKey: Self.savedBrightnessKey)
-        UIScreen.main.brightness = 0
+        let current = brightness.level
+        // Persisted before the change, not after: brightness is a system wide
+        // setting that outlives the app, so a crash from here on must still be
+        // recoverable.
+        preference.blankedPhoneBrightness = current
+        brightness.level = 0
         isBlanked = true
         print("[PhoneScreen] blanked, saved brightness \(String(format: "%.2f", current))")
     }
@@ -86,19 +102,17 @@ final class PhoneScreenBlanker: ObservableObject {
 
     /// Called on launch: if a previous run was killed while blanked, the saved
     /// brightness is still on disk and the panel is still dark.
-    static func recoverIfNeeded() {
-        guard UserDefaults.standard.object(forKey: savedBrightnessKey) != nil else { return }
+    func recoverIfNeeded() {
+        guard preference.blankedPhoneBrightness != nil else { return }
         print("[PhoneScreen] recovering brightness after an unclean exit")
-        MainActor.assumeIsolated { shared.applySavedBrightness() }
+        applySavedBrightness()
     }
 
     private func applySavedBrightness() {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: Self.savedBrightnessKey) != nil else { return }
-        let saved = defaults.double(forKey: Self.savedBrightnessKey)
+        guard let saved = preference.blankedPhoneBrightness else { return }
         // A saved value of 0 would mean restoring to black, which can only be a
         // bad read. Fall back to something clearly usable.
-        UIScreen.main.brightness = saved > 0.05 ? CGFloat(saved) : 0.5
-        defaults.removeObject(forKey: Self.savedBrightnessKey)
+        brightness.level = saved > 0.05 ? saved : 0.5
+        preference.blankedPhoneBrightness = nil
     }
 }

--- a/romm/romm/UI/Emulator/ExternalDisplay/PlayOnTVModifier.swift
+++ b/romm/romm/UI/Emulator/ExternalDisplay/PlayOnTVModifier.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+extension View {
+
+    /// Wires a running emulator screen into Play on TV: takes the display over
+    /// for the duration of the session, keeps the device awake, and dims the
+    /// handset once nobody is looking at it.
+    ///
+    /// Both emulator paths need exactly this, and had it copied verbatim.
+    ///
+    /// - Parameters:
+    ///   - areTouchControlsHidden: The app's signal that a physical controller is
+    ///     in use, since the skin is hidden precisely then.
+    ///   - isMenuOpen: The in-game menu is touch operated, so it blocks dimming.
+    func playOnTV(areTouchControlsHidden: Bool, isMenuOpen: Bool) -> some View {
+        modifier(PlayOnTVModifier(
+            areTouchControlsHidden: areTouchControlsHidden,
+            isMenuOpen: isMenuOpen
+        ))
+    }
+}
+
+private struct PlayOnTVModifier: ViewModifier {
+
+    let areTouchControlsHidden: Bool
+    let isMenuOpen: Bool
+
+    @ObservedObject private var display = ExternalDisplayManager.shared
+    @ObservedObject private var screenBlanker = PhoneScreenBlanker.shared
+    @Environment(\.scenePhase) private var scenePhase
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if screenBlanker.isBlanked {
+                    blankingOverlay
+                }
+            }
+            .animation(.easeOut(duration: 0.2), value: screenBlanker.isBlanked)
+            .onAppear {
+                // Only take over an external display while a game is on screen.
+                // Anchored in the SwiftUI view rather than a view controller
+                // because presenting the menu sheet does not disturb this
+                // lifecycle, while `viewDidDisappear` fires for it.
+                display.beginSession()
+                // Playing with a controller means nobody touches the phone, so
+                // auto lock would otherwise background the app and stop emulation.
+                UIApplication.shared.isIdleTimerDisabled = true
+                updateAutoDim()
+            }
+            .onDisappear {
+                display.endSession()
+                UIApplication.shared.isIdleTimerDisabled = false
+                screenBlanker.setAutoDimAllowed(false)
+            }
+            .onChange(of: display.isActive) { _, _ in updateAutoDim() }
+            .onChange(of: areTouchControlsHidden) { _, _ in updateAutoDim() }
+            .onChange(of: isMenuOpen) { _, _ in updateAutoDim() }
+            .onChange(of: scenePhase) { _, phase in
+                // Leaving the app must never strand the user with a dark panel.
+                if phase != .active { screenBlanker.restore() }
+            }
+    }
+
+    /// Covers everything including the menu button, so the only way out is the
+    /// tap, which is also the most obvious one.
+    private var blankingOverlay: some View {
+        Color.black
+            .ignoresSafeArea()
+            .contentShape(Rectangle())
+            .onTapGesture { screenBlanker.noteActivity() }
+            .overlay(alignment: .bottom) {
+                Text("Tap to turn the screen back on")
+                    .font(.footnote)
+                    .foregroundStyle(.white.opacity(0.2))
+                    .padding(.bottom, 40)
+            }
+            .transition(.opacity)
+    }
+
+    private func updateAutoDim() {
+        screenBlanker.setAutoDimAllowed(
+            ExternalDisplayPolicy.shouldAutoDimPhone(
+                isRenderingExternally: display.isActive,
+                areTouchControlsHidden: areTouchControlsHidden,
+                isMenuOpen: isMenuOpen,
+                isAutoDimPhoneEnabled: display.isAutoDimPhoneEnabled
+            )
+        )
+    }
+}

--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorView.swift
@@ -7,8 +7,6 @@ struct LibretroEmulatorView: View {
     @SwiftUI.State private var isQuitting = false
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
-    @ObservedObject private var screenBlanker = PhoneScreenBlanker.shared
-    @ObservedObject private var externalDisplay = ExternalDisplayManager.shared
 
     private let resumeSlot: Int?
 
@@ -43,54 +41,19 @@ struct LibretroEmulatorView: View {
                 EmulatorMenuButtonOverlay { showMenu = true }
                     .transition(.opacity)
             }
-            if screenBlanker.isBlanked {
-                // Covers everything including the menu button, so the only way
-                // out is the tap, which is also the most obvious one.
-                Color.black
-                    .ignoresSafeArea()
-                    .contentShape(Rectangle())
-                    .onTapGesture { screenBlanker.noteActivity() }
-                    .overlay(alignment: .bottom) {
-                        Text("Tap to turn the screen back on")
-                            .font(.footnote)
-                            .foregroundStyle(.white.opacity(0.2))
-                            .padding(.bottom, 40)
-                    }
-                    .transition(.opacity)
-            }
         }
         .animation(.easeOut(duration: 0.2), value: viewModel.controlsHidden)
         .animation(.easeOut(duration: 0.25), value: viewModel.isLoading)
-        // Dim on its own only while the game really is on the TV and the player
-        // has a controller, so the phone is genuinely not being looked at.
-        .onChange(of: externalDisplay.isActive) { _, _ in updateAutoDim() }
-        .onChange(of: viewModel.controlsHidden) { _, _ in updateAutoDim() }
-        .onChange(of: showMenu) { _, presented in
-            // The menu is touch operated, dimming underneath it would be absurd.
-            if presented { screenBlanker.setAutoDimAllowed(false) } else { updateAutoDim() }
-        }
+        .playOnTV(areTouchControlsHidden: viewModel.controlsHidden, isMenuOpen: showMenu)
         .onAppear {
             OrientationLock.set([.portrait, .landscapeLeft, .landscapeRight])
             viewModel.onMenuRequested = { showMenu = true }
             viewModel.bootstrap(resumeSlot: resumeSlot)
-            // Only take over an external display while a game is on screen.
-            // Anchored here rather than in the view controller because a sheet
-            // does not disturb this view's lifecycle.
-            ExternalDisplayManager.shared.beginSession()
-            // Playing with a controller means nobody touches the phone, so auto
-            // lock would otherwise background the app and stop emulation.
-            UIApplication.shared.isIdleTimerDisabled = true
-            updateAutoDim()
         }
         .onDisappear {
             viewModel.teardown()
-            ExternalDisplayManager.shared.endSession()
-            UIApplication.shared.isIdleTimerDisabled = false
-            screenBlanker.setAutoDimAllowed(false)
         }
         .onChange(of: scenePhase) { _, phase in
-            // Leaving the app must never strand the user with a dark panel.
-            if phase != .active { screenBlanker.restore() }
             // Gate on session presence: after teardown the session is nil,
             // and a stray .background firing here would otherwise reach the
             // singleton frontend with stale state.
@@ -124,14 +87,6 @@ struct LibretroEmulatorView: View {
             )
             .preferredColorScheme(.dark)
         }
-    }
-
-    /// Auto dimming is allowed exactly when the game is being shown on the TV and
-    /// the touch controls are gone, which is the app's signal for "a physical
-    /// controller is in use".
-    private func updateAutoDim() {
-        let allowed = externalDisplay.isActive && viewModel.controlsHidden && !showMenu
-        screenBlanker.setAutoDimAllowed(allowed)
     }
 }
 

--- a/romm/romm/UI/Emulator/Libretro/LibretroExternalRenderTarget.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroExternalRenderTarget.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+/// Sends libretro's picture to an external display.
+///
+/// Cheap by construction: the video view already builds one `CGImage` per frame
+/// for the phone, so the TV costs a second `contents` assignment of an image that
+/// exists either way.
+@MainActor
+final class LibretroExternalRenderTarget: PExternalRenderTarget {
+
+    private weak var videoView: LibretroVideoView?
+
+    init(videoView: LibretroVideoView) {
+        self.videoView = videoView
+    }
+
+    func startRendering(into surface: PExternalDisplaySurface) {
+        videoView?.mirrorLayer = surface.videoLayer
+    }
+
+    func stopRendering() {
+        videoView?.mirrorLayer = nil
+    }
+}

--- a/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
@@ -21,6 +21,10 @@ final class LibretroSession: NSObject {
 
     let viewController: LibretroGameViewController
 
+    /// Owned here so the display manager can hold it weakly: the target must not
+    /// outlive the session it paints from.
+    private var externalRenderTarget: LibretroExternalRenderTarget?
+
     // MARK: - Physical controller input bridge
     private let controllerInput: LibretroControllerInput
     /// The controller currently wired to the input bridge, if any.
@@ -43,6 +47,7 @@ final class LibretroSession: NSObject {
         self.aspectRatioPreference = aspectRatioPreference
         self.screenPositionPreference = screenPositionPreference
         self.cloudSync = cloudSync
+        self.externalRenderTarget = nil
         self.viewController = LibretroGameViewController(
             core: core,
             gameURL: gameURL,
@@ -97,6 +102,12 @@ final class LibretroSession: NSObject {
     func start(resumeSlot: Int? = nil) {
         let videoView = viewController.videoView
         frontend.videoSink = videoView
+
+        // Feed an external display the same frames. The manager decides when,
+        // this only says how.
+        let target = LibretroExternalRenderTarget(videoView: videoView)
+        externalRenderTarget = target
+        ExternalDisplayManager.shared.setRenderTarget(target)
 
         Task { [weak self] in
             guard let self else { return }
@@ -191,9 +202,11 @@ final class LibretroSession: NSObject {
         // clearAllButtons() runs while the frontend is still live.
         controllerInput.detach(from: attachedController)
         attachedController = nil
-        // Unwire the sink BEFORE tearing down the core: pcsx_rearmed can emit a
+        // Unwire both sinks BEFORE tearing down the core: pcsx_rearmed can emit a
         // final video frame during retro_unload_game / retro_deinit, and after
         // dlclose() any CGImage backed by core memory would crash on render.
+        ExternalDisplayManager.shared.setRenderTarget(nil)
+        externalRenderTarget = nil
         frontend.videoSink = nil
         frontend.stop()
         flushBatteryFromSaveDir()
@@ -381,10 +394,6 @@ final class LibretroGameViewController: UIViewController {
         view.addSubview(videoView)
         applyAspectConstraints()
         view.addGestureRecognizer(screenPanRecognizer)
-
-        // Feed an external display (AirPlay or wired) the same frames. Wiring is
-        // unconditional, the manager decides whether the layer is on screen.
-        videoView.mirrorLayer = ExternalDisplayManager.shared.videoLayer
 
         controllerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(controllerView)

--- a/romm/romm/UI/Emulator/Native/DeltaCoreExternalRenderTarget.swift
+++ b/romm/romm/UI/Emulator/Native/DeltaCoreExternalRenderTarget.swift
@@ -1,0 +1,39 @@
+import UIKit
+import DeltaCore
+
+/// Sends a DeltaCore game to an external display.
+///
+/// DeltaCore is built for this: an `EmulatorCore` hands every frame to each
+/// `GameView` registered with its `VideoManager`, so a second one costs one more
+/// draw of an image that already exists rather than a second emulation pass.
+@MainActor
+final class DeltaCoreExternalRenderTarget: PExternalRenderTarget {
+
+    private weak var core: EmulatorCore?
+    private weak var surface: PExternalDisplaySurface?
+    private var screen: ExternalGameScreenView?
+
+    init(core: EmulatorCore) {
+        self.core = core
+    }
+
+    func startRendering(into surface: PExternalDisplaySurface) {
+        guard screen == nil, let core else { return }
+        let screen = ExternalGameScreenView()
+        screen.renderingSize = core.preferredRenderingSize
+        core.add(screen.gameView)
+        surface.setContent(screen)
+        self.screen = screen
+        self.surface = surface
+        print("[Native] rendering to the external display at \(Int(core.preferredRenderingSize.width))x\(Int(core.preferredRenderingSize.height))")
+    }
+
+    func stopRendering() {
+        guard let screen else { return }
+        // Unregister before dropping the view: the core must never keep a render
+        // target that is no longer on screen.
+        core?.remove(screen.gameView)
+        surface?.setContent(nil)
+        self.screen = nil
+    }
+}

--- a/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
+++ b/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
@@ -9,6 +9,7 @@ struct EmulatorMenuSheet: View {
     @SwiftUI.State private var statusMessage: String?
     @SwiftUI.State private var refreshTick: Int = 0
     @SwiftUI.State private var showQuitConfirmation = false
+    @ObservedObject private var externalDisplay = ExternalDisplayManager.shared
 
     // Slots are 0-based to match the save-state storage / cloud-sync layer
     // (files are `slot0.state`…`slot20.state`). Slot 0 is a real, usable slot.
@@ -36,6 +37,14 @@ struct EmulatorMenuSheet: View {
                     actionButtons
                         .padding(.horizontal, 16)
                         .padding(.bottom, 12)
+                    // Unlike the libretro menu this sheet is a fixed stack, not a
+                    // scroll view, so the section only appears once there really
+                    // is a display. Settings carries the discoverability.
+                    if externalDisplay.isConnected {
+                        Divider().background(Color.white.opacity(0.1))
+                        ExternalDisplayControls(onRequestDismiss: onResume)
+                            .padding(16)
+                    }
                     if let preference = session?.screenPositionPreference,
                        EmulatorControllerState.isConnected {
                         Divider().background(Color.white.opacity(0.1))

--- a/romm/romm/UI/Emulator/Native/ExternalGameScreenView.swift
+++ b/romm/romm/UI/Emulator/Native/ExternalGameScreenView.swift
@@ -1,0 +1,47 @@
+import UIKit
+import AVFoundation
+import DeltaCore
+
+/// Shows a DeltaCore game on an external display.
+///
+/// DeltaCore is built for this: an `EmulatorCore` hands every frame to each
+/// `GameView` registered with its `VideoManager`, so a second one costs one more
+/// draw of an image that already exists rather than a second emulation pass.
+/// This view owns that extra `GameView` and does nothing but letterbox it, since
+/// a TV's aspect ratio has no relation to a console's.
+///
+/// No filter is set on the game view on purpose. The on-screen views get crop
+/// filters from the controller skin, which is how a dual-screen system like the
+/// DS is split into two panes on the phone. Leaving it unfiltered means the TV
+/// shows the core's framebuffer as it is, which for the DS is both screens
+/// stacked, the same thing the phone shows once the touch skin is hidden.
+final class ExternalGameScreenView: UIView {
+
+    let gameView = GameView(frame: .zero)
+
+    /// The core's framebuffer size, used purely for the aspect ratio.
+    var renderingSize: CGSize = .zero {
+        didSet {
+            guard renderingSize != oldValue else { return }
+            setNeedsLayout()
+        }
+    }
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .black
+        // Blowing a 240p console up to 4K with bilinear smearing looks like a
+        // washed out mess; nearest keeps the pixels as pixels.
+        gameView.samplerMode = .nearestNeighbor
+        addSubview(gameView)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard bounds.width > 0, bounds.height > 0,
+              renderingSize.width > 0, renderingSize.height > 0 else { return }
+        gameView.frame = AVMakeRect(aspectRatio: renderingSize, insideRect: bounds).integral
+    }
+}

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 import AVFoundation
-import Combine
 import DeltaCore
 import GBADeltaCore
 import GameController
@@ -152,10 +151,9 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
 
     let viewController: GameViewController
 
-    /// The extra game view rendering to the TV, present only while we own the
-    /// display.
-    private var externalScreen: ExternalGameScreenView?
-    private var externalDisplayObserver: AnyCancellable?
+    /// Owned here so the display manager can hold it weakly: the target must not
+    /// outlive the core it renders from.
+    private var externalRenderTarget: DeltaCoreExternalRenderTarget?
 
     // MARK: - GameViewControllerDelegate
 
@@ -222,7 +220,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
             self.viewController.startEmulation()
             self.attachExternalControllers()
             self.observeControllerConnections()
-            self.observeExternalDisplay()
+            self.registerExternalRenderTarget()
             guard let slot = resumeSlot else { return }
             try? await Task.sleep(nanoseconds: 600_000_000)
             self.viewController.pauseEmulation()
@@ -256,49 +254,21 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         detachExternalControllers()
         // Before `core.stop()`: the core must not be torn down while a view of
         // ours is still registered as one of its render targets.
-        externalDisplayObserver = nil
-        detachExternalScreen()
+        ExternalDisplayManager.shared.setRenderTarget(nil)
+        externalRenderTarget = nil
         NotificationCenter.default.removeObserver(self)
         emulatorCore?.stop()
     }
 
     // MARK: - External display
 
-    /// Follows the manager's take-over state rather than merely being connected:
-    /// while the display is back on plain mirroring there is nothing of ours on
-    /// it, so the core should not be rendering a second view at all.
-    ///
-    /// `@Published` replays its current value on subscribe, so a display that was
-    /// already active when the game launched is picked up here too.
-    private func observeExternalDisplay() {
-        externalDisplayObserver = ExternalDisplayManager.shared.$isActive
-            .sink { [weak self] isActive in
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    if isActive {
-                        self.attachExternalScreen()
-                    } else {
-                        self.detachExternalScreen()
-                    }
-                }
-            }
-    }
-
-    private func attachExternalScreen() {
-        guard externalScreen == nil, let core = emulatorCore else { return }
-        let screen = ExternalGameScreenView()
-        screen.renderingSize = core.preferredRenderingSize
-        core.add(screen.gameView)
-        ExternalDisplayManager.shared.setContent(screen)
-        externalScreen = screen
-        print("[Native] rendering to the external display at \(Int(core.preferredRenderingSize.width))x\(Int(core.preferredRenderingSize.height))")
-    }
-
-    private func detachExternalScreen() {
-        guard let screen = externalScreen else { return }
-        emulatorCore?.remove(screen.gameView)
-        ExternalDisplayManager.shared.setContent(nil)
-        externalScreen = nil
+    /// Registered once the core exists. Whether it actually paints is the display
+    /// manager's call, so there is nothing to observe here.
+    private func registerExternalRenderTarget() {
+        guard let core = emulatorCore else { return }
+        let target = DeltaCoreExternalRenderTarget(core: core)
+        externalRenderTarget = target
+        ExternalDisplayManager.shared.setRenderTarget(target)
     }
 
     // MARK: - External Controllers

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import AVFoundation
+import Combine
 import DeltaCore
 import GBADeltaCore
 import GameController
@@ -151,6 +152,11 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
 
     let viewController: GameViewController
 
+    /// The extra game view rendering to the TV, present only while we own the
+    /// display.
+    private var externalScreen: ExternalGameScreenView?
+    private var externalDisplayObserver: AnyCancellable?
+
     // MARK: - GameViewControllerDelegate
 
     func gameViewController(_ gameViewController: GameViewController, handleMenuInputFrom gameController: GameController) {
@@ -216,6 +222,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
             self.viewController.startEmulation()
             self.attachExternalControllers()
             self.observeControllerConnections()
+            self.observeExternalDisplay()
             guard let slot = resumeSlot else { return }
             try? await Task.sleep(nanoseconds: 600_000_000)
             self.viewController.pauseEmulation()
@@ -247,8 +254,51 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         viewController.pauseEmulation()
         flushBattery()
         detachExternalControllers()
+        // Before `core.stop()`: the core must not be torn down while a view of
+        // ours is still registered as one of its render targets.
+        externalDisplayObserver = nil
+        detachExternalScreen()
         NotificationCenter.default.removeObserver(self)
         emulatorCore?.stop()
+    }
+
+    // MARK: - External display
+
+    /// Follows the manager's take-over state rather than merely being connected:
+    /// while the display is back on plain mirroring there is nothing of ours on
+    /// it, so the core should not be rendering a second view at all.
+    ///
+    /// `@Published` replays its current value on subscribe, so a display that was
+    /// already active when the game launched is picked up here too.
+    private func observeExternalDisplay() {
+        externalDisplayObserver = ExternalDisplayManager.shared.$isActive
+            .sink { [weak self] isActive in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    if isActive {
+                        self.attachExternalScreen()
+                    } else {
+                        self.detachExternalScreen()
+                    }
+                }
+            }
+    }
+
+    private func attachExternalScreen() {
+        guard externalScreen == nil, let core = emulatorCore else { return }
+        let screen = ExternalGameScreenView()
+        screen.renderingSize = core.preferredRenderingSize
+        core.add(screen.gameView)
+        ExternalDisplayManager.shared.setContent(screen)
+        externalScreen = screen
+        print("[Native] rendering to the external display at \(Int(core.preferredRenderingSize.width))x\(Int(core.preferredRenderingSize.height))")
+    }
+
+    private func detachExternalScreen() {
+        guard let screen = externalScreen else { return }
+        emulatorCore?.remove(screen.gameView)
+        ExternalDisplayManager.shared.setContent(nil)
+        externalScreen = nil
     }
 
     // MARK: - External Controllers

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorView.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorView.swift
@@ -6,6 +6,8 @@ struct NativeEmulatorView: View {
     @SwiftUI.State private var showMenu = false
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
+    @ObservedObject private var screenBlanker = PhoneScreenBlanker.shared
+    @ObservedObject private var externalDisplay = ExternalDisplayManager.shared
 
     private let resumeSlot: Int?
 
@@ -39,18 +41,46 @@ struct NativeEmulatorView: View {
                 EmulatorMenuButtonOverlay { showMenu = true }
                     .transition(.opacity)
             }
+            if screenBlanker.isBlanked {
+                // Covers everything including the menu button, so the only way
+                // out is the tap, which is also the most obvious one.
+                Color.black
+                    .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .onTapGesture { screenBlanker.noteActivity() }
+                    .overlay(alignment: .bottom) {
+                        Text("Tap to turn the screen back on")
+                            .font(.footnote)
+                            .foregroundStyle(.white.opacity(0.2))
+                            .padding(.bottom, 40)
+                    }
+                    .transition(.opacity)
+            }
         }
         .animation(.easeOut(duration: 0.2), value: viewModel.controlsHidden)
         .animation(.easeOut(duration: 0.25), value: viewModel.isLoading)
+        .onChange(of: externalDisplay.isActive) { _, _ in updateAutoDim() }
+        .onChange(of: viewModel.controlsHidden) { _, _ in updateAutoDim() }
         .onAppear {
             OrientationLock.set([.portrait, .landscapeLeft, .landscapeRight])
             viewModel.bootstrap(resumeSlot: resumeSlot)
             viewModel.session?.onMenuRequested = { showMenu = true }
+            // Only take over an external display while a game is on screen.
+            ExternalDisplayManager.shared.beginSession()
+            // Playing with a controller means nobody touches the phone, so auto
+            // lock would otherwise background the app and stop emulation.
+            UIApplication.shared.isIdleTimerDisabled = true
+            updateAutoDim()
         }
         .onDisappear {
             viewModel.teardown()
+            ExternalDisplayManager.shared.endSession()
+            UIApplication.shared.isIdleTimerDisabled = false
+            screenBlanker.setAutoDimAllowed(false)
         }
         .onChange(of: scenePhase) { _, phase in
+            // Leaving the app must never strand the user with a dark panel.
+            if phase != .active { screenBlanker.restore() }
             switch phase {
             case .active: viewModel.session?.resume()
             case .inactive, .background: viewModel.session?.pause()
@@ -60,8 +90,11 @@ struct NativeEmulatorView: View {
         .onChange(of: showMenu) { _, presented in
             if presented {
                 viewModel.session?.pause()
+                // The menu is touch operated, dimming underneath it would be absurd.
+                screenBlanker.setAutoDimAllowed(false)
             } else {
                 viewModel.session?.resume()
+                updateAutoDim()
             }
         }
         .sheet(isPresented: $showMenu) {
@@ -75,6 +108,14 @@ struct NativeEmulatorView: View {
             )
             .preferredColorScheme(.dark)
         }
+    }
+
+    /// Auto dimming is allowed exactly when the game is being shown on the TV and
+    /// the touch controls are gone, which is the app's signal for "a physical
+    /// controller is in use".
+    private func updateAutoDim() {
+        let allowed = externalDisplay.isActive && viewModel.controlsHidden && !showMenu
+        screenBlanker.setAutoDimAllowed(allowed)
     }
 }
 

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorView.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorView.swift
@@ -6,8 +6,6 @@ struct NativeEmulatorView: View {
     @SwiftUI.State private var showMenu = false
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
-    @ObservedObject private var screenBlanker = PhoneScreenBlanker.shared
-    @ObservedObject private var externalDisplay = ExternalDisplayManager.shared
 
     private let resumeSlot: Int?
 
@@ -41,46 +39,19 @@ struct NativeEmulatorView: View {
                 EmulatorMenuButtonOverlay { showMenu = true }
                     .transition(.opacity)
             }
-            if screenBlanker.isBlanked {
-                // Covers everything including the menu button, so the only way
-                // out is the tap, which is also the most obvious one.
-                Color.black
-                    .ignoresSafeArea()
-                    .contentShape(Rectangle())
-                    .onTapGesture { screenBlanker.noteActivity() }
-                    .overlay(alignment: .bottom) {
-                        Text("Tap to turn the screen back on")
-                            .font(.footnote)
-                            .foregroundStyle(.white.opacity(0.2))
-                            .padding(.bottom, 40)
-                    }
-                    .transition(.opacity)
-            }
         }
         .animation(.easeOut(duration: 0.2), value: viewModel.controlsHidden)
         .animation(.easeOut(duration: 0.25), value: viewModel.isLoading)
-        .onChange(of: externalDisplay.isActive) { _, _ in updateAutoDim() }
-        .onChange(of: viewModel.controlsHidden) { _, _ in updateAutoDim() }
+        .playOnTV(areTouchControlsHidden: viewModel.controlsHidden, isMenuOpen: showMenu)
         .onAppear {
             OrientationLock.set([.portrait, .landscapeLeft, .landscapeRight])
             viewModel.bootstrap(resumeSlot: resumeSlot)
             viewModel.session?.onMenuRequested = { showMenu = true }
-            // Only take over an external display while a game is on screen.
-            ExternalDisplayManager.shared.beginSession()
-            // Playing with a controller means nobody touches the phone, so auto
-            // lock would otherwise background the app and stop emulation.
-            UIApplication.shared.isIdleTimerDisabled = true
-            updateAutoDim()
         }
         .onDisappear {
             viewModel.teardown()
-            ExternalDisplayManager.shared.endSession()
-            UIApplication.shared.isIdleTimerDisabled = false
-            screenBlanker.setAutoDimAllowed(false)
         }
         .onChange(of: scenePhase) { _, phase in
-            // Leaving the app must never strand the user with a dark panel.
-            if phase != .active { screenBlanker.restore() }
             switch phase {
             case .active: viewModel.session?.resume()
             case .inactive, .background: viewModel.session?.pause()
@@ -90,11 +61,8 @@ struct NativeEmulatorView: View {
         .onChange(of: showMenu) { _, presented in
             if presented {
                 viewModel.session?.pause()
-                // The menu is touch operated, dimming underneath it would be absurd.
-                screenBlanker.setAutoDimAllowed(false)
             } else {
                 viewModel.session?.resume()
-                updateAutoDim()
             }
         }
         .sheet(isPresented: $showMenu) {
@@ -108,14 +76,6 @@ struct NativeEmulatorView: View {
             )
             .preferredColorScheme(.dark)
         }
-    }
-
-    /// Auto dimming is allowed exactly when the game is being shown on the TV and
-    /// the touch controls are gone, which is the app's signal for "a physical
-    /// controller is in use".
-    private func updateAutoDim() {
-        let allowed = externalDisplay.isActive && viewModel.controlsHidden && !showMenu
-        screenBlanker.setAutoDimAllowed(allowed)
     }
 }
 

--- a/romm/romm/UI/Settings/ExternalDisplaySettingsView.swift
+++ b/romm/romm/UI/Settings/ExternalDisplaySettingsView.swift
@@ -4,9 +4,9 @@ import SwiftUI
 /// for changing them mid-session, this is where they can be set up beforehand.
 struct ExternalDisplaySettingsView: View {
 
-    @SwiftUI.State private var playOnTV = ExternalDisplayPreferences.isEnabled
-    @SwiftUI.State private var autoDim = ExternalDisplayPreferences.autoDimPhone
     @ObservedObject private var display = ExternalDisplayManager.shared
+    @SwiftUI.State private var playOnTV = ExternalDisplayManager.shared.isPlayOnTVEnabled
+    @SwiftUI.State private var autoDim = ExternalDisplayManager.shared.isAutoDimPhoneEnabled
 
     var body: some View {
         List {
@@ -39,7 +39,7 @@ struct ExternalDisplaySettingsView: View {
                     }
                 }
                 .onChange(of: playOnTV) { _, newValue in
-                    ExternalDisplayManager.shared.setEnabled(newValue)
+                    display.setPlayOnTVEnabled(newValue)
                 }
 
                 Toggle(isOn: $autoDim) {
@@ -51,7 +51,7 @@ struct ExternalDisplaySettingsView: View {
                     }
                 }
                 .onChange(of: autoDim) { _, newValue in
-                    ExternalDisplayPreferences.autoDimPhone = newValue
+                    display.setAutoDimPhoneEnabled(newValue)
                 }
             } header: {
                 Text("Options")

--- a/romm/rommTests/EmulatorEnginePreferenceTests.swift
+++ b/romm/rommTests/EmulatorEnginePreferenceTests.swift
@@ -8,24 +8,38 @@ struct EmulatorEnginePreferenceTests {
         return UserDefaults(suiteName: suiteName)!
     }
 
-    @Test func defaultIsWeb() {
-        let defaults = makeDefaults()
-        let pref = EmulatorEnginePreference(userDefaults: defaults)
-        #expect(pref.current == .web)
+    /// Expressed against the feature flag rather than hard coded to `.web`: the
+    /// store coerces to native in builds where the web engine is unavailable, and
+    /// TestFlight and the App Store ship the same binary.
+    private var expectedDefault: EmulatorEngine {
+        AppFeatures.webEmulatorEnabled ? .web : .native
+    }
+
+    @Test func defaultIsTheAvailableEngine() {
+        let pref = UserDefaultsEmulatorEnginePreferenceStore(userDefaults: makeDefaults())
+        #expect(pref.current == expectedDefault)
     }
 
     @Test func persistsAcrossInstances() {
         let defaults = makeDefaults()
-        let pref1 = EmulatorEnginePreference(userDefaults: defaults)
+        let pref1 = UserDefaultsEmulatorEnginePreferenceStore(userDefaults: defaults)
         pref1.current = .native
-        let pref2 = EmulatorEnginePreference(userDefaults: defaults)
+        let pref2 = UserDefaultsEmulatorEnginePreferenceStore(userDefaults: defaults)
         #expect(pref2.current == .native)
     }
 
-    @Test func unknownRawValueFallsBackToWeb() {
+    @Test func unknownRawValueFallsBack() {
         let defaults = makeDefaults()
         defaults.set("xxx", forKey: "emulator.engine.preference")
-        let pref = EmulatorEnginePreference(userDefaults: defaults)
-        #expect(pref.current == .web)
+        let pref = UserDefaultsEmulatorEnginePreferenceStore(userDefaults: defaults)
+        #expect(pref.current == expectedDefault)
+    }
+
+    /// "deltaCore" was the raw value before the rename to "native".
+    @Test func legacyRawValueStillMapsToNative() {
+        let defaults = makeDefaults()
+        defaults.set("deltaCore", forKey: "emulator.engine.preference")
+        let pref = UserDefaultsEmulatorEnginePreferenceStore(userDefaults: defaults)
+        #expect(pref.current == .native)
     }
 }

--- a/romm/rommTests/ExternalDisplayPolicyTests.swift
+++ b/romm/rommTests/ExternalDisplayPolicyTests.swift
@@ -1,0 +1,129 @@
+import Testing
+@testable import romm
+
+struct ExternalDisplayPolicyTests {
+
+    // MARK: - Taking the display over
+
+    @Test func rendersWhenConnectedDuringASessionAndEnabled() {
+        #expect(ExternalDisplayPolicy.shouldRenderExternally(
+            isDisplayConnected: true, isSessionRunning: true, isPlayOnTVEnabled: true
+        ))
+    }
+
+    /// Mirroring the library UI is the sensible default for a browsing user.
+    @Test func doesNotRenderOutsideASession() {
+        #expect(!ExternalDisplayPolicy.shouldRenderExternally(
+            isDisplayConnected: true, isSessionRunning: false, isPlayOnTVEnabled: true
+        ))
+    }
+
+    @Test func doesNotRenderWithoutADisplay() {
+        #expect(!ExternalDisplayPolicy.shouldRenderExternally(
+            isDisplayConnected: false, isSessionRunning: true, isPlayOnTVEnabled: true
+        ))
+    }
+
+    /// The opt-out has to win, that is what makes the A/B comparison in the
+    /// in-game menu work.
+    @Test func doesNotRenderWhenTurnedOff() {
+        #expect(!ExternalDisplayPolicy.shouldRenderExternally(
+            isDisplayConnected: true, isSessionRunning: true, isPlayOnTVEnabled: false
+        ))
+    }
+
+    // MARK: - Dimming the phone
+
+    @Test func dimsWhileOnTVWithAController() {
+        #expect(ExternalDisplayPolicy.shouldAutoDimPhone(
+            isRenderingExternally: true, areTouchControlsHidden: true,
+            isMenuOpen: false, isAutoDimPhoneEnabled: true
+        ))
+    }
+
+    /// Visible touch controls mean the player is holding the phone and playing on
+    /// it, so going dark would take the game away.
+    @Test func doesNotDimWhileTouchControlsAreVisible() {
+        #expect(!ExternalDisplayPolicy.shouldAutoDimPhone(
+            isRenderingExternally: true, areTouchControlsHidden: false,
+            isMenuOpen: false, isAutoDimPhoneEnabled: true
+        ))
+    }
+
+    /// The menu is operated by touch.
+    @Test func doesNotDimWithTheMenuOpen() {
+        #expect(!ExternalDisplayPolicy.shouldAutoDimPhone(
+            isRenderingExternally: true, areTouchControlsHidden: true,
+            isMenuOpen: true, isAutoDimPhoneEnabled: true
+        ))
+    }
+
+    /// Mirroring means the phone screen *is* what the TV shows, so blanking it
+    /// would blank the TV as well.
+    @Test func doesNotDimWhileOnlyMirroring() {
+        #expect(!ExternalDisplayPolicy.shouldAutoDimPhone(
+            isRenderingExternally: false, areTouchControlsHidden: true,
+            isMenuOpen: false, isAutoDimPhoneEnabled: true
+        ))
+    }
+
+    @Test func doesNotDimWhenTurnedOff() {
+        #expect(!ExternalDisplayPolicy.shouldAutoDimPhone(
+            isRenderingExternally: true, areTouchControlsHidden: true,
+            isMenuOpen: false, isAutoDimPhoneEnabled: false
+        ))
+    }
+}
+
+struct PhoneScreenBlankerTests {
+
+    private final class BrightnessSpy: PScreenBrightness {
+        var level: Double = 0.8
+    }
+
+    @MainActor
+    private func makeBlanker() -> (PhoneScreenBlanker, BrightnessSpy, InMemoryExternalDisplayPreference) {
+        let brightness = BrightnessSpy()
+        let preference = InMemoryExternalDisplayPreference()
+        return (PhoneScreenBlanker(brightness: brightness, preference: preference), brightness, preference)
+    }
+
+    @MainActor
+    @Test func blankingSavesTheOldBrightnessAndGoesDark() {
+        let (blanker, brightness, preference) = makeBlanker()
+        blanker.blank()
+        #expect(brightness.level == 0)
+        #expect(preference.blankedPhoneBrightness == 0.8)
+        #expect(blanker.isBlanked)
+    }
+
+    @MainActor
+    @Test func restoringPutsTheBrightnessBackAndClearsTheRecoveryValue() {
+        let (blanker, brightness, preference) = makeBlanker()
+        blanker.blank()
+        blanker.restore()
+        #expect(brightness.level == 0.8)
+        #expect(preference.blankedPhoneBrightness == nil)
+        #expect(!blanker.isBlanked)
+    }
+
+    /// A saved 0 can only be a bad read, and restoring to black would look like a
+    /// broken phone.
+    @MainActor
+    @Test func recoveryRefusesToRestoreToBlack() {
+        let brightness = BrightnessSpy()
+        brightness.level = 0
+        let preference = InMemoryExternalDisplayPreference()
+        preference.blankedPhoneBrightness = 0
+        let blanker = PhoneScreenBlanker(brightness: brightness, preference: preference)
+        blanker.recoverIfNeeded()
+        #expect(brightness.level == 0.5)
+    }
+
+    @MainActor
+    @Test func recoveryDoesNothingAfterACleanExit() {
+        let (blanker, brightness, _) = makeBlanker()
+        blanker.recoverIfNeeded()
+        #expect(brightness.level == 0.8)
+    }
+}

--- a/romm/rommTests/HeartbeatRepositoryTests.swift
+++ b/romm/rommTests/HeartbeatRepositoryTests.swift
@@ -18,14 +18,16 @@ struct HeartbeatRepositoryTests {
 
     // MARK: - isVersionCompatible: normale Releases
 
+    // Derived from the repository's own bounds rather than hard coded: the
+    // supported range moves with every server release these tests should survive.
     @Test func minSupportedVersionIsCompatible() {
         let repo = HeartbeatRepository()
-        #expect(repo.isVersionCompatible("4.1.0") == true)
+        #expect(repo.isVersionCompatible(repo.minSupportedServerVersion) == true)
     }
 
     @Test func maxSupportedVersionIsCompatible() {
         let repo = HeartbeatRepository()
-        #expect(repo.isVersionCompatible("4.8.1") == true)
+        #expect(repo.isVersionCompatible(repo.maxSupportedServerVersion) == true)
     }
 
     @Test func versionBelowMinIsNotCompatible() {
@@ -35,7 +37,7 @@ struct HeartbeatRepositoryTests {
 
     @Test func versionAboveMaxIsNotCompatible() {
         let repo = HeartbeatRepository()
-        #expect(repo.isVersionCompatible("4.9.0") == false)
+        #expect(repo.isVersionCompatible("99.0.0") == false)
     }
 
     @Test func prereleaseVersionStripsCorrectly() {

--- a/romm/rommTests/LaunchEmulatorUseCaseTests.swift
+++ b/romm/rommTests/LaunchEmulatorUseCaseTests.swift
@@ -13,6 +13,7 @@ private final class StubSupport: PPlatformEngineSupport {
     func preferred(for platformSlug: String) -> EmulatorEngine {
         engines.contains(.web) ? .web : .native
     }
+    func isEmulationAvailable(for platformSlug: String) -> Bool { !engines.isEmpty }
 }
 
 private final class StubTokenProvider: PTokenProvider {

--- a/romm/rommTests/PlatformEngineSupportTests.swift
+++ b/romm/rommTests/PlatformEngineSupportTests.swift
@@ -9,11 +9,13 @@ struct PlatformEngineSupportTests {
         #expect(engines.contains(.web))
     }
 
-    @Test func psxOnlySupportsWeb() {
+    /// PlayStation used to be web only. It gained a libretro core
+    /// (pcsx_rearmed), which the native engine covers alongside DeltaCore.
+    @Test func psxSupportsBothEngines() {
         let support = PlatformEngineSupport()
         let engines = support.supportedEngines(for: "psx")
         #expect(engines.contains(.web))
-        #expect(!engines.contains(.native))
+        #expect(engines.contains(.native))
     }
 
     @Test func unknownPlatformReturnsEmpty() {

--- a/romm/rommTests/ROMFileResolverTests.swift
+++ b/romm/rommTests/ROMFileResolverTests.swift
@@ -2,6 +2,20 @@ import Testing
 import Foundation
 @testable import romm
 
+/// Answers "yes" for whatever paths the test declares present, so the resolver
+/// can be exercised without touching the disk.
+private final class StubFileSystem: PFileSystemService {
+    var presentFileNames: Set<String> = []
+
+    func fileExists(at url: URL) -> Bool { presentFileNames.contains(url.lastPathComponent) }
+    func documentsDirectory() -> URL { URL(fileURLWithPath: "/tmp") }
+    func cachesDirectory() -> URL { URL(fileURLWithPath: "/tmp") }
+    func createDirectory(at url: URL, withIntermediateDirectories: Bool) throws {}
+    func contentsOfDirectory(at url: URL, skipHidden: Bool) throws -> [URL] { [] }
+    func removeItem(at url: URL) throws {}
+    func write(_ data: Data, to url: URL) throws {}
+}
+
 struct ROMFileResolverTests {
 
     private func makeROM(files: [String]) -> DownloadedROM {
@@ -9,20 +23,25 @@ struct ROMFileResolverTests {
             id: 1, name: "Test", platformName: "Game Boy Advance",
             platformSlug: "gba", downloadedAt: Date(), totalSizeBytes: 0,
             localDirectory: "rom1",
-            files: files.map { DownloadedROMFile(fileName: $0, fileSizeBytes: 0) }
+            files: files.map {
+                DownloadedROMFile(id: UUID(), fileName: $0, fileSizeBytes: 0, md5Hash: nil)
+            },
+            urlCover: nil
         )
     }
 
     @Test func picksGBAExtension() throws {
         let rom = makeROM(files: ["readme.txt", "Game.gba"])
-        let resolver = ROMFileResolver()
+        let fileSystem = StubFileSystem()
+        fileSystem.presentFileNames = ["Game.gba"]
+        let resolver = ROMFileResolver(fileSystem: fileSystem)
         let url = try resolver.resolve(rom: rom, baseURL: URL(fileURLWithPath: "/tmp"), gameType: .gba)
         #expect(url.lastPathComponent == "Game.gba")
     }
 
     @Test func throwsWhenNoMatch() {
         let rom = makeROM(files: ["readme.txt"])
-        let resolver = ROMFileResolver()
+        let resolver = ROMFileResolver(fileSystem: StubFileSystem())
         #expect(throws: ROMFileResolverError.self) {
             _ = try resolver.resolve(rom: rom, baseURL: URL(fileURLWithPath: "/tmp"), gameType: .gba)
         }


### PR DESCRIPTION
Stacked on #82, review that one first.

#82 only covered libretro, so Play on TV worked for PlayStation, PC Engine and Master System. Everything else runs on DeltaCore, so Game Boy, GBA, NES, SNES, N64, DS and Mega Drive kept mirroring the whole phone. This closes that gap.

DeltaCore is built for it, an EmulatorCore hands each frame to every GameView registered with its VideoManager, so the TV costs one more draw of an image that already exists rather than a second emulation pass. No fork or submodule change needed, the API is public.

The external view gets no filter, so the TV shows the core's framebuffer as it is. For the DS that means both screens stacked, same as what the phone shows once the touch skin is hidden. Side by side would need the skin's crop filters rebuilt and can come later if you want it.

## Then a cleanup pass

The feature worked but sat across the grain of the codebase, so the second half of this PR moves it onto the existing layers.

The two toggles were a static enum inside a UIKit file; they now follow the same path as the other four preferences, protocol in Domain, UserDefaults store in Data, in-memory double for the mock factory. The decisions moved into `ExternalDisplayPolicy`, plain functions over plain booleans, one of which existed twice because it was copied into both emulator views. Painting is now a `PExternalRenderTarget` with one implementation per backend, so the manager knows *when* the app owns the display and a target knows *how* to draw, and the native session loses its Combine subscription. Both views share a `playOnTV` modifier instead of forty duplicated lines each.

The two singletons stay, UIKit instantiates the scene delegate itself, but their collaborators are injected and the reason is in the code.

## The test target was dead

The scheme had an empty Testables block, so `xcodebuild test` refused the test action and nothing in `rommTests` had run for a while. Hooking it up surfaced three files that no longer compiled against current APIs and two assertions describing behaviour we changed on purpose, PlayStation being web only and the supported server range. Fixed, and the version bounds are now read from the repository so they stop rotting. No production code was changed to satisfy a test.

Suite is green, 14 new cases for the policy and the blanker.