### PR TITLE
fix(favorites): restore heart badge in lists via FavouritesStore

### DIFF
--- a/romm/romm/Data/Services/FavouritesStore.swift
+++ b/romm/romm/Data/Services/FavouritesStore.swift
@@ -1,0 +1,78 @@
+//
+//  FavouritesStore.swift
+//  romm
+//
+
+import Foundation
+import Observation
+
+/// App-wide cache of favourite ROM IDs, loaded once from the server and kept in
+/// sync when the user toggles a favourite. Views read this directly so that the
+/// heart badge in list cards reflects the real server state without every list
+/// view having to manage its own favourites fetch.
+///
+/// Usage pattern mirrors DownloadQueueManager: share as `.shared`, observe in
+/// SwiftUI views, mutate via `setFavourite(_:isFavourite:)`.
+@Observable
+@MainActor
+final class FavouritesStore {
+    static let shared = FavouritesStore()
+
+    /// IDs of all ROMs that are in the Favourites collection.
+    private(set) var favouriteIds: Set<Int> = []
+
+    /// True while the initial fetch is in progress.
+    private(set) var isLoading: Bool = false
+
+    private var hasFetched: Bool = false
+
+    private let apiClient: PRommAPIClient
+    private let logger = Logger.data
+
+    init(apiClient: PRommAPIClient = RommAPIClient.shared) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Public API
+
+    /// Returns whether a given ROM is marked as favourite according to the cached set.
+    func isFavourite(romId: Int) -> Bool {
+        favouriteIds.contains(romId)
+    }
+
+    /// Fetches the Favourites collection from the server and refreshes the cache.
+    /// Safe to call multiple times: subsequent calls while a fetch is in progress
+    /// are no-ops, and a force refresh skips the guard.
+    func refresh(force: Bool = false) async {
+        guard !isLoading else { return }
+        guard force || !hasFetched else { return }
+
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let collections = try await apiClient.getCollections(limit: nil, offset: nil)
+            if let favouritesCollection = collections.first(where: { $0.isFavorite == true }) {
+                favouriteIds = favouritesCollection.romIds
+                logger.info("FavouritesStore: loaded \(favouriteIds.count) favourite ROM IDs from collection \(favouritesCollection.id)")
+            } else {
+                favouriteIds = []
+                logger.info("FavouritesStore: no Favourites collection found on server")
+            }
+            hasFetched = true
+        } catch {
+            logger.error("FavouritesStore: failed to load favourites - \(error)")
+        }
+    }
+
+    /// Optimistically updates the local cache after the user toggles a favourite.
+    /// Call this after a successful `toggleRomFavorite` API call so the badge
+    /// updates instantly without waiting for a full refresh.
+    func setFavourite(_ romId: Int, isFavourite: Bool) {
+        if isFavourite {
+            favouriteIds.insert(romId)
+        } else {
+            favouriteIds.remove(romId)
+        }
+    }
+}

--- a/romm/romm/UI/App/MainTabView.swift
+++ b/romm/romm/UI/App/MainTabView.swift
@@ -57,6 +57,11 @@ struct MainTabView: View {
                 .id(flight.id)
             }
         }
+        .onAppear {
+            Task {
+                await FavouritesStore.shared.refresh()
+            }
+        }
     }
 }
 

--- a/romm/romm/UI/Platforms/PlatformDetailView.swift
+++ b/romm/romm/UI/Platforms/PlatformDetailView.swift
@@ -480,20 +480,21 @@ struct TableRomRowView: View {
 
 struct RomStatusIcons: View {
     let rom: Rom
-    
+    private var store: FavouritesStore { FavouritesStore.shared }
+
     var body: some View {
         HStack(spacing: 4) {
-            if rom.isFavourite {
+            if store.isFavourite(romId: rom.id) {
                 Image(systemName: "heart.fill")
                     .foregroundColor(.red)
                     .font(.caption)
             }
-            
+
             if rom.hasRetroAchievements {
                 Image(systemName: "star.fill")
                     .foregroundColor(.yellow)
                     .font(.caption)
-            }                        
+            }
         }
     }
 }

--- a/romm/romm/UI/RomDetail/RomDetailViewModel.swift
+++ b/romm/romm/UI/RomDetail/RomDetailViewModel.swift
@@ -159,8 +159,9 @@ class RomDetailViewModel {
 
                 logger.info("Successfully toggled favorite state")
 
-                // Update the actual favorite status
+                // Update the actual favorite status and the app-wide cache
                 actualFavoriteStatus = newFavoriteState
+                FavouritesStore.shared.setFavourite(romId, isFavourite: newFavoriteState)
 
                 // Also update the romDetails if available
                 if let romDetails = romDetails {

--- a/romm/romm/UI/Shared/Components/BigRomCardView.swift
+++ b/romm/romm/UI/Shared/Components/BigRomCardView.swift
@@ -33,6 +33,8 @@ struct BigRomCardView: View {
     let rom: Rom
     let platform: Platform?
 
+    private var store: FavouritesStore { FavouritesStore.shared }
+
     // N64 covers are typically taller/narrower, so we use .fit to prevent overflow
     private var coverContentMode: ContentMode {
         rom.platformSlug?.lowercased() == "n64" ? .fit : .fill
@@ -77,7 +79,7 @@ struct BigRomCardView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                 
                 // Favorite badge - top right
-                if rom.isFavourite {
+                if store.isFavourite(romId: rom.id) {
                     Image(systemName: "heart.fill")
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(.white)


### PR DESCRIPTION
After the mapper fix in #91, `isFavourite` is always false, so no badge ever shows. This adds `FavouritesStore`, an `@Observable @MainActor` singleton that loads the favourite ROM IDs from the Favourites collection once on login and keeps them in sync when the user toggles. `RomStatusIcons` and `BigRomCardView` read from the store, covering all four list surfaces (Platform, Collection, Search, Home) at once.

Toggling in the detail view updates the store optimistically, so the badge reflects the new state immediately on back-navigation.

Closes #93