### PR TITLE
Add native emulator fast forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Join the beta program and help improve the app:
 - 🖥️ Libretro-based emulation for Sega Genesis/Mega Drive, Master System, Game Gear, Saturn, Dreamcast, PlayStation, PSP, and Arcade
 - ☁️ Cloud save sync — upload and download save states and save files to/from your RomM server
 - 🎛️ Physical controller support
+- ⏩ 2x fast-forward for native DeltaCore emulation from the in-game menu
 
 ### Library
 - 📱 Native SwiftUI design with dark mode support

--- a/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
+++ b/romm/romm/UI/Emulator/Native/EmulatorMenuSheet.swift
@@ -8,6 +8,7 @@ struct EmulatorMenuSheet: View {
     @SwiftUI.State private var selectedSlot: Int
     @SwiftUI.State private var statusMessage: String?
     @SwiftUI.State private var refreshTick: Int = 0
+    @SwiftUI.State private var isFastForwarding: Bool
     @SwiftUI.State private var showQuitConfirmation = false
     @ObservedObject private var externalDisplay = ExternalDisplayManager.shared
 
@@ -26,6 +27,7 @@ struct EmulatorMenuSheet: View {
             return (slot, date)
         }.max(by: { $0.date < $1.date })?.slot ?? 0
         self._selectedSlot = SwiftUI.State(initialValue: mostRecent)
+        self._isFastForwarding = SwiftUI.State(initialValue: session?.isFastForwarding ?? false)
     }
 
     var body: some View {
@@ -34,6 +36,9 @@ struct EmulatorMenuSheet: View {
                 Color.black.ignoresSafeArea()
                 VStack(spacing: 0) {
                     detailHeader
+                    fastForwardButton
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 10)
                     actionButtons
                         .padding(.horizontal, 16)
                         .padding(.bottom, 12)
@@ -252,6 +257,41 @@ struct EmulatorMenuSheet: View {
                 )
             }
         }
+    }
+
+    private var fastForwardButton: some View {
+        Button {
+            isFastForwarding = session?.toggleFastForward() ?? false
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "forward.fill")
+                    .font(.system(size: 18, weight: .semibold))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Fast Forward")
+                        .font(.body.weight(.semibold))
+                    Text("2x speed")
+                        .font(.caption)
+                }
+                Spacer()
+                Text(isFastForwarding ? "On" : "Off")
+                    .font(.subheadline.weight(.semibold))
+                Image(systemName: isFastForwarding ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isFastForwarding ? Color.accentColor : .white.opacity(0.45))
+            }
+            .foregroundStyle(.white)
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isFastForwarding ? Color.accentColor.opacity(0.22) : Color.white.opacity(0.06))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isFastForwarding ? Color.accentColor.opacity(0.7) : Color.white.opacity(0.12), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(session == nil)
+        .opacity(session == nil ? 0.35 : 1)
     }
 
     @ViewBuilder

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -5,6 +5,15 @@ import DeltaCore
 import GBADeltaCore
 import GameController
 
+enum NativeEmulatorPlaybackRate {
+    static let normal = 1.0
+    static let fastForward = 2.0
+
+    static func value(isFastForwarding: Bool) -> Double {
+        isFastForwarding ? fastForward : normal
+    }
+}
+
 /// GameViewController subclass that forces the on-screen controller skin to
 /// reload after a rotation. DeltaCore only loads the skin image on initial
 /// layout, so without this the portrait skin stays active in landscape and the
@@ -182,6 +191,8 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     /// SwiftUI layer can show a standalone menu button in their place.
     var onControlsHiddenChanged: ((Bool) -> Void)?
 
+    private(set) var isFastForwarding = false
+
     let viewController: GameViewController
 
     /// Owned here so the display manager can hold it weakly: the target must not
@@ -274,6 +285,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
             // would mute itself if another app still held the audio by then.
             EmulatorAudioSession.activate()
             self.viewController.startEmulation()
+            self.emulatorCore?.rate = NativeEmulatorPlaybackRate.normal
             // Assigning this re-runs that volume decision, now without the
             // ring switch muting a console the user deliberately started.
             self.emulatorCore?.audioManager.respectsSilentMode = false
@@ -292,7 +304,10 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         }
     }
 
-    func pause() { viewController.pauseEmulation() }
+    func pause() {
+        setFastForwarding(false)
+        viewController.pauseEmulation()
+    }
     func resume() {
         viewController.resumeEmulation()
         // Controller may have (dis)connected while paused in the menu.
@@ -305,6 +320,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     }
 
     func stop() {
+        setFastForwarding(false)
         // Pause the render thread before flushing battery — DeltaCore expects
         // the emulator to be paused around save(), otherwise the save can race
         // with an in-flight frame and crash.
@@ -317,6 +333,17 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         externalRenderTarget = nil
         NotificationCenter.default.removeObserver(self)
         emulatorCore?.stop()
+    }
+
+    @discardableResult
+    func toggleFastForward() -> Bool {
+        setFastForwarding(!isFastForwarding)
+        return isFastForwarding
+    }
+
+    private func setFastForwarding(_ enabled: Bool) {
+        isFastForwarding = enabled
+        emulatorCore?.rate = NativeEmulatorPlaybackRate.value(isFastForwarding: enabled)
     }
 
     // MARK: - External display

--- a/romm/rommTests/NativeEmulatorPlaybackRateTests.swift
+++ b/romm/rommTests/NativeEmulatorPlaybackRateTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import romm
+
+struct NativeEmulatorPlaybackRateTests {
+    @Test func normalRateIsOneX() {
+        #expect(NativeEmulatorPlaybackRate.value(isFastForwarding: false) == 1.0)
+    }
+
+    @Test func fastForwardRateIsTwoX() {
+        #expect(NativeEmulatorPlaybackRate.value(isFastForwarding: true) == 2.0)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a 2x fast-forward toggle to the native DeltaCore emulator menu.

## Details

- Applies the pinned DeltaCore `EmulatorCore.rate` API while gameplay is resumed
- Resets playback speed when emulation pauses or stops
- Adds a visible Fast Forward control above save-state actions
- Documents the native-emulation feature

## Testing

- `git diff --check`
- `xcodebuild test -project romm/romm.xcodeproj -scheme romm -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5"`
- `xcodebuild build -project romm/romm.xcodeproj -scheme romm -destination "generic/platform=iOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- Verified the pinned DeltaCore implementation exposes `EmulatorCore.rate` and propagates it to the audio manager
- Added and ran unit coverage for normal and fast-forward rate policy

Manual device installation was not performed because Xcode has no usable development signing identity for the connected iPhone.