### PR TITLE
Play game audio in silent mode

### DIFF
--- a/romm/romm/UI/Emulator/EmulatorAudioSession.swift
+++ b/romm/romm/UI/Emulator/EmulatorAudioSession.swift
@@ -1,0 +1,36 @@
+import AVFoundation
+
+/// Shared audio session setup for all three emulator engines.
+///
+/// `.playback` is what makes a running game behave like a media app: it ignores
+/// the ring switch, so muting the phone no longer mutes the console, and it
+/// leaves the volume entirely to the hardware buttons. Activating without
+/// `.mixWithOthers` also stops whatever else was playing, which matters beyond
+/// the obvious: DeltaCore silences its own mixer for as long as another app
+/// holds the audio, so a game started over a running podcast would come up mute.
+enum EmulatorAudioSession {
+
+    /// - Parameter preferredIOBufferDuration: Hardware buffer size to ask for,
+    ///   in seconds. Has to be requested before the session goes active, so it
+    ///   belongs here rather than at the call site.
+    static func activate(preferredIOBufferDuration: TimeInterval? = nil) {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playback, mode: .default, options: [])
+            if let preferredIOBufferDuration {
+                try session.setPreferredIOBufferDuration(preferredIOBufferDuration)
+            }
+            try session.setActive(true, options: [])
+        } catch {
+            Logger.ui.error("Audio session activation failed: \(error.localizedDescription)")
+        }
+    }
+
+    static func deactivate() {
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        } catch {
+            Logger.ui.error("Audio session deactivation failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/romm/romm/UI/Emulator/EmulatorView.swift
+++ b/romm/romm/UI/Emulator/EmulatorView.swift
@@ -5,7 +5,6 @@
 //  Created by Ilyas Hallak on 11.12.25.
 //
 
-import AVFoundation
 import SwiftUI
 import WebKit
 
@@ -204,14 +203,7 @@ struct EmulatorWebView: UIViewRepresentable {
 
         // Configure audio session for playback (non-simulator only)
         #if !targetEnvironment(simulator)
-            do {
-                try AVAudioSession.sharedInstance().setCategory(
-                    .playback, mode: .default, options: [])
-                try AVAudioSession.sharedInstance().setActive(true)
-                print("🔊 Audio session activated for playback")
-            } catch {
-                print("⚠️ Failed to activate audio session: \(error)")
-            }
+            EmulatorAudioSession.activate()
         #endif
 
         // Enable inspection in iOS Simulator

--- a/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Audio.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Audio.swift
@@ -48,16 +48,14 @@ extension LibretroFrontend {
     func startAudio(sampleRate: Double) {
         Self.audioActiveSampleRate = sampleRate > 0 ? sampleRate : Double(Self.audioSampleRateHz)
         Self.audioUnderruns = 0
-        let session = AVAudioSession.sharedInstance()
-        try? session.setCategory(.playback, mode: .default, options: [])
         // Ask for a short hardware buffer. The default under .playback is around
         // 20 ms, chosen for power rather than latency, and every millisecond here
         // is a millisecond between the core producing a sample and it being
         // heard. The render callback only copies out of a ring, so it can
         // comfortably run this often. The system may grant less than asked, and
         // over AirPlay it usually ignores this entirely, hence the log below.
-        try? session.setPreferredIOBufferDuration(0.005)
-        try? session.setActive(true, options: [])
+        EmulatorAudioSession.activate(preferredIOBufferDuration: 0.005)
+        let session = AVAudioSession.sharedInstance()
         print(String(
             format: "[Libretro] audio out: io buffer %.1f ms, route latency %.1f ms",
             session.ioBufferDuration * 1000, session.outputLatency * 1000
@@ -85,7 +83,7 @@ extension LibretroFrontend {
             audioEngine.detach(node)
             audioSourceNode = nil
         }
-        try? AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        EmulatorAudioSession.deactivate()
     }
 
     /// Drops any buffered samples by collapsing the read cursor onto the write

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -270,7 +270,13 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
             guard let self else { return }
             await self.cloudSync?.pullBeforeLaunch()
             self.loadBatteryIfAvailable()
+            // First: DeltaCore picks its output volume as the core comes up, and
+            // would mute itself if another app still held the audio by then.
+            EmulatorAudioSession.activate()
             self.viewController.startEmulation()
+            // Assigning this re-runs that volume decision, now without the
+            // ring switch muting a console the user deliberately started.
+            self.emulatorCore?.audioManager.respectsSilentMode = false
             self.attachExternalControllers()
             self.observeControllerConnections()
             self.registerExternalRenderTarget()


### PR DESCRIPTION
Fixes #102.

DeltaCore turns its own mixer down when the ring switch is silenced, so all the native systems (GBA, SNES, NES, GB/GBC, N64, Mega Drive, DS) were mute even though the audio session category already ignores that switch. Same code also mutes while another app holds the audio, so starting a game over a running podcast was silent too.

Sets `respectsSilentMode = false` once the core exists, and moves the audio session setup that all three engines were each doing themselves into `EmulatorAudioSession`, so the session is claimed before DeltaCore picks its output volume.

Needs a device to verify, the simulator has no ring switch.