### PR TITLE
Fix N64 save states and hide resume for the web emulator

### DIFF
--- a/romm/romm/Domain/Models/SaveData.swift
+++ b/romm/romm/Domain/Models/SaveData.swift
@@ -10,3 +10,15 @@ struct SaveStateEntry: Equatable, Identifiable {
     let modifiedAt: Date
     var id: Int { slot }
 }
+
+enum SaveStateCaptureError: LocalizedError {
+    /// The core never finished writing the state file it was asked for.
+    case incomplete
+
+    var errorDescription: String? {
+        switch self {
+        case .incomplete:
+            return "The emulator did not finish writing the save state. Nothing was overwritten."
+        }
+    }
+}

--- a/romm/romm/Domain/UseCases/Emulator/LaunchEmulatorUseCase.swift
+++ b/romm/romm/Domain/UseCases/Emulator/LaunchEmulatorUseCase.swift
@@ -20,9 +20,8 @@ enum LaunchDecision: Identifiable {
         }
     }
 
-    /// Save states are driven by the app around a local core. The web emulator
-    /// runs inside EmulatorJS on the server, out of the app's reach, so a ROM
-    /// booting there can neither be resumed nor snapshotted.
+    /// EmulatorJS runs on the server, out of the app's reach, so a ROM booting
+    /// there can neither be resumed nor snapshotted.
     var supportsSaveStates: Bool {
         switch self {
         case .web: return false

--- a/romm/romm/Domain/UseCases/Emulator/LaunchEmulatorUseCase.swift
+++ b/romm/romm/Domain/UseCases/Emulator/LaunchEmulatorUseCase.swift
@@ -19,6 +19,16 @@ enum LaunchDecision: Identifiable {
         case .libretro(let rom, _): return "libretro-\(rom.id)"
         }
     }
+
+    /// Save states are driven by the app around a local core. The web emulator
+    /// runs inside EmulatorJS on the server, out of the app's reach, so a ROM
+    /// booting there can neither be resumed nor snapshotted.
+    var supportsSaveStates: Bool {
+        switch self {
+        case .web: return false
+        case .native, .libretro: return true
+        }
+    }
 }
 
 enum EmulatorLaunchResult {

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
@@ -136,9 +136,8 @@ struct PlatformROMsListView: View {
         return false
     }
 
-    /// Resolves the engine before anything is shown: only local cores can load a
-    /// save state, so a ROM that boots into the web emulator skips the resume
-    /// choice and goes straight into a fresh session.
+    /// Resolves the engine first: a ROM booting into the web emulator skips the
+    /// resume choice, since only local cores can load a save state.
     private func startPlay(rom: DownloadedROM) async {
         let start = Date()
         let result = await launchUseCase.execute(rom: rom.toRom())

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
@@ -1,5 +1,13 @@
 import SwiftUI
 
+/// A ROM whose engine is already resolved, waiting for the user's resume choice.
+private struct PendingLaunch: Identifiable {
+    let rom: DownloadedROM
+    let decision: LaunchDecision
+
+    var id: Int { rom.id }
+}
+
 /// Shows list of ROMs for a specific platform
 struct PlatformROMsListView: View {
     let platformName: String
@@ -18,8 +26,9 @@ struct PlatformROMsListView: View {
     @State private var romPendingDelete: DownloadedROM?
     @State private var romPendingSync: DownloadedROM?
     @State private var detailRom: DownloadedROM?
-    /// ROM awaiting a resume/new-game choice in the pre-launch sheet.
-    @State private var romPendingLaunch: DownloadedROM?
+    /// ROM awaiting a resume/new-game choice in the pre-launch sheet, together
+    /// with the engine already resolved for it.
+    @State private var romPendingLaunch: PendingLaunch?
     /// Slot chosen in the pre-launch sheet; read by the emulator cover builder.
     @State private var pendingResumeSlot: Int?
     private let factory: PDependencyFactory
@@ -50,13 +59,8 @@ struct PlatformROMsListView: View {
                     lastSync: viewModel.lastSync(romId: rom.id),
                     onPlay: {
                         guard isPlatformSupported(rom.platformSlug), launchingRomId == nil else { return }
-                        if hasSaveState(romId: rom.id) {
-                            // Offer resume vs. new game before booting the core.
-                            romPendingLaunch = rom
-                        } else {
-                            launchingRomId = rom.id
-                            Task { await launch(rom: rom, resumeSlot: nil) }
-                        }
+                        launchingRomId = rom.id
+                        Task { await startPlay(rom: rom) }
                     },
                     onSync: { romPendingSync = rom },
                     onDetails: { detailRom = rom }
@@ -86,15 +90,15 @@ struct PlatformROMsListView: View {
             EmulatorRouterView(decision: decision, resumeSlot: pendingResumeSlot)
                 .ignoresSafeArea()
         }
-        .sheet(item: $romPendingLaunch) { rom in
+        .sheet(item: $romPendingLaunch) { pending in
             PreLaunchSheet(
-                romName: rom.name,
-                romId: rom.id,
+                romName: pending.rom.name,
+                romId: pending.rom.id,
                 saveStore: saveStore
             ) { resumeSlot in
                 romPendingLaunch = nil
-                launchingRomId = rom.id
-                Task { await launch(rom: rom, resumeSlot: resumeSlot) }
+                launchingRomId = pending.rom.id
+                present(pending.decision, rom: pending.rom, resumeSlot: resumeSlot)
             }
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
@@ -132,23 +136,38 @@ struct PlatformROMsListView: View {
         return false
     }
 
-    private func launch(rom: DownloadedROM, resumeSlot: Int?) async {
+    /// Resolves the engine before anything is shown: only local cores can load a
+    /// save state, so a ROM that boots into the web emulator skips the resume
+    /// choice and goes straight into a fresh session.
+    private func startPlay(rom: DownloadedROM) async {
         let start = Date()
         let result = await launchUseCase.execute(rom: rom.toRom())
+        guard case .success(let decision) = result else {
+            launchingRomId = nil
+            return
+        }
+
+        if decision.supportsSaveStates, hasSaveState(romId: rom.id) {
+            launchingRomId = nil
+            romPendingLaunch = PendingLaunch(rom: rom, decision: decision)
+            return
+        }
+
+        // Keep the card's spinner on screen long enough to read as feedback.
         let elapsed = Date().timeIntervalSince(start)
         let minVisible: TimeInterval = 0.45
         if elapsed < minVisible {
             try? await Task.sleep(nanoseconds: UInt64((minVisible - elapsed) * 1_000_000_000))
         }
-        if case .success(let decision) = result {
-            // Set the slot before the decision so the cover builder reads it.
-            pendingResumeSlot = resumeSlot
-            launchDecision = decision
-            Task { [updateLastPlayedUseCase] in
-                try? await updateLastPlayedUseCase.execute(romId: rom.id)
-            }
-        } else {
-            launchingRomId = nil
+        present(decision, rom: rom, resumeSlot: nil)
+    }
+
+    private func present(_ decision: LaunchDecision, rom: DownloadedROM, resumeSlot: Int?) {
+        // Set the slot before the decision so the cover builder reads it.
+        pendingResumeSlot = resumeSlot
+        launchDecision = decision
+        Task { [updateLastPlayedUseCase] in
+            try? await updateLastPlayedUseCase.execute(romId: rom.id)
         }
     }
 

--- a/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
+++ b/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
@@ -203,9 +203,12 @@ struct EmulatorMenuSheet: View {
                 filled: true,
                 disabled: session?.hasState(slot: selectedSlot) != true
             ) {
-                perform { try session?.loadState(slot: selectedSlot) }
-                statusMessage = "Slot \(selectedSlot) loaded"
-                onResume()
+                let slot = selectedSlot
+                perform(
+                    success: "Slot \(slot) loaded",
+                    action: { try await session?.loadState(slot: slot) },
+                    onSuccess: { onResume() }
+                )
             }
             stackedButton(
                 title: "Save",
@@ -214,9 +217,12 @@ struct EmulatorMenuSheet: View {
                 filled: false,
                 disabled: false
             ) {
-                perform { try session?.saveState(slot: selectedSlot) }
-                statusMessage = "Slot \(selectedSlot) saved"
-                refreshTick += 1
+                let slot = selectedSlot
+                perform(
+                    success: "Slot \(slot) saved",
+                    action: { try await session?.saveState(slot: slot) },
+                    onSuccess: { refreshTick += 1 }
+                )
             }
             stackedButton(
                 title: "Undo Save",
@@ -225,9 +231,12 @@ struct EmulatorMenuSheet: View {
                 filled: false,
                 disabled: session?.hasUndoSave(slot: selectedSlot) != true
             ) {
-                perform { try session?.undoSave(slot: selectedSlot) }
-                statusMessage = "Save for slot \(selectedSlot) undone"
-                refreshTick += 1
+                let slot = selectedSlot
+                perform(
+                    success: "Save for slot \(slot) undone",
+                    action: { try session?.undoSave(slot: slot) },
+                    onSuccess: { refreshTick += 1 }
+                )
             }
             stackedButton(
                 title: "Undo Load",
@@ -236,9 +245,11 @@ struct EmulatorMenuSheet: View {
                 filled: false,
                 disabled: session?.hasUndoLoad() != true
             ) {
-                perform { try session?.undoLoad() }
-                statusMessage = "Load undone"
-                onResume()
+                perform(
+                    success: "Load undone",
+                    action: { try session?.undoLoad() },
+                    onSuccess: { onResume() }
+                )
             }
         }
     }
@@ -279,11 +290,23 @@ struct EmulatorMenuSheet: View {
         .disabled(disabled)
     }
 
-    private func perform(_ action: () throws -> Void) {
-        do {
-            try action()
-        } catch {
-            statusMessage = "Error: \(error.localizedDescription)"
+    /// Runs a save-state action and reports what actually happened. The success
+    /// message and the follow-up only fire when the action succeeded. They used
+    /// to run unconditionally right after the call, overwriting the error and
+    /// making failed saves look like they had worked.
+    private func perform(
+        success: String,
+        action: @escaping () async throws -> Void,
+        onSuccess: @escaping () -> Void = {}
+    ) {
+        Task {
+            do {
+                try await action()
+                statusMessage = success
+                onSuccess()
+            } catch {
+                statusMessage = "Error: \(error.localizedDescription)"
+            }
         }
     }
 }

--- a/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
+++ b/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
@@ -290,10 +290,8 @@ struct EmulatorMenuSheet: View {
         .disabled(disabled)
     }
 
-    /// Runs a save-state action and reports what actually happened. The success
-    /// message and the follow-up only fire when the action succeeded. They used
-    /// to run unconditionally right after the call, overwriting the error and
-    /// making failed saves look like they had worked.
+    /// Success message and follow-up only fire on success. They used to run
+    /// unconditionally, overwriting the error and hiding failed saves.
     private func perform(
         success: String,
         action: @escaping () async throws -> Void,

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -174,6 +174,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     private let saveStates: PEmulatorSaveStatesUseCase
     private let romId: Int
     private let cloudSync: CloudSaveSyncService?
+    private let logger = Logger.ui
     let screenPositionPreference: PEmulatorScreenPositionPreference
 
     var onMenuRequested: (() -> Void)?
@@ -226,11 +227,11 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     private static func loadControllerSkin(at url: URL?, gameType: GameType) -> ControllerSkin? {
         guard let url else { return nil }
         guard let skin = ControllerSkin(fileURL: url) else {
-            print("[Native] Controller skin \(url.lastPathComponent) failed to load, using the built-in skin")
+            Logger.ui.warning("Controller skin \(url.lastPathComponent) failed to load, using the built-in skin")
             return nil
         }
         guard skin.gameType == gameType else {
-            print("[Native] Controller skin \(url.lastPathComponent) is for \(skin.gameType.rawValue), not \(gameType.rawValue)")
+            Logger.ui.warning("Controller skin \(url.lastPathComponent) is for \(skin.gameType.rawValue), not \(gameType.rawValue)")
             return nil
         }
         return skin
@@ -279,7 +280,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
             do {
                 try await self.loadState(slot: slot)
             } catch {
-                print("[Native] resume from slot \(slot) failed: \(error.localizedDescription)")
+                self.logger.error("Resume from slot \(slot) failed: \(error.localizedDescription)")
             }
             self.viewController.resumeEmulation()
         }
@@ -418,8 +419,8 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         core.saveSaveState(to: tmp)
         defer { try? FileManager.default.removeItem(at: tmp) }
         let data = try await settledStateData(at: tmp)
-        // Rotate the old state into the undo slot only once the new one is safely
-        // in hand, so a failed capture cannot destroy what was already there.
+        // Rotate only once the new state is in hand, so a failed capture
+        // cannot destroy what was already there.
         try saveStates.backupSlotForUndoSave(romId: romId, slot: slot)
         try saveStates.writeState(romId: romId, slot: slot, data: data)
         let thumb = currentThumbnailPNG()
@@ -472,16 +473,8 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         try saveStates.writeUndoLoadSnapshot(romId: romId, stateData: data, thumbnailData: thumb)
     }
 
-    /// Reads a state file the core was just asked to write, once it is actually
-    /// complete.
-    ///
-    /// Mupen64Plus hands the real gzip write to an internal worker thread and
-    /// fires its save-complete callback before any of those bytes reach disk
-    /// (`savestates.c`, `queue_work`). Reading straight after `saveSaveState(to:)`
-    /// therefore yielded a state truncated to a multiple of zlib's 16 KB buffer,
-    /// which the core then silently refused to load, so N64 slots looked
-    /// populated, complete with thumbnail, but never resumed. Cores that write
-    /// synchronously settle on the first check and only pay one poll interval.
+    /// Mupen64Plus queues the gzip write on a worker thread and reports done
+    /// before the bytes land, so wait for the file to stop growing.
     private func settledStateData(at url: URL) async throws -> Data {
         let pollInterval: UInt64 = 50_000_000
         let deadline = Date().addingTimeInterval(15)
@@ -491,8 +484,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
             let size = fileSize(at: url)
             if let size, size > 0, size == previousSize {
                 let data = try Data(contentsOf: url)
-                // Re-check the size: a write that resumed while we were reading
-                // would otherwise hand back another torso.
+                // A write resuming mid-read would hand back another torso.
                 if fileSize(at: url) == UInt64(data.count) { return data }
                 previousSize = nil
             } else {

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -277,7 +277,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
             try? await Task.sleep(nanoseconds: 600_000_000)
             self.viewController.pauseEmulation()
             do {
-                try self.loadState(slot: slot)
+                try await self.loadState(slot: slot)
             } catch {
                 print("[Native] resume from slot \(slot) failed: \(error.localizedDescription)")
             }
@@ -411,26 +411,28 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
 
     // MARK: - Save / Load
 
-    func saveState(slot: Int) throws {
+    func saveState(slot: Int) async throws {
         guard let core = emulatorCore else { return }
-        try saveStates.backupSlotForUndoSave(romId: romId, slot: slot)
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("state-\(UUID().uuidString).dltastate")
         core.saveSaveState(to: tmp)
-        let data = try Data(contentsOf: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let data = try await settledStateData(at: tmp)
+        // Rotate the old state into the undo slot only once the new one is safely
+        // in hand, so a failed capture cannot destroy what was already there.
+        try saveStates.backupSlotForUndoSave(romId: romId, slot: slot)
         try saveStates.writeState(romId: romId, slot: slot, data: data)
         let thumb = currentThumbnailPNG()
         if let thumb {
             try saveStates.writeThumbnail(romId: romId, slot: slot, data: thumb)
         }
-        try? FileManager.default.removeItem(at: tmp)
         cloudSync?.pushState(slot: slot, data: data, thumbnail: thumb)
     }
 
-    func loadState(slot: Int) throws {
+    func loadState(slot: Int) async throws {
         guard let core = emulatorCore else { return }
         guard let data = try saveStates.readState(romId: romId, slot: slot) else { return }
-        try captureUndoLoadSnapshot(core: core)
+        try await captureUndoLoadSnapshot(core: core)
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("state-\(UUID().uuidString).dltastate")
         try data.write(to: tmp)
@@ -460,14 +462,51 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         return image.pngData()
     }
 
-    private func captureUndoLoadSnapshot(core: EmulatorCore) throws {
+    private func captureUndoLoadSnapshot(core: EmulatorCore) async throws {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("undoload-\(UUID().uuidString).dltastate")
         core.saveSaveState(to: tmp)
-        let data = try Data(contentsOf: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let data = try await settledStateData(at: tmp)
         let thumb = currentThumbnailPNG()
         try saveStates.writeUndoLoadSnapshot(romId: romId, stateData: data, thumbnailData: thumb)
-        try? FileManager.default.removeItem(at: tmp)
+    }
+
+    /// Reads a state file the core was just asked to write, once it is actually
+    /// complete.
+    ///
+    /// Mupen64Plus hands the real gzip write to an internal worker thread and
+    /// fires its save-complete callback before any of those bytes reach disk
+    /// (`savestates.c`, `queue_work`). Reading straight after `saveSaveState(to:)`
+    /// therefore yielded a state truncated to a multiple of zlib's 16 KB buffer,
+    /// which the core then silently refused to load, so N64 slots looked
+    /// populated, complete with thumbnail, but never resumed. Cores that write
+    /// synchronously settle on the first check and only pay one poll interval.
+    private func settledStateData(at url: URL) async throws -> Data {
+        let pollInterval: UInt64 = 50_000_000
+        let deadline = Date().addingTimeInterval(15)
+        var previousSize: UInt64?
+
+        while Date() < deadline {
+            let size = fileSize(at: url)
+            if let size, size > 0, size == previousSize {
+                let data = try Data(contentsOf: url)
+                // Re-check the size: a write that resumed while we were reading
+                // would otherwise hand back another torso.
+                if fileSize(at: url) == UInt64(data.count) { return data }
+                previousSize = nil
+            } else {
+                previousSize = size
+            }
+            try? await Task.sleep(nanoseconds: pollInterval)
+        }
+
+        throw SaveStateCaptureError.incomplete
+    }
+
+    private func fileSize(at url: URL) -> UInt64? {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes?[.size] as? NSNumber)?.uint64Value
     }
 
     // MARK: - Battery

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -38,6 +38,9 @@ struct RomDetailView: View {
     /// Distinguishes "user picked a slot" from "user cancelled" once the
     /// pre-launch sheet has dismissed.
     @State private var shouldLaunchAfterPreLaunch = false
+    /// Engine resolved before the pre-launch sheet opened, booted once the
+    /// sheet is gone so the choice and the launch stay consistent.
+    @State private var preLaunchDecision: LaunchDecision?
     private let saveStore: PSaveStore = DefaultDependencyFactory.shared.saveStore
 
     enum DetailTab: String, CaseIterable {
@@ -170,7 +173,7 @@ struct RomDetailView: View {
                             Task {
                                 async let savesTask = viewModel.loadSaves(for: rom.id)
                                 async let statesTask = viewModel.loadStates(for: rom.id)
-                                await (savesTask, statesTask)
+                                _ = await (savesTask, statesTask)
                             }
                         }
                     }
@@ -267,9 +270,15 @@ struct RomDetailView: View {
                 // Boot only once the sheet is fully gone. Presenting the emulator's
                 // full screen cover while the sheet is still dismissing can swallow
                 // the presentation entirely.
-                guard shouldLaunchAfterPreLaunch else { return }
+                let decision = preLaunchDecision
+                preLaunchDecision = nil
+                guard shouldLaunchAfterPreLaunch, let decision else {
+                    // Sheet was swiped away, release the Play button's spinner.
+                    viewModel.emulatorPresentationDidEnd()
+                    return
+                }
                 shouldLaunchAfterPreLaunch = false
-                Task { await viewModel.launchEmulator(rom: currentSelectedRom) }
+                viewModel.present(decision, rom: currentSelectedRom)
             }) {
                 PreLaunchSheet(
                     romName: currentSelectedRom.name,
@@ -555,14 +564,18 @@ struct RomDetailView: View {
         .padding(.bottom, 24)
     }
     
-    /// Routes a Play tap: offer resume when save states exist, otherwise boot
-    /// straight into a fresh session.
+    /// Routes a Play tap: offer resume when save states exist and the engine can
+    /// actually load them, otherwise boot straight into a fresh session.
     private func startPlay() {
-        let states = (try? saveStore.listStates(romId: rom.id)) ?? []
-        if states.isEmpty {
-            pendingResumeSlot = nil
-            Task { await viewModel.launchEmulator(rom: currentSelectedRom) }
-        } else {
+        Task {
+            guard let decision = await viewModel.resolveLaunch(rom: currentSelectedRom) else { return }
+            let states = (try? saveStore.listStates(romId: rom.id)) ?? []
+            guard decision.supportsSaveStates, !states.isEmpty else {
+                pendingResumeSlot = nil
+                viewModel.present(decision, rom: currentSelectedRom)
+                return
+            }
+            preLaunchDecision = decision
             showingPreLaunch = true
         }
     }

--- a/romm/romm/UI/RomDetail/RomDetailViewModel.swift
+++ b/romm/romm/UI/RomDetail/RomDetailViewModel.swift
@@ -346,14 +346,12 @@ class RomDetailViewModel {
         present(decision, rom: rom)
     }
 
-    /// Works out which engine would run this ROM without presenting anything.
-    /// Callers need this up front to decide whether offering a resume makes
-    /// sense at all: only local cores can load a save state.
+    /// Picks the engine without presenting anything, so callers can tell whether
+    /// offering a resume makes sense at all.
     func resolveLaunch(rom: Rom) async -> LaunchDecision? {
-        print("[RomDetailVM] launchEmulator tapped for rom id=\(rom.id)")
-        // Check if experimental feature is enabled first
+        logger.debug("Play tapped for ROM \(rom.id)")
         guard ExperimentalFeatureSettings.shared.isEmulatorEnabled else {
-            print("[RomDetailVM] experimental emulator disabled — showing hint")
+            logger.info("Experimental emulator disabled, showing hint")
             showingEmulatorFeatureHint = true
             return nil
         }

--- a/romm/romm/UI/RomDetail/RomDetailViewModel.swift
+++ b/romm/romm/UI/RomDetail/RomDetailViewModel.swift
@@ -342,12 +342,20 @@ class RomDetailViewModel {
     }
 
     func launchEmulator(rom: Rom) async {
+        guard let decision = await resolveLaunch(rom: rom) else { return }
+        present(decision, rom: rom)
+    }
+
+    /// Works out which engine would run this ROM without presenting anything.
+    /// Callers need this up front to decide whether offering a resume makes
+    /// sense at all: only local cores can load a save state.
+    func resolveLaunch(rom: Rom) async -> LaunchDecision? {
         print("[RomDetailVM] launchEmulator tapped for rom id=\(rom.id)")
         // Check if experimental feature is enabled first
         guard ExperimentalFeatureSettings.shared.isEmulatorEnabled else {
             print("[RomDetailVM] experimental emulator disabled — showing hint")
             showingEmulatorFeatureHint = true
-            return
+            return nil
         }
 
         isLaunchingEmulator = true
@@ -355,20 +363,24 @@ class RomDetailViewModel {
 
         switch result {
         case .success(let decision):
-            logger.info("Launching emulator for ROM: \(rom.name) — decision: \(String(describing: decision))")
-            self.launchDecision = decision
-            Task { [updateLastPlayedUseCase, logger] in
-                do {
-                    try await updateLastPlayedUseCase.execute(romId: rom.id)
-                } catch {
-                    logger.warning("Failed to update last_played for ROM \(rom.id): \(error)")
-                }
-            }
-
+            return decision
         case .failure(let error):
             logger.error("Failed to launch emulator: \(error.localizedDescription)")
             errorMessage = error.localizedDescription
             isLaunchingEmulator = false
+            return nil
+        }
+    }
+
+    func present(_ decision: LaunchDecision, rom: Rom) {
+        logger.info("Launching emulator for ROM: \(rom.name) — decision: \(String(describing: decision))")
+        self.launchDecision = decision
+        Task { [updateLastPlayedUseCase, logger] in
+            do {
+                try await updateLastPlayedUseCase.execute(romId: rom.id)
+            } catch {
+                logger.warning("Failed to update last_played for ROM \(rom.id): \(error)")
+            }
         }
     }
 


### PR DESCRIPTION
Zwei Sachen, die beim Resume schiefgingen.

**N64 states waren kaputt.** Mupen64Plus schreibt den State asynchron auf einem Worker-Thread, meldet aber sofort "fertig". Wir haben die Temp-Datei direkt danach gelesen und dadurch einen abgeschnittenen gzip gespeichert, den der Core beim Laden still verworfen hat. Nachgewiesen auf dem Gerät: Diddy Kong Racing Slot 0 lag bei 16 KB, Slot 1 bei 40 KB (glatte Vielfache von zlibs 16-KB-Puffer), `gzip -t` sagt "unexpected end of file". Ein vollständiger State ist ~1,7 MB.

Jetzt wird gewartet, bis die Datei nicht mehr wächst. Der alte State wandert erst dann ins Undo-Slot, wenn der neue sicher im Speicher liegt.

Dass das so lange unbemerkt blieb, lag am Menü: es setzte "Slot N saved" unbedingt direkt nach dem Aufruf und hat damit die Fehlermeldung von `perform()` überschrieben. Erfolgsmeldungen laufen jetzt nur noch bei echtem Erfolg.

Auf dem iPhone gegengetestet: derselbe Slot geht von 16.384 Bytes (gzip defekt) auf 1.755.997 Bytes (gzip vollständig), Laden funktioniert, der alte Torso ist korrekt ins Undo-Slot rotiert.

**Resume beim Web-Emulator.** EmulatorJS läuft auf dem Server, die App kommt an keinen State. Trotzdem kam der Pre-Launch-Dialog, sobald alte States existierten, und die Slot-Auswahl lief ins Nichts. Beide Play-Pfade lösen jetzt zuerst die Engine auf und booten bei Web direkt durch.