### PR TITLE
fix(emulator): prevent crash when tearing down an unstarted core

### DIFF
--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -148,6 +148,9 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     /// Reports whether the on-screen touch controls are currently hidden, so the
     /// SwiftUI layer can show a standalone menu button in their place.
     var onControlsHiddenChanged: ((Bool) -> Void)?
+    /// Called on the main actor when `startEmulation()` returns false, so the
+    /// view can surface an error instead of silently disappearing.
+    var onLaunchFailed: ((String) -> Void)?
 
     let viewController: GameViewController
 
@@ -217,7 +220,11 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
             guard let self else { return }
             await self.cloudSync?.pullBeforeLaunch()
             self.loadBatteryIfAvailable()
-            self.viewController.startEmulation()
+            let started = self.viewController.startEmulation()
+            guard started else {
+                self.onLaunchFailed?("Failed to start the emulator. The ROM file may be unsupported or corrupted.")
+                return
+            }
             self.attachExternalControllers()
             self.observeControllerConnections()
             self.registerExternalRenderTarget()
@@ -466,7 +473,11 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     }
 
     private func flushBattery() {
-        emulatorCore?.save()
+        // Only flush when the core actually ran. If the core is still in
+        // .stopped (e.g. the game failed to launch), the bridge's internal
+        // storage is uninitialised and calling save() causes EXC_BAD_ACCESS.
+        guard let core = emulatorCore, core.state != .stopped else { return }
+        core.save()
         let savURL = Game(fileURL: gameURL, type: gameType).gameSaveURL
         if let data = try? Data(contentsOf: savURL) {
             try? saveStates.writeBattery(romId: romId, data: data)

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -148,9 +148,6 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     /// Reports whether the on-screen touch controls are currently hidden, so the
     /// SwiftUI layer can show a standalone menu button in their place.
     var onControlsHiddenChanged: ((Bool) -> Void)?
-    /// Called on the main actor when `startEmulation()` returns false, so the
-    /// view can surface an error instead of silently disappearing.
-    var onLaunchFailed: ((String) -> Void)?
 
     let viewController: GameViewController
 
@@ -220,11 +217,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
             guard let self else { return }
             await self.cloudSync?.pullBeforeLaunch()
             self.loadBatteryIfAvailable()
-            let started = self.viewController.startEmulation()
-            guard started else {
-                self.onLaunchFailed?("Failed to start the emulator. The ROM file may be unsupported or corrupted.")
-                return
-            }
+            self.viewController.startEmulation()
             self.attachExternalControllers()
             self.observeControllerConnections()
             self.registerExternalRenderTarget()
@@ -473,9 +466,13 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     }
 
     private func flushBattery() {
-        // Only flush when the core actually ran. If the core is still in
-        // .stopped (e.g. the game failed to launch), the bridge's internal
-        // storage is uninitialised and calling save() causes EXC_BAD_ACCESS.
+        // Covers the case where the view disappears before the async start task
+        // even reaches `startEmulation()`: the core is still .stopped, the
+        // bridge never allocated its cart save storage, and save() would
+        // dereference NULL (EXC_BAD_ACCESS in N64/GPGX `saveGameSaveToURL:`).
+        // Does not cover a core that did start but whose bridge failed to set
+        // up that storage, since `EmulatorCore.start()` flips the state to
+        // .running before it calls into the bridge.
         guard let core = emulatorCore, core.state != .stopped else { return }
         core.save()
         let savURL = Game(fileURL: gameURL, type: gameType).gameSaveURL

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -466,13 +466,8 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     }
 
     private func flushBattery() {
-        // Covers the case where the view disappears before the async start task
-        // even reaches `startEmulation()`: the core is still .stopped, the
-        // bridge never allocated its cart save storage, and save() would
-        // dereference NULL (EXC_BAD_ACCESS in N64/GPGX `saveGameSaveToURL:`).
-        // Does not cover a core that did start but whose bridge failed to set
-        // up that storage, since `EmulatorCore.start()` flips the state to
-        // .running before it calls into the bridge.
+        // If the view disappears before startEmulation() runs, the core is still
+        // .stopped and save() dereferences NULL (EXC_BAD_ACCESS in N64/GPGX).
         guard let core = emulatorCore, core.state != .stopped else { return }
         core.save()
         let savURL = Game(fileURL: gameURL, type: gameType).gameSaveURL

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
@@ -79,6 +79,10 @@ final class NativeEmulatorViewModel {
             session?.onControlsHiddenChanged = { [weak self] hidden in
                 self?.controlsHidden = hidden
             }
+            session?.onLaunchFailed = { [weak self] message in
+                self?.errorMessage = message
+                self?.isLoading = false
+            }
             // The session sequences the resume-load after emulation is live and
             // performs it while paused (see NativeEmulatorSession.start).
             session?.start(resumeSlot: resumeSlot)

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
@@ -79,10 +79,6 @@ final class NativeEmulatorViewModel {
             session?.onControlsHiddenChanged = { [weak self] hidden in
                 self?.controlsHidden = hidden
             }
-            session?.onLaunchFailed = { [weak self] message in
-                self?.errorMessage = message
-                self?.isLoading = false
-            }
             // The session sequences the resume-load after emulation is live and
             // performs it while paused (see NativeEmulatorSession.start).
             session?.start(resumeSlot: resumeSlot)


### PR DESCRIPTION
When the view disappears before the async start task reaches startEmulation(), the core is still .stopped and the N64/GPGX bridge has not allocated its cart save storage, so teardown() -> flushBattery() -> core.save() dereferences NULL and crashes.

flushBattery() now skips the save while the core is .stopped. This does not cover a core that did start but whose bridge failed to set up that storage, since EmulatorCore.start() flips the state to .running before calling into the bridge. Reporting such a failed launch to the user needs a signal DeltaCore does not currently expose, tracked in #92.

Closes #88