### PR TITLE
Create the favourites collection when it is missing

### DIFF
--- a/romm/romm/Data/API/RommAPIClient+Collections.swift
+++ b/romm/romm/Data/API/RommAPIClient+Collections.swift
@@ -29,16 +29,20 @@ extension RommAPIClient {
         return try await get("api/collections/virtual/\(id)", responseType: VirtualCollectionSchema.self)
     }
 
+    /// Creates a collection. `is_public` and `is_favorite` are query parameters on this
+    /// endpoint rather than multipart fields. `is_favorite` can only be set here, because
+    /// PUT /api/collections/{id} does not accept it.
     func createCollection(
         name: String,
         description: String,
         isPublic: Bool,
+        isFavorite: Bool = false,
         artwork: URL? = nil
     ) async throws -> CollectionSchema {
-        logger.info("🚀 Creating collection - name: '\(name)', isPublic: \(isPublic)")
+        logger.info("🚀 Creating collection - name: '\(name)', isPublic: \(isPublic), isFavorite: \(isFavorite)")
         return try await createOrUpdateCollection(
             method: .post,
-            path: "api/collections",
+            path: "api/collections?is_public=\(isPublic)&is_favorite=\(isFavorite)",
             name: name,
             description: description,
             romIds: nil,
@@ -68,6 +72,29 @@ extension RommAPIClient {
     func deleteCollection(id: Int) async throws -> String {
         let data = try await delete("api/collections/\(id)")
         return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    /// Adds ROMs to a collection without touching the ones already in it. Preferred over
+    /// updateCollection, which replaces the whole ROM list and therefore loses concurrent
+    /// changes made from another client.
+    func addRomsToCollection(id: Int, romIds: [Int]) async throws -> CollectionSchema {
+        logger.info("➕ Adding \(romIds.count) ROM(s) to collection \(id)")
+        return try await makeRequest(
+            path: "api/collections/\(id)/roms",
+            method: .post,
+            body: try JSONEncoder().encode(CollectionRomsPayload(romIds: romIds)),
+            responseType: CollectionSchema.self
+        )
+    }
+
+    func removeRomsFromCollection(id: Int, romIds: [Int]) async throws -> CollectionSchema {
+        logger.info("➖ Removing \(romIds.count) ROM(s) from collection \(id)")
+        return try await makeRequest(
+            path: "api/collections/\(id)/roms",
+            method: .delete,
+            body: try JSONEncoder().encode(CollectionRomsPayload(romIds: romIds)),
+            responseType: CollectionSchema.self
+        )
     }
 
     // MARK: - Private Helper
@@ -137,6 +164,16 @@ extension RommAPIClient {
         } catch {
             throw APIClientError.networkError(error)
         }
+    }
+}
+
+// MARK: - Request Payloads
+
+private struct CollectionRomsPayload: Encodable {
+    let romIds: [Int]
+
+    enum CodingKeys: String, CodingKey {
+        case romIds = "rom_ids"
     }
 }
 

--- a/romm/romm/Data/API/RommAPIClient.swift
+++ b/romm/romm/Data/API/RommAPIClient.swift
@@ -61,9 +61,12 @@ protocol PRommAPIClient {
     func getCollection(id: Int) async throws -> CollectionSchema
     func getVirtualCollections(type: String, limit: Int?) async throws -> [VirtualCollectionSchema]
     func getVirtualCollection(id: String) async throws -> VirtualCollectionSchema
-    func createCollection(name: String, description: String, isPublic: Bool, artwork: URL?) async throws -> CollectionSchema
+    func createCollection(name: String, description: String, isPublic: Bool, isFavorite: Bool, artwork: URL?) async throws -> CollectionSchema
     func updateCollection(id: Int, name: String, description: String, isPublic: Bool, romIds: [Int]?, artwork: URL?) async throws -> CollectionSchema
     func deleteCollection(id: Int) async throws -> String
+    func addRomsToCollection(id: Int, romIds: [Int]) async throws -> CollectionSchema
+    func removeRomsFromCollection(id: Int, romIds: [Int]) async throws -> CollectionSchema
+    func getCurrentUser() async throws -> UserSchema
 
     // Platforms API Wrapper methods
     func getPlatforms() async throws -> [PlatformSchema]

--- a/romm/romm/Data/Repositories/CollectionsRepository.swift
+++ b/romm/romm/Data/Repositories/CollectionsRepository.swift
@@ -88,6 +88,7 @@ class CollectionsRepository: PCollectionsRepository {
                 name: data.name,
                 description: data.description,
                 isPublic: data.isPublic,
+                isFavorite: false,
                 artwork: data.artworkURL
             )
             

--- a/romm/romm/Data/Repositories/RomsRepository.swift
+++ b/romm/romm/Data/Repositories/RomsRepository.swift
@@ -116,56 +116,20 @@ class RomsRepository: PRomsRepository {
         logger.info("❤️ Toggling favorite for ROM \(romId): \(isFavorite)")
         
         do {
-            // ROM favorites are managed through the Favourites collection (usually ID 2)
-            // First, get the current Favourites collection to get existing ROM IDs
-            logger.debug("📱 Fetching favorites collection...")
-            let favouritesCollection = try await apiClient.get("api/collections/2", responseType: CollectionSchema.self)
-            logger.debug("📱 Got favorites collection with \(favouritesCollection.romIds.count) ROMs")
-            var currentRomIds = Array(favouritesCollection.romIds)
-            
-            // Add or remove the ROM from the favorites collection
-            if isFavorite {
-                if !currentRomIds.contains(romId) {
-                    currentRomIds.append(romId)
-                }
-            } else {
-                currentRomIds.removeAll { $0 == romId }
+            let collection = isFavorite
+                ? try await favouritesCollection()
+                : try await findFavouritesCollection()
+
+            guard let collection else {
+                // Nothing to remove the ROM from, so the desired state is already reached.
+                logger.info("✅ No favourites collection, ROM \(romId) is not a favourite anyway")
+                return
             }
-            
-            // Create multipart form data manually
-            let boundary = "----RommAppBoundary\(UUID().uuidString)"
-            var formData = Data()
-            
-            // Helper function to add form field
-            func addFormField(_ name: String, _ value: String) {
-                formData.append("--\(boundary)\r\n".data(using: .utf8)!)
-                formData.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
-                formData.append("\(value)\r\n".data(using: .utf8)!)
-            }
-            
-            // Add form fields
-            addFormField("name", favouritesCollection.name)
-            addFormField("description", favouritesCollection.description ?? "")
-            addFormField("url_cover", favouritesCollection.urlCover ?? "")
-            addFormField("rom_ids", "[\(currentRomIds.map(String.init).joined(separator: ","))]")
-            
-            // Close boundary
-            formData.append("--\(boundary)--\r\n".data(using: .utf8)!)
-            
-            // Make request via the API client with custom multipart data
-            let isPublicValue = favouritesCollection.isPublic ?? false ? "true" : "false"
-            let path = "api/collections/2?is_public=\(isPublicValue)&remove_cover=false"
-            logger.debug("📱 Making multipart request to: \(path)")
-            logger.debug("📱 Sending ROM IDs: [\(currentRomIds.map(String.init).joined(separator: ","))]")
-            
-            _ = try await apiClient.multipartRequest(
-                path: path,
-                method: .put,
-                boundary: boundary,
-                formData: formData,
-                additionalHeaders: nil
-            )
-            
+
+            _ = isFavorite
+                ? try await apiClient.addRomsToCollection(id: collection.id, romIds: [romId])
+                : try await apiClient.removeRomsFromCollection(id: collection.id, romIds: [romId])
+
             logger.info("✅ ROM favorite toggled: \(romId)")
         } catch {
             logger.error("❌ Error toggling ROM favorite: \(error)")
@@ -201,9 +165,11 @@ class RomsRepository: PRomsRepository {
         logger.info("🔍 Checking favorite status for ROM \(romId)")
         
         do {
-            // Get the Favourites collection to check if ROM is included
-            let favouritesCollection = try await apiClient.get("api/collections/2", responseType: CollectionSchema.self)
-            let isFavorite = favouritesCollection.romIds.contains(romId)
+            guard let collection = try await findFavouritesCollection() else {
+                logger.info("ℹ️ No favourites collection yet, treating ROM as not favourite")
+                return false
+            }
+            let isFavorite = collection.romIds.contains(romId)
             
             logger.info("✅ ROM \(romId) favorite status: \(isFavorite)")
             return isFavorite
@@ -257,5 +223,36 @@ class RomsRepository: PRomsRepository {
         
         logger.info("🔍 Legacy Search completed: found \(response.roms.count) ROMs out of \(response.total) total matches")
         return response.roms
+    }
+
+    // MARK: - Favourites Collection
+
+    /// Finds the user's own favourites collection, identified by the `is_favorite` flag.
+    /// The collection has no fixed ID, so it cannot be hardcoded. The owner has to be
+    /// checked as well, because the endpoint also returns other users' public collections
+    /// and writing to one of those fails with a permission error.
+    private func findFavouritesCollection() async throws -> CollectionSchema? {
+        let currentUserId = try await apiClient.getCurrentUser().id
+        let collections = try await apiClient.getCollections(limit: nil, offset: nil)
+        return collections.first { $0.isFavorite == true && $0.userId == currentUserId }
+    }
+
+    /// Same as `findFavouritesCollection`, but creates the collection when it is missing.
+    /// RomM never creates it on its own, neither during setup nor when a user is added, so
+    /// the first favourite has to. The name matches the one the web frontend uses so both
+    /// clients end up on the same collection.
+    private func favouritesCollection() async throws -> CollectionSchema {
+        if let existing = try await findFavouritesCollection() {
+            return existing
+        }
+
+        logger.info("❤️ No favourites collection on the server yet, creating one")
+        return try await apiClient.createCollection(
+            name: "Favorites",
+            description: "",
+            isPublic: false,
+            isFavorite: true,
+            artwork: nil
+        )
     }
 }

--- a/romm/rommTests/RomsRepositoryFavouritesTests.swift
+++ b/romm/rommTests/RomsRepositoryFavouritesTests.swift
@@ -1,0 +1,272 @@
+import Testing
+import Foundation
+@testable import romm
+
+/// Serves canned collections and records the favourite-related writes, so the
+/// repository's lookup/create logic can be exercised without a server.
+private final class FakeAPIClient: PRommAPIClient {
+    var collectionsToReturn: [CollectionSchema] = []
+    var currentUserId: Int = 1
+    var errorToThrow: Error?
+
+    var createCollectionCallCount = 0
+    var createdCollectionNames: [String] = []
+    var createdCollectionIsPublic: [Bool] = []
+    var createdCollectionIsFavorite: [Bool] = []
+    /// Id handed back by `createCollection`, so tests can assert the ROM lands in the new collection.
+    var createdCollectionId = 99
+
+    var addedRoms: [(collectionId: Int, romIds: [Int])] = []
+    var removedRoms: [(collectionId: Int, romIds: [Int])] = []
+
+    // MARK: - Favourites relevant
+
+    func getCurrentUser() async throws -> UserSchema {
+        if let errorToThrow { throw errorToThrow }
+        return makeUser(id: currentUserId)
+    }
+
+    func getCollections(limit: Int?, offset: Int?) async throws -> [CollectionSchema] {
+        if let errorToThrow { throw errorToThrow }
+        return collectionsToReturn
+    }
+
+    func createCollection(name: String, description: String, isPublic: Bool, isFavorite: Bool, artwork: URL?) async throws -> CollectionSchema {
+        if let errorToThrow { throw errorToThrow }
+        createCollectionCallCount += 1
+        createdCollectionNames.append(name)
+        createdCollectionIsPublic.append(isPublic)
+        createdCollectionIsFavorite.append(isFavorite)
+        return makeCollection(id: createdCollectionId, userId: currentUserId, isFavorite: isFavorite, name: name)
+    }
+
+    func addRomsToCollection(id: Int, romIds: [Int]) async throws -> CollectionSchema {
+        if let errorToThrow { throw errorToThrow }
+        addedRoms.append((collectionId: id, romIds: romIds))
+        return makeCollection(id: id, userId: currentUserId, isFavorite: true, romIds: Set(romIds))
+    }
+
+    func removeRomsFromCollection(id: Int, romIds: [Int]) async throws -> CollectionSchema {
+        if let errorToThrow { throw errorToThrow }
+        removedRoms.append((collectionId: id, romIds: romIds))
+        return makeCollection(id: id, userId: currentUserId, isFavorite: true)
+    }
+
+    // MARK: - Unused
+
+    func makeRequest<T: Codable>(path: String, method: HTTPMethod, body: Data?, responseType: T.Type) async throws -> T { fatalError("not used in these tests") }
+    func makeRequest(path: String, method: HTTPMethod, body: Data?) async throws -> Data { fatalError("not used in these tests") }
+    func downloadFile(path: String, progressHandler: ((Int64, Int64) -> Void)?) async throws -> URL { fatalError("not used in these tests") }
+    func multipartRequest(path: String, method: HTTPMethod, boundary: String, formData: Data, additionalHeaders: [String: String]?) async throws -> Data { fatalError("not used in these tests") }
+    func get<T: Codable>(_ path: String, responseType: T.Type) async throws -> T { fatalError("not used in these tests") }
+    func get(_ path: String) async throws -> Data { fatalError("not used in these tests") }
+    func getBinary(_ path: String) async throws -> Data { fatalError("not used in these tests") }
+    func post<RequestBody: Codable, ResponseType: Codable>(_ path: String, body: RequestBody, responseType: ResponseType.Type) async throws -> ResponseType { fatalError("not used in these tests") }
+    func post(_ path: String, body: Data?) async throws -> Data { fatalError("not used in these tests") }
+    func put<RequestBody: Codable, ResponseType: Codable>(_ path: String, body: RequestBody, responseType: ResponseType.Type) async throws -> ResponseType { fatalError("not used in these tests") }
+    func put<RequestBody: Codable>(_ path: String, body: RequestBody) async throws -> Data { fatalError("not used in these tests") }
+    func put(_ path: String, body: Data?) async throws -> Data { fatalError("not used in these tests") }
+    func delete(_ path: String) async throws -> Data { fatalError("not used in these tests") }
+    func getRomManual(romId: Int) async throws -> Manual? { fatalError("not used in these tests") }
+    func getManualPDFData(manualURL: String) async throws -> Data { fatalError("not used in these tests") }
+    func getRomDetails(id: Int) async throws -> DetailedRomSchema { fatalError("not used in these tests") }
+    func getRoms(searchTerm: String?, platformId: Int?, limit: Int) async throws -> CustomLimitOffsetPageSimpleRomSchema { fatalError("not used in these tests") }
+    func getRomsWithFilters(searchTerm: String?, platformId: Int?, collectionId: Int?, limit: Int, offset: Int?, withCharIndex: Bool?, orderBy: String?, orderDir: String?, filters: RomFilters) async throws -> CustomLimitOffsetPageSimpleRomSchema { fatalError("not used in these tests") }
+    func searchRomsWithOpenAPI(query: String) async throws -> CustomLimitOffsetPageSimpleRomSchema { fatalError("not used in these tests") }
+    func getCollection(id: Int) async throws -> CollectionSchema { fatalError("not used in these tests") }
+    func getVirtualCollections(type: String, limit: Int?) async throws -> [VirtualCollectionSchema] { fatalError("not used in these tests") }
+    func getVirtualCollection(id: String) async throws -> VirtualCollectionSchema { fatalError("not used in these tests") }
+    func updateCollection(id: Int, name: String, description: String, isPublic: Bool, romIds: [Int]?, artwork: URL?) async throws -> CollectionSchema { fatalError("not used in these tests") }
+    func deleteCollection(id: Int) async throws -> String { fatalError("not used in these tests") }
+    func getPlatforms() async throws -> [PlatformSchema] { fatalError("not used in these tests") }
+    func addPlatform(name: String, slug: String) async throws -> PlatformSchema { fatalError("not used in these tests") }
+    func deletePlatform(id: Int) async throws -> String { fatalError("not used in these tests") }
+    func getPlatformFirmware(platformId: Int) async throws -> [FirmwareSchema] { fatalError("not used in these tests") }
+    func downloadFirmwareContent(id: Int, fileName: String) async throws -> Data { fatalError("not used in these tests") }
+    func getHeartbeat() async throws -> HeartbeatResponse { fatalError("not used in these tests") }
+    func getHeartbeat(from serverURL: String) async throws -> HeartbeatResponse { fatalError("not used in these tests") }
+    func updateRomLastPlayed(id: Int) async throws -> RomUserSchema { fatalError("not used in these tests") }
+    func getStats() async throws -> StatsReturn { fatalError("not used in these tests") }
+    func getSaves(romId: Int) async throws -> [SaveSchema] { fatalError("not used in these tests") }
+    func getStates(romId: Int) async throws -> [StateSchema] { fatalError("not used in these tests") }
+    func uploadSave(romId: Int, emulator: String?, slot: String?, deviceId: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema { fatalError("not used in these tests") }
+    func updateSave(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema { fatalError("not used in these tests") }
+    func downloadSave(id: Int, deviceId: String?) async throws -> Data { fatalError("not used in these tests") }
+    func deleteSaves(ids: [Int]) async throws {}
+    func uploadState(romId: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema { fatalError("not used in these tests") }
+    func updateState(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema { fatalError("not used in these tests") }
+    func downloadState(id: Int) async throws -> Data { fatalError("not used in these tests") }
+    func deleteStates(ids: [Int]) async throws {}
+    func registerDevice(_ body: DeviceRegisterRequest) async throws -> DeviceSchema { fatalError("not used in these tests") }
+    func negotiateSync(_ body: SyncNegotiateRequest) async throws -> SyncNegotiateResponse { fatalError("not used in these tests") }
+}
+
+// MARK: - Fixtures
+
+private func makeCollection(
+    id: Int,
+    userId: Int,
+    isFavorite: Bool,
+    romIds: Set<Int> = [],
+    name: String = "Favorites"
+) -> CollectionSchema {
+    CollectionSchema(
+        name: name,
+        description: "",
+        romIds: romIds,
+        romCount: romIds.count,
+        pathCoverSmall: nil,
+        pathCoverLarge: nil,
+        pathCoversSmall: [],
+        pathCoversLarge: [],
+        isPublic: false,
+        isFavorite: isFavorite,
+        isVirtual: false,
+        isSmart: false,
+        createdAt: Date(timeIntervalSince1970: 0),
+        updatedAt: Date(timeIntervalSince1970: 0),
+        id: id,
+        urlCover: nil,
+        userId: userId,
+        userUsername: "user\(userId)"
+    )
+}
+
+private func makeUser(id: Int) -> UserSchema {
+    UserSchema(
+        id: id,
+        username: "user\(id)",
+        email: nil,
+        enabled: true,
+        role: .viewer,
+        oauthScopes: [],
+        avatarPath: "",
+        lastLogin: nil,
+        lastActive: nil,
+        createdAt: Date(timeIntervalSince1970: 0),
+        updatedAt: Date(timeIntervalSince1970: 0)
+    )
+}
+
+private struct FakeAPIError: Error {}
+
+struct RomsRepositoryFavouritesTests {
+
+    @Test func addsRomToExistingFavouritesCollection() async throws {
+        let api = FakeAPIClient()
+        api.currentUserId = 7
+        api.collectionsToReturn = [
+            makeCollection(id: 3, userId: 7, isFavorite: false, name: "Shooters"),
+            makeCollection(id: 42, userId: 7, isFavorite: true)
+        ]
+        let repository = RomsRepository(apiClient: api)
+
+        try await repository.toggleRomFavorite(romId: 100, isFavorite: true)
+
+        #expect(api.createCollectionCallCount == 0)
+        #expect(api.addedRoms.count == 1)
+        #expect(api.addedRoms.first?.collectionId == 42)
+        #expect(api.addedRoms.first?.romIds == [100])
+    }
+
+    @Test func createsFavouritesCollectionWhenMissingBeforeAdding() async throws {
+        let api = FakeAPIClient()
+        api.currentUserId = 7
+        api.createdCollectionId = 55
+        api.collectionsToReturn = []
+        let repository = RomsRepository(apiClient: api)
+
+        try await repository.toggleRomFavorite(romId: 100, isFavorite: true)
+
+        #expect(api.createCollectionCallCount == 1)
+        #expect(api.createdCollectionNames == ["Favorites"])
+        #expect(api.createdCollectionIsPublic == [false])
+        #expect(api.createdCollectionIsFavorite == [true])
+        #expect(api.addedRoms.count == 1)
+        #expect(api.addedRoms.first?.collectionId == 55)
+        #expect(api.addedRoms.first?.romIds == [100])
+    }
+
+    @Test func ignoresForeignFavouritesCollectionAndCreatesOwnOne() async throws {
+        let api = FakeAPIClient()
+        api.currentUserId = 7
+        api.createdCollectionId = 55
+        // Public favourites collection of another user, as returned by the collections endpoint.
+        api.collectionsToReturn = [makeCollection(id: 2, userId: 9, isFavorite: true)]
+        let repository = RomsRepository(apiClient: api)
+
+        try await repository.toggleRomFavorite(romId: 100, isFavorite: true)
+
+        #expect(api.createCollectionCallCount == 1)
+        #expect(api.addedRoms.count == 1)
+        #expect(api.addedRoms.first?.collectionId == 55)
+        #expect(api.addedRoms.contains { $0.collectionId == 2 } == false)
+    }
+
+    @Test func removesRomFromExistingFavouritesCollection() async throws {
+        let api = FakeAPIClient()
+        api.currentUserId = 7
+        api.collectionsToReturn = [makeCollection(id: 42, userId: 7, isFavorite: true, romIds: [100])]
+        let repository = RomsRepository(apiClient: api)
+
+        try await repository.toggleRomFavorite(romId: 100, isFavorite: false)
+
+        #expect(api.removedRoms.count == 1)
+        #expect(api.removedRoms.first?.collectionId == 42)
+        #expect(api.removedRoms.first?.romIds == [100])
+        #expect(api.createCollectionCallCount == 0)
+    }
+
+    @Test func removeIsNoOpWithoutFavouritesCollection() async throws {
+        let api = FakeAPIClient()
+        api.currentUserId = 7
+        api.collectionsToReturn = []
+        let repository = RomsRepository(apiClient: api)
+
+        try await repository.toggleRomFavorite(romId: 100, isFavorite: false)
+
+        #expect(api.createCollectionCallCount == 0)
+        #expect(api.removedRoms.isEmpty)
+        #expect(api.addedRoms.isEmpty)
+    }
+
+    @Test func isRomFavoriteReturnsTrueWhenCollectionContainsRom() async throws {
+        let api = FakeAPIClient()
+        api.currentUserId = 7
+        api.collectionsToReturn = [makeCollection(id: 42, userId: 7, isFavorite: true, romIds: [100, 101])]
+        let repository = RomsRepository(apiClient: api)
+
+        #expect(try await repository.isRomFavorite(romId: 100) == true)
+    }
+
+    @Test func isRomFavoriteReturnsFalseWhenCollectionDoesNotContainRom() async throws {
+        let api = FakeAPIClient()
+        api.currentUserId = 7
+        api.collectionsToReturn = [makeCollection(id: 42, userId: 7, isFavorite: true, romIds: [101])]
+        let repository = RomsRepository(apiClient: api)
+
+        #expect(try await repository.isRomFavorite(romId: 100) == false)
+    }
+
+    @Test func isRomFavoriteReturnsFalseWithoutFavouritesCollection() async throws {
+        let api = FakeAPIClient()
+        api.currentUserId = 7
+        api.collectionsToReturn = [makeCollection(id: 2, userId: 9, isFavorite: true, romIds: [100])]
+        let repository = RomsRepository(apiClient: api)
+
+        #expect(try await repository.isRomFavorite(romId: 100) == false)
+    }
+
+    @Test func toggleThrowsNetworkErrorWhenCollectionLookupFails() async {
+        let api = FakeAPIClient()
+        api.errorToThrow = FakeAPIError()
+        let repository = RomsRepository(apiClient: api)
+
+        do {
+            try await repository.toggleRomFavorite(romId: 100, isFavorite: true)
+            Issue.record("expected RomError.networkError")
+        } catch {
+            #expect(error as? RomError == .networkError)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #63.

RomM never creates the favourites collection on its own, so on a server where nobody ever favourited a game `api/collections` is empty and every favourite failed with a network error. Reproduced against a 5.1.0 instance: `api/collections/2` returns 404, `api/collections` returns `[]`.

The collection is now looked up by its `is_favorite` flag (scoped to the current user, since the endpoint also returns other users' public collections) and created on first use with the same name the web frontend uses. ROMs are added/removed via `POST`/`DELETE api/collections/{id}/roms` instead of replacing the whole list, so concurrent toggles no longer clobber each other. Also fixes `is_public` never being sent on create.

Built for arm64, not yet exercised live in the app.