### PR TITLE
fix(emulator): hide RomM 5.x navigation chrome in EmulatorJS view

### DIFF
--- a/romm/romm/UI/Emulator/EmulatorView.swift
+++ b/romm/romm/UI/Emulator/EmulatorView.swift
@@ -415,9 +415,12 @@ struct EmulatorWebView: UIViewRepresentable {
         }
 
         private func injectFullscreenCSS(_ webView: WKWebView) {
-            // CSS to hide ROMM UI elements and make emulator fullscreen
+            // CSS to hide RomM UI elements and make the emulator fullscreen.
+            // Two rule blocks cover both server generations simultaneously —
+            // a selector that matches nothing is a no-op, so both can be
+            // active at once without a version check.
             let css = """
-                /* Hide ROMM UI elements */
+                /* RomM 4.x (Vuetify-based layout) */
                 header.v-toolbar,
                 header.v-bottom-navigation,
                 nav.v-navigation-drawer,
@@ -429,8 +432,29 @@ struct EmulatorWebView: UIViewRepresentable {
                 div.sticky-bottom {
                     display: none !important;
                     visibility: hidden !important;
-                }            
+                }
+
+                /* RomM 5.x (v2 shell — AppNav top bar, BottomNav floating pill, UserMenu chip) */
+                .r-v2-nav-bar,
+                .r-v2-bottom-nav-anchor,
+                .r-v2-user {
+                    display: none !important;
+                    visibility: hidden !important;
+                }
                 """
+
+            // After injecting the styles, count how many elements were
+            // actually hidden. Zero matches means the server layout has
+            // changed again and the selectors need updating.
+            let selectorList = [
+                // 4.x selectors
+                "header.v-toolbar", "header.v-bottom-navigation",
+                "nav.v-navigation-drawer", ".v-toolbar",
+                ".v-navigation-drawer", ".v-bottom-navigation",
+                "div.my-4", "div.sticky-bottom",
+                // 5.x selectors
+                ".r-v2-nav-bar", ".r-v2-bottom-nav-anchor", ".r-v2-user",
+            ].joined(separator: ", ")
 
             let javascript = """
                 (function() {
@@ -438,9 +462,12 @@ struct EmulatorWebView: UIViewRepresentable {
                         var style = document.createElement('style');
                         style.textContent = `\(css)`;
                         document.head.appendChild(style);
-                        console.log('✅ CSS injected');
+
+                        var matched = document.querySelectorAll('\(selectorList)').length;
+                        return matched;
                     } catch(e) {
                         console.error('❌ CSS injection failed:', e);
+                        return -1;
                     }
                 })();
                 """
@@ -448,8 +475,16 @@ struct EmulatorWebView: UIViewRepresentable {
             webView.evaluateJavaScript(javascript) { result, error in
                 if let error = error {
                     self.logger.error("❌ Failed to inject CSS: \(error.localizedDescription)")
+                } else if let count = result as? Int {
+                    if count == 0 {
+                        self.logger.warning(
+                            "⚠️ CSS injected but no UI elements matched — RomM layout may have changed"
+                        )
+                    } else {
+                        self.logger.info("✅ CSS injected, \(count) UI element(s) hidden")
+                    }
                 } else {
-                    self.logger.info("✅ CSS injected successfully")
+                    self.logger.info("✅ CSS injected")
                 }
             }
         }

--- a/romm/romm/UI/Emulator/EmulatorView.swift
+++ b/romm/romm/UI/Emulator/EmulatorView.swift
@@ -414,34 +414,44 @@ struct EmulatorWebView: UIViewRepresentable {
             }
         }
 
-        /// Selectors for the RomM web chrome that is hidden so the emulator
-        /// fills the screen. Single source of truth, the CSS rule and the
-        /// match count are both derived from this list. A selector that
-        /// matches nothing is a no-op, so both server generations stay
-        /// covered at once without a version check.
-        private static let hiddenUISelectors: [String] =
-            // RomM 4.x, Vuetify-based layout
-            [
-                "header.v-toolbar",
-                "header.v-bottom-navigation",
-                "nav.v-navigation-drawer",
-                ".v-toolbar",
-                ".v-navigation-drawer",
-                ".v-bottom-navigation",
-                "div.my-4",
-                "div.mt-4.align-center > div:first-child",
-                "div.sticky-bottom",
-            ]
-            // RomM 5.x, v2 shell: AppNav top bar, BottomNav floating pill,
-            // UserMenu chip, toast host and upload progress toast. The last
-            // two can pop up mid-game, the rest is permanent chrome.
-            + [
-                ".r-v2-nav-bar",
-                ".r-v2-bottom-nav-anchor",
-                ".r-v2-user",
-                ".r-v2-toasts",
-                ".r-v2-upload",
-            ]
+        /// RomM 4.x web chrome, Vuetify-based layout.
+        private static let legacyUISelectors: [String] = [
+            "header.v-toolbar",
+            "header.v-bottom-navigation",
+            "nav.v-navigation-drawer",
+            ".v-toolbar",
+            ".v-navigation-drawer",
+            ".v-bottom-navigation",
+            "div.my-4",
+            "div.mt-4.align-center > div:first-child",
+            "div.sticky-bottom",
+        ]
+
+        /// RomM 5.x web chrome: AppNav top bar, BottomNav pill, UserMenu chip,
+        /// toast host and upload progress toast. The last two can pop up
+        /// mid-game, the rest is permanent chrome.
+        ///
+        /// Matched on a class substring rather than an exact class name,
+        /// because the shell decorates these blocks with BEM suffixes and
+        /// renames them between releases: the pill shipped as
+        /// `r-v2-bottom-nav-anchor` at one point and is plain
+        /// `r-v2-bottom-nav` now, wrapping a `r-v2-bottom-nav__group`. An
+        /// exact selector silently stops matching on such a rename, a
+        /// substring survives it.
+        private static let v2UISelectors: [String] = [
+            "[class*=\"r-v2-nav\"]",
+            "[class*=\"r-v2-bottom-nav\"]",
+            "[class*=\"r-v2-user\"]",
+            "[class*=\"r-v2-toast\"]",
+            "[class*=\"r-v2-upload\"]",
+        ]
+
+        /// Every selector that gets hidden. A selector that matches nothing is
+        /// a no-op, so both server generations stay covered at once without a
+        /// version check.
+        private static var hiddenUISelectors: [String] {
+            legacyUISelectors + v2UISelectors
+        }
 
         private func injectFullscreenCSS(_ webView: WKWebView) {
             let selectorList = Self.hiddenUISelectors.joined(separator: ", ")
@@ -470,9 +480,14 @@ struct EmulatorWebView: UIViewRepresentable {
                 }
                 """
 
-            // After injecting the styles, count how many elements were
-            // actually hidden. Zero matches means the server layout has
-            // changed again and the selectors need updating.
+            // After injecting the styles, report the match count per selector
+            // rather than one total. A selector that silently stops matching
+            // after an upstream rename is the failure mode here, and a total
+            // hides it as long as the other selectors still match.
+            let selectorsArray = Self.hiddenUISelectors
+                .map { "'\($0)'" }
+                .joined(separator: ", ")
+
             let javascript = """
                 (function() {
                     try {
@@ -480,10 +495,14 @@ struct EmulatorWebView: UIViewRepresentable {
                         style.textContent = `\(css)`;
                         document.head.appendChild(style);
 
-                        return document.querySelectorAll('\(selectorList)').length;
+                        var counts = {};
+                        [\(selectorsArray)].forEach(function(selector) {
+                            counts[selector] = document.querySelectorAll(selector).length;
+                        });
+                        return counts;
                     } catch(e) {
                         console.error('❌ CSS injection failed:', e);
-                        return -1;
+                        return null;
                     }
                 })();
                 """
@@ -491,16 +510,33 @@ struct EmulatorWebView: UIViewRepresentable {
             webView.evaluateJavaScript(javascript) { result, error in
                 if let error = error {
                     self.logger.error("❌ Failed to inject CSS: \(error.localizedDescription)")
-                } else if let count = result as? Int {
-                    if count == 0 {
-                        self.logger.warning(
-                            "⚠️ CSS injected but no UI elements matched, RomM layout may have changed"
-                        )
-                    } else {
-                        self.logger.info("✅ CSS injected, \(count) UI element(s) hidden")
-                    }
-                } else {
+                    return
+                }
+                guard let raw = result as? [String: Any] else {
                     self.logger.info("✅ CSS injected")
+                    return
+                }
+                let counts = raw.compactMapValues { ($0 as? NSNumber)?.intValue }
+                let hidden = counts.values.reduce(0, +)
+
+                if hidden == 0 {
+                    self.logger.warning(
+                        "⚠️ CSS injected but no UI elements matched, RomM layout may have changed"
+                    )
+                } else {
+                    self.logger.info("✅ CSS injected, \(hidden) UI element(s) hidden")
+                }
+
+                // Only the generation that matched something can have dead
+                // selectors worth reporting, the other one is expected to
+                // match nothing on this server.
+                let v2IsLive = Self.v2UISelectors.contains { (counts[$0] ?? 0) > 0 }
+                let live = v2IsLive ? Self.v2UISelectors : Self.legacyUISelectors
+                let dead = live.filter { (counts[$0] ?? 0) == 0 }
+                if !dead.isEmpty {
+                    self.logger.warning(
+                        "⚠️ Selectors matched nothing: \(dead.joined(separator: ", "))"
+                    )
                 }
             }
         }

--- a/romm/romm/UI/Emulator/EmulatorView.swift
+++ b/romm/romm/UI/Emulator/EmulatorView.swift
@@ -414,30 +414,36 @@ struct EmulatorWebView: UIViewRepresentable {
             }
         }
 
-        private func injectFullscreenCSS(_ webView: WKWebView) {
-            // CSS to hide RomM UI elements and make the emulator fullscreen.
-            // Two rule blocks cover both server generations simultaneously —
-            // a selector that matches nothing is a no-op, so both can be
-            // active at once without a version check.
-            let css = """
-                /* RomM 4.x (Vuetify-based layout) */
-                header.v-toolbar,
-                header.v-bottom-navigation,
-                nav.v-navigation-drawer,
-                .v-toolbar,
-                .v-navigation-drawer,
-                .v-bottom-navigation,
-                div.my-4,
-                div.mt-4.align-center > div:first-child,
-                div.sticky-bottom {
-                    display: none !important;
-                    visibility: hidden !important;
-                }
+        /// Selectors for the RomM web chrome that is hidden so the emulator
+        /// fills the screen. Single source of truth, the CSS rule and the
+        /// match count are both derived from this list. A selector that
+        /// matches nothing is a no-op, so both server generations stay
+        /// covered at once without a version check.
+        private static let hiddenUISelectors: [String] =
+            // RomM 4.x, Vuetify-based layout
+            [
+                "header.v-toolbar",
+                "header.v-bottom-navigation",
+                "nav.v-navigation-drawer",
+                ".v-toolbar",
+                ".v-navigation-drawer",
+                ".v-bottom-navigation",
+                "div.my-4",
+                "div.mt-4.align-center > div:first-child",
+                "div.sticky-bottom",
+            ]
+            // RomM 5.x, v2 shell: AppNav top bar, BottomNav floating pill, UserMenu chip
+            + [
+                ".r-v2-nav-bar",
+                ".r-v2-bottom-nav-anchor",
+                ".r-v2-user",
+            ]
 
-                /* RomM 5.x (v2 shell — AppNav top bar, BottomNav floating pill, UserMenu chip) */
-                .r-v2-nav-bar,
-                .r-v2-bottom-nav-anchor,
-                .r-v2-user {
+        private func injectFullscreenCSS(_ webView: WKWebView) {
+            let selectorList = Self.hiddenUISelectors.joined(separator: ", ")
+
+            let css = """
+                \(selectorList) {
                     display: none !important;
                     visibility: hidden !important;
                 }
@@ -446,16 +452,6 @@ struct EmulatorWebView: UIViewRepresentable {
             // After injecting the styles, count how many elements were
             // actually hidden. Zero matches means the server layout has
             // changed again and the selectors need updating.
-            let selectorList = [
-                // 4.x selectors
-                "header.v-toolbar", "header.v-bottom-navigation",
-                "nav.v-navigation-drawer", ".v-toolbar",
-                ".v-navigation-drawer", ".v-bottom-navigation",
-                "div.my-4", "div.sticky-bottom",
-                // 5.x selectors
-                ".r-v2-nav-bar", ".r-v2-bottom-nav-anchor", ".r-v2-user",
-            ].joined(separator: ", ")
-
             let javascript = """
                 (function() {
                     try {
@@ -463,8 +459,7 @@ struct EmulatorWebView: UIViewRepresentable {
                         style.textContent = `\(css)`;
                         document.head.appendChild(style);
 
-                        var matched = document.querySelectorAll('\(selectorList)').length;
-                        return matched;
+                        return document.querySelectorAll('\(selectorList)').length;
                     } catch(e) {
                         console.error('❌ CSS injection failed:', e);
                         return -1;
@@ -478,7 +473,7 @@ struct EmulatorWebView: UIViewRepresentable {
                 } else if let count = result as? Int {
                     if count == 0 {
                         self.logger.warning(
-                            "⚠️ CSS injected but no UI elements matched — RomM layout may have changed"
+                            "⚠️ CSS injected but no UI elements matched, RomM layout may have changed"
                         )
                     } else {
                         self.logger.info("✅ CSS injected, \(count) UI element(s) hidden")

--- a/romm/romm/UI/Emulator/EmulatorView.swift
+++ b/romm/romm/UI/Emulator/EmulatorView.swift
@@ -432,20 +432,41 @@ struct EmulatorWebView: UIViewRepresentable {
                 "div.mt-4.align-center > div:first-child",
                 "div.sticky-bottom",
             ]
-            // RomM 5.x, v2 shell: AppNav top bar, BottomNav floating pill, UserMenu chip
+            // RomM 5.x, v2 shell: AppNav top bar, BottomNav floating pill,
+            // UserMenu chip, toast host and upload progress toast. The last
+            // two can pop up mid-game, the rest is permanent chrome.
             + [
                 ".r-v2-nav-bar",
                 ".r-v2-bottom-nav-anchor",
                 ".r-v2-user",
+                ".r-v2-toasts",
+                ".r-v2-upload",
             ]
 
         private func injectFullscreenCSS(_ webView: WKWebView) {
             let selectorList = Self.hiddenUISelectors.joined(separator: ", ")
 
+            // Hiding the chrome is not enough on RomM 5.x: the EmulatorJS
+            // stage is laid out as `inset: var(--r-nav-h) 0 0 0`, so it
+            // still starts below where the navbar used to be and leaves an
+            // empty strip at the top. Zeroing the variable closes that gap.
+            // RomM declares it on `.r-v2`, a class it toggles on <html>, so
+            // `:root` and `.r-v2` are the same element and !important wins.
+            // Both are listed in case the class ever moves off the root.
+            // This override is deliberately kept out of the selector list
+            // above, it assigns a variable rather than hiding an element and
+            // must not affect the match count.
+            // Upstream has no fullscreen mode or URL parameter for this,
+            // see rommapp/romm#4081.
             let css = """
                 \(selectorList) {
                     display: none !important;
                     visibility: hidden !important;
+                }
+
+                :root,
+                .r-v2 {
+                    --r-nav-h: 0px !important;
                 }
                 """
 


### PR DESCRIPTION
RomM 5.x rebuilt its frontend as a "v2 shell" with new class names, so the existing Vuetify selectors no longer matched anything, leaving the top bar, floating bottom pill, and user chip visible during emulation.

Adds the v2 CSS selectors (`.r-v2-nav-bar`, `.r-v2-bottom-nav-anchor`, `.r-v2-user`) alongside the existing 4.x ones. Both sets stay active at all times — unmatched selectors are harmless, so no version check is needed. Also logs a warning when zero elements are hidden, so a future layout change won't go unnoticed.

Closes #87