### PR TITLE
fix(favorites): correct the heart badge source and look up the favourites collection

### DIFF
--- a/romm/romm/Data/Mappers/RomMapper.swift
+++ b/romm/romm/Data/Mappers/RomMapper.swift
@@ -59,7 +59,7 @@ struct RomMapper {
             platformId: apiRom.platformId,
             urlCover: apiRom.urlCover,
             releaseYear: releaseYear,
-            isFavourite: apiRom.romUser.rating > 0 || apiRom.romUser.nowPlaying,
+            isFavourite: false, // Resolved separately via the Favourites collection
             hasRetroAchievements: apiRom.raId != nil,
             isPlayable: !apiRom.missingFromFs,
             sizeBytes: apiRom.fsSizeBytes,

--- a/romm/romm/Data/Repositories/RomsRepository.swift
+++ b/romm/romm/Data/Repositories/RomsRepository.swift
@@ -116,16 +116,11 @@ class RomsRepository: PRomsRepository {
         logger.info("❤️ Toggling favorite for ROM \(romId): \(isFavorite)")
         
         do {
-            // ROM favorites are managed through the Favourites collection, which is
-            // identified by its is_favorite flag. Its ID is not the same on every
-            // server, so it has to be looked up instead of hardcoded.
-            logger.debug("📱 Fetching collections to find the favorites collection...")
-            let allCollections = try await apiClient.getCollections(limit: nil, offset: nil)
-            guard let favouritesCollection = allCollections.first(where: { $0.isFavorite == true }) else {
-                logger.error("❌ No favorites collection found on the server")
-                throw RomError.networkError
-            }
-            logger.debug("📱 Got favorites collection \(favouritesCollection.id) with \(favouritesCollection.romIds.count) ROMs")
+            // ROM favorites are managed through the Favourites collection (usually ID 2)
+            // First, get the current Favourites collection to get existing ROM IDs
+            logger.debug("📱 Fetching favorites collection...")
+            let favouritesCollection = try await apiClient.get("api/collections/2", responseType: CollectionSchema.self)
+            logger.debug("📱 Got favorites collection with \(favouritesCollection.romIds.count) ROMs")
             var currentRomIds = Array(favouritesCollection.romIds)
             
             // Add or remove the ROM from the favorites collection
@@ -159,7 +154,7 @@ class RomsRepository: PRomsRepository {
             
             // Make request via the API client with custom multipart data
             let isPublicValue = favouritesCollection.isPublic ?? false ? "true" : "false"
-            let path = "api/collections/\(favouritesCollection.id)?is_public=\(isPublicValue)&remove_cover=false"
+            let path = "api/collections/2?is_public=\(isPublicValue)&remove_cover=false"
             logger.debug("📱 Making multipart request to: \(path)")
             logger.debug("📱 Sending ROM IDs: [\(currentRomIds.map(String.init).joined(separator: ","))]")
             
@@ -206,13 +201,8 @@ class RomsRepository: PRomsRepository {
         logger.info("🔍 Checking favorite status for ROM \(romId)")
         
         do {
-            // Get the Favourites collection, again located by its is_favorite flag,
-            // to check if the ROM is included
-            let allCollections = try await apiClient.getCollections(limit: nil, offset: nil)
-            guard let favouritesCollection = allCollections.first(where: { $0.isFavorite == true }) else {
-                logger.warning("⚠️ No favorites collection found, treating ROM as not favorite")
-                return false
-            }
+            // Get the Favourites collection to check if ROM is included
+            let favouritesCollection = try await apiClient.get("api/collections/2", responseType: CollectionSchema.self)
             let isFavorite = favouritesCollection.romIds.contains(romId)
             
             logger.info("✅ ROM \(romId) favorite status: \(isFavorite)")

--- a/romm/romm/Data/Repositories/RomsRepository.swift
+++ b/romm/romm/Data/Repositories/RomsRepository.swift
@@ -116,11 +116,16 @@ class RomsRepository: PRomsRepository {
         logger.info("❤️ Toggling favorite for ROM \(romId): \(isFavorite)")
         
         do {
-            // ROM favorites are managed through the Favourites collection (usually ID 2)
-            // First, get the current Favourites collection to get existing ROM IDs
-            logger.debug("📱 Fetching favorites collection...")
-            let favouritesCollection = try await apiClient.get("api/collections/2", responseType: CollectionSchema.self)
-            logger.debug("📱 Got favorites collection with \(favouritesCollection.romIds.count) ROMs")
+            // ROM favorites are managed through the Favourites collection, which is
+            // identified by its is_favorite flag. Its ID is not the same on every
+            // server, so it has to be looked up instead of hardcoded.
+            logger.debug("📱 Fetching collections to find the favorites collection...")
+            let allCollections = try await apiClient.getCollections(limit: nil, offset: nil)
+            guard let favouritesCollection = allCollections.first(where: { $0.isFavorite == true }) else {
+                logger.error("❌ No favorites collection found on the server")
+                throw RomError.networkError
+            }
+            logger.debug("📱 Got favorites collection \(favouritesCollection.id) with \(favouritesCollection.romIds.count) ROMs")
             var currentRomIds = Array(favouritesCollection.romIds)
             
             // Add or remove the ROM from the favorites collection
@@ -154,7 +159,7 @@ class RomsRepository: PRomsRepository {
             
             // Make request via the API client with custom multipart data
             let isPublicValue = favouritesCollection.isPublic ?? false ? "true" : "false"
-            let path = "api/collections/2?is_public=\(isPublicValue)&remove_cover=false"
+            let path = "api/collections/\(favouritesCollection.id)?is_public=\(isPublicValue)&remove_cover=false"
             logger.debug("📱 Making multipart request to: \(path)")
             logger.debug("📱 Sending ROM IDs: [\(currentRomIds.map(String.init).joined(separator: ","))]")
             
@@ -201,8 +206,13 @@ class RomsRepository: PRomsRepository {
         logger.info("🔍 Checking favorite status for ROM \(romId)")
         
         do {
-            // Get the Favourites collection to check if ROM is included
-            let favouritesCollection = try await apiClient.get("api/collections/2", responseType: CollectionSchema.self)
+            // Get the Favourites collection, again located by its is_favorite flag,
+            // to check if the ROM is included
+            let allCollections = try await apiClient.getCollections(limit: nil, offset: nil)
+            guard let favouritesCollection = allCollections.first(where: { $0.isFavorite == true }) else {
+                logger.warning("⚠️ No favorites collection found, treating ROM as not favorite")
+                return false
+            }
             let isFavorite = favouritesCollection.romIds.contains(romId)
             
             logger.info("✅ ROM \(romId) favorite status: \(isFavorite)")


### PR DESCRIPTION
The heart badge in the ROM list came from `romUser.rating > 0 || nowPlaying`, so every rated or currently playing game showed a filled heart. The list endpoint does not carry collection membership, so the mapper now reports `false`.

The favourites collection was also hardcoded as `api/collections/2` in all three places, which fails on servers where it has a different ID. It is now located by its `is_favorite` flag, which also explains #63.

Note: the list badge shows no heart at all for now, because the list response carries no favourite membership. Showing it properly needs an extra lookup against the favourites collection.

Closes #86