### PR TITLE
Support RomM server 5.2.0

### DIFF
--- a/romm/romm/Data/API/Models/CollectionSchema.swift
+++ b/romm/romm/Data/API/Models/CollectionSchema.swift
@@ -68,6 +68,7 @@ public struct CollectionSchema: Codable, JSONEncodable, Hashable {
         case urlCover = "url_cover"
         case userId = "user_id"
         case userUsername = "user__username"
+        case ownerUsername = "owner_username"
     }
 
     // Decodable protocol methods
@@ -90,7 +91,12 @@ public struct CollectionSchema: Codable, JSONEncodable, Hashable {
         id = try container.decode(Int.self, forKey: .id)
         urlCover = try container.decodeIfPresent(String.self, forKey: .urlCover)
         userId = try container.decode(Int.self, forKey: .userId)
-        userUsername = container.decodeFlexibleString(forKey: .userUsername, default: "")
+        // RomM 5.0 renamed `user__username` to `owner_username`; 4.x still sends
+        // the old key, so accept both.
+        let ownerUsername = container.decodeFlexibleString(forKey: .ownerUsername, default: "")
+        userUsername = ownerUsername.isEmpty
+            ? container.decodeFlexibleString(forKey: .userUsername, default: "")
+            : ownerUsername
     }
 
     // Encodable protocol methods
@@ -114,7 +120,7 @@ public struct CollectionSchema: Codable, JSONEncodable, Hashable {
         try container.encode(id, forKey: .id)
         try container.encode(urlCover, forKey: .urlCover)
         try container.encode(userId, forKey: .userId)
-        try container.encode(userUsername, forKey: .userUsername)
+        try container.encode(userUsername, forKey: .ownerUsername)
     }
 }
 

--- a/romm/romm/Data/Repositories/HeartbeatRepository.swift
+++ b/romm/romm/Data/Repositories/HeartbeatRepository.swift
@@ -13,7 +13,7 @@ class HeartbeatRepository: PHeartbeatRepository {
     // MARK: - Constants
 
     let minSupportedServerVersion = "4.1.0"
-    let maxSupportedServerVersion = "5.1.0"
+    let maxSupportedServerVersion = "5.2.0"
     let versionCheckThrottleSeconds: TimeInterval = 30
 
     // MARK: - UserDefaults Keys

--- a/romm/romm/UI/App/AppViewModel.swift
+++ b/romm/romm/UI/App/AppViewModel.swift
@@ -296,13 +296,17 @@ class AppViewModel {
         logger.warning("Heartbeat error: \(error.localizedDescription)")
 
         let affectedVersion: String?
+        let alertTitle: String
         switch error {
         case .serverVersionChanged(_, let to):
             affectedVersion = to
+            alertTitle = "Server Version Changed"
         case .serverVersionTooHigh(let serverVersion, _):
             affectedVersion = serverVersion
+            alertTitle = "Unsupported Server Version"
         case .serverVersionTooLow(let serverVersion, _):
             affectedVersion = serverVersion
+            alertTitle = "Unsupported Server Version"
         case .decodingError, .networkError:
             // Transient errors should not disturb the user or log them out.
             logger.warning("Ignoring transient heartbeat error: \(error.localizedDescription)")
@@ -315,13 +319,13 @@ class AppViewModel {
             return
         }
 
-        presentServerVersionAlert(message: error.errorDescription, newVersion: affectedVersion)
+        presentServerVersionAlert(title: alertTitle, message: error.errorDescription, newVersion: affectedVersion)
     }
 
-    private func presentServerVersionAlert(message: String?, newVersion: String?) {
+    private func presentServerVersionAlert(title: String, message: String?, newVersion: String?) {
         guard appState == .authenticated, serverVersionAlert == nil else { return }
         serverVersionAlert = ServerVersionAlert(
-            title: "Server Version Changed",
+            title: title,
             message: message ?? "The server version has changed. Some features may not work correctly.",
             newVersion: newVersion
         )

--- a/romm/rommTests/CollectionSchemaDecodingTests.swift
+++ b/romm/rommTests/CollectionSchemaDecodingTests.swift
@@ -1,0 +1,46 @@
+//
+//  CollectionSchemaDecodingTests.swift
+//  rommTests
+//
+
+import Foundation
+import Testing
+@testable import romm
+
+struct CollectionSchemaDecodingTests {
+
+    // The API client decodes with a plain JSONDecoder; CollectionSchema resolves
+    // keys and dates itself in init(from:).
+    private func decode(usernameField: String?) throws -> CollectionSchema {
+        var json = """
+        {
+          "name": "My Collection",
+          "rom_ids": [1, 2, 3],
+          "rom_count": 3,
+          "created_at": "2025-01-15T10:30:00Z",
+          "updated_at": "2025-01-16T11:00:00Z",
+          "id": 42,
+          "user_id": 7
+        """
+        if let usernameField {
+            json += ",\n  \(usernameField)"
+        }
+        json += "\n}"
+        return try JSONDecoder().decode(CollectionSchema.self, from: Data(json.utf8))
+    }
+
+    @Test func decodesOwnerUsernameFromRomM5Payload() throws {
+        let collection = try decode(usernameField: #""owner_username": "ilyas""#)
+        #expect(collection.userUsername == "ilyas")
+    }
+
+    @Test func decodesLegacyUserUsernameFromRomM4Payload() throws {
+        let collection = try decode(usernameField: #""user__username": "ilyas""#)
+        #expect(collection.userUsername == "ilyas")
+    }
+
+    @Test func decodesEmptyUsernameWhenBothKeysAreMissing() throws {
+        let collection = try decode(usernameField: nil)
+        #expect(collection.userUsername == "")
+    }
+}


### PR DESCRIPTION
Die App hat 5.2.0-Server als inkompatibel gemeldet, obwohl nichts bricht. Ich habe die 5.2.0-Schemas gegen unsere Models geprüft, es gibt keinen Breaking Change bei den Endpoints, die wir nutzen. Die Scope-Verschärfung in den Release Notes betrifft `/api/streaming/*` (Remote-Play), nicht unsere ROM-Downloads, und `roms.user.write` fordern wir ohnehin an.

Drei Änderungen:

- Gate hoch auf 5.2.0.
- Der Versions-Alert hieß immer "Server Version Changed", auch wenn der Server nur zu neu war. Der Titel richtet sich jetzt nach dem Fehlerfall.
- Collections liefern den Besitzer seit 5.0 unter `owner_username` statt `user__username`, der Name war dadurch immer leer. Beide Keys werden jetzt akzeptiert, damit 4.x weiter funktioniert. Dafür gibt es drei neue Tests.

Volle Suite grün, 81 Tests.