### PR TITLE
Play ROMs in RetroArch

### DIFF
--- a/romm/romm/Data/Preferences/UserDefaultsExternalEmulatorHandoffStore.swift
+++ b/romm/romm/Data/Preferences/UserDefaultsExternalEmulatorHandoffStore.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Persists handed-off ROM ids as one id list per target, which keeps `forget`
+/// cheap and avoids scattering a key per ROM across UserDefaults.
+final class UserDefaultsExternalEmulatorHandoffStore: PExternalEmulatorHandoffStore {
+
+    private let keyPrefix = "externalEmulator.handoff."
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func hasHandedOff(romId: Int, to target: ExternalEmulator) -> Bool {
+        romIds(for: target).contains(romId)
+    }
+
+    func markHandedOff(romId: Int, to target: ExternalEmulator) {
+        var ids = romIds(for: target)
+        guard ids.insert(romId).inserted else { return }
+        userDefaults.set(Array(ids), forKey: key(for: target))
+    }
+
+    func forget(romId: Int) {
+        for target in ExternalEmulator.allCases {
+            var ids = romIds(for: target)
+            guard ids.remove(romId) != nil else { continue }
+            userDefaults.set(Array(ids), forKey: key(for: target))
+        }
+    }
+
+    // MARK: - Private
+
+    private func key(for target: ExternalEmulator) -> String {
+        keyPrefix + target.rawValue
+    }
+
+    private func romIds(for target: ExternalEmulator) -> Set<Int> {
+        Set(userDefaults.array(forKey: key(for: target)) as? [Int] ?? [])
+    }
+}

--- a/romm/romm/Data/Preferences/UserDefaultsPlayTargetPreferenceStore.swift
+++ b/romm/romm/Data/Preferences/UserDefaultsPlayTargetPreferenceStore.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Persists the Play destination as a plain string: `"builtIn"` or the raw value
+/// of an `ExternalEmulator`.
+final class UserDefaultsPlayTargetPreferenceStore: PPlayTargetPreference {
+
+    private let key = "emulator.playTarget"
+    private let builtInValue = "builtIn"
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    var current: PlayTarget {
+        get {
+            guard let raw = userDefaults.string(forKey: key), raw != builtInValue else { return .builtIn }
+            // An emulator that was removed from the app in a later version falls
+            // back to the built-in one rather than leaving Play without a target.
+            guard let emulator = ExternalEmulator(rawValue: raw) else { return .builtIn }
+            return .external(emulator)
+        }
+        set {
+            switch newValue {
+            case .builtIn:
+                userDefaults.set(builtInValue, forKey: key)
+            case .external(let emulator):
+                userDefaults.set(emulator.rawValue, forKey: key)
+            }
+        }
+    }
+}

--- a/romm/romm/Data/Services/UIExternalAppLauncher.swift
+++ b/romm/romm/Data/Services/UIExternalAppLauncher.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+final class UIExternalAppLauncher: PExternalAppLauncher {
+
+    @MainActor
+    func isInstalled(_ emulator: ExternalEmulator) -> Bool {
+        guard let url = emulator.probeURL else { return false }
+        return UIApplication.shared.canOpenURL(url)
+    }
+
+    @MainActor
+    func launch(_ emulator: ExternalEmulator, fileName: String) async -> Bool {
+        guard let url = emulator.launchURL(fileName: fileName) else { return false }
+        return await UIApplication.shared.open(url)
+    }
+}

--- a/romm/romm/Domain/Models/ExternalAppLauncher.swift
+++ b/romm/romm/Domain/Models/ExternalAppLauncher.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Opens external emulator apps, so view models can stay free of UIKit.
+protocol PExternalAppLauncher: AnyObject {
+    /// Whether the app is installed. Requires its scheme in `LSApplicationQueriesSchemes`.
+    @MainActor func isInstalled(_ emulator: ExternalEmulator) -> Bool
+    /// Boots a ROM the app has already imported. False when the app refused the link.
+    @MainActor func launch(_ emulator: ExternalEmulator, fileName: String) async -> Bool
+}

--- a/romm/romm/Domain/Models/ExternalEmulator.swift
+++ b/romm/romm/Domain/Models/ExternalEmulator.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// An emulator app outside of RomM that a downloaded ROM can be handed off to.
+///
+/// Handing a ROM over takes two steps: iOS does not let us preselect a target in
+/// the share sheet, so the first launch goes through the system "Open in" menu
+/// and every later one uses the target app's own URL scheme.
+enum ExternalEmulator: String, CaseIterable, Codable, Sendable {
+    case retroarch
+
+    var displayName: String {
+        switch self {
+        case .retroarch: return "RetroArch"
+        }
+    }
+
+    /// Scheme used both for the installation check and for the deep link. It has
+    /// to be listed in `LSApplicationQueriesSchemes` or `canOpenURL` always says no.
+    var urlScheme: String {
+        switch self {
+        case .retroarch: return "retroarch"
+        }
+    }
+
+    var probeURL: URL? {
+        URL(string: "\(urlScheme)://")
+    }
+
+    /// Deep link that boots a ROM the target app has already imported.
+    ///
+    /// RetroArch resolves `retroarch://game/<name.ext>` against its own library,
+    /// so the plain file name is the identifier and nothing has to be hashed.
+    func launchURL(fileName: String) -> URL? {
+        guard !fileName.isEmpty else { return nil }
+        switch self {
+        case .retroarch:
+            var components = URLComponents()
+            components.scheme = urlScheme
+            components.host = "game"
+            components.path = "/\(fileName)"
+            return components.url
+        }
+    }
+
+    /// Whether an app that just received a document is this emulator.
+    ///
+    /// `UIDocumentInteractionController` reports the receiving bundle identifier,
+    /// which is the only reliable signal that the handoff actually happened.
+    /// RetroArch ships under several identifiers (`com.libretro.RetroArch`,
+    /// `…RetroArchiOS11`, plus ad-hoc builds), so match on the substring.
+    func matches(bundleIdentifier: String) -> Bool {
+        switch self {
+        case .retroarch: return bundleIdentifier.lowercased().contains("retroarch")
+        }
+    }
+}
+
+/// Where a Play tap sends the user.
+enum PlayTarget: Hashable, Sendable {
+    case builtIn
+    case external(ExternalEmulator)
+
+    var externalEmulator: ExternalEmulator? {
+        if case .external(let emulator) = self { return emulator }
+        return nil
+    }
+}

--- a/romm/romm/Domain/Models/ExternalEmulatorPreferences.swift
+++ b/romm/romm/Domain/Models/ExternalEmulatorPreferences.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Where the Play button sends a ROM: the built-in emulator or an external app.
+protocol PPlayTargetPreference: AnyObject {
+    var current: PlayTarget { get set }
+}
+
+/// Remembers which ROMs have already been handed to which external emulator.
+///
+/// Once a target app has imported a ROM it can be booted straight through its
+/// URL scheme, so the share sheet only has to appear once per ROM and target.
+protocol PExternalEmulatorHandoffStore: AnyObject {
+    func hasHandedOff(romId: Int, to target: ExternalEmulator) -> Bool
+    func markHandedOff(romId: Int, to target: ExternalEmulator)
+    /// Drops the handoff state for a ROM, e.g. after it was deleted locally.
+    func forget(romId: Int)
+}

--- a/romm/romm/Domain/UseCases/LocalROMs/GetROMShareFilesUseCase.swift
+++ b/romm/romm/Domain/UseCases/LocalROMs/GetROMShareFilesUseCase.swift
@@ -5,6 +5,10 @@ protocol PGetROMShareFilesUseCase {
 }
 
 final class GetROMShareFilesUseCase: PGetROMShareFilesUseCase {
+    static let shareDirectoryPrefix = "ROMShare-"
+    /// How long a share copy is kept around before the next share may delete it.
+    static let shareDirectoryLifetime: TimeInterval = 60 * 60
+
     private let localROMRepository: PLocalROMRepository
 
     init(localROMRepository: PLocalROMRepository) {
@@ -14,8 +18,9 @@ final class GetROMShareFilesUseCase: PGetROMShareFilesUseCase {
     func execute(rom: DownloadedROM) -> (files: [URL], tempDirectory: URL?) {
         let romsBaseURL = localROMRepository.romsBaseURL
         let fileManager = FileManager.default
+        purgeStaleShareDirectories(fileManager: fileManager)
         let shareDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("ROMShare-\(UUID().uuidString)")
+            .appendingPathComponent("\(Self.shareDirectoryPrefix)\(UUID().uuidString)")
         try? fileManager.createDirectory(at: shareDirectory, withIntermediateDirectories: true)
 
         var romDirectoryURL = romsBaseURL.appendingPathComponent(rom.localDirectory)
@@ -39,6 +44,28 @@ final class GetROMShareFilesUseCase: PGetROMShareFilesUseCase {
         }
 
         return (urls, urls.isEmpty ? nil : shareDirectory)
+    }
+
+    /// Removes leftovers from earlier shares.
+    ///
+    /// The copy cannot be deleted right after handing it over: apps that open
+    /// documents in place (RetroArch) read straight from this directory while
+    /// importing. So the cleanup is deferred to the next share instead, and only
+    /// touches directories old enough that no import can still be running.
+    private func purgeStaleShareDirectories(fileManager: FileManager) {
+        let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: temporaryDirectory,
+            includingPropertiesForKeys: [.creationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        let cutoff = Date().addingTimeInterval(-Self.shareDirectoryLifetime)
+        for entry in entries where entry.lastPathComponent.hasPrefix(Self.shareDirectoryPrefix) {
+            let created = (try? entry.resourceValues(forKeys: [.creationDateKey]))?.creationDate
+            guard let created, created < cutoff else { continue }
+            try? fileManager.removeItem(at: entry)
+        }
     }
 
     private func findActualPath(romsBaseURL: URL, romName: String, fileManager: FileManager) -> URL? {

--- a/romm/romm/Info.plist
+++ b/romm/romm/Info.plist
@@ -15,6 +15,10 @@
 			</array>
 		</dict>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>retroarch</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -118,8 +118,14 @@ protocol PDependencyFactory {
     var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference { get }
     var externalDisplayPreference: PExternalDisplayPreference { get }
     var screenBrightness: PScreenBrightness { get }
+
     func makePlatformEngineSupport() -> PPlatformEngineSupport
     func makeControllerSkinsUseCase() -> PControllerSkinsUseCase
+
+    // External emulator apps
+    var playTargetPreference: PPlayTargetPreference { get }
+    var externalEmulatorHandoffStore: PExternalEmulatorHandoffStore { get }
+    var externalAppLauncher: PExternalAppLauncher { get }
 
     // SFTP ViewModels
     @MainActor func makeSFTPDevicesViewModel() -> SFTPDevicesViewModel
@@ -390,6 +396,12 @@ class DefaultDependencyFactory: PDependencyFactory {
     lazy var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference = UserDefaultsEmulatorMenuShortcutPreferenceStore()
     lazy var externalDisplayPreference: PExternalDisplayPreference = UserDefaultsExternalDisplayPreferenceStore()
     lazy var screenBrightness: PScreenBrightness = UIScreenBrightness()
+
+    // MARK: - External Emulator Apps
+
+    lazy var playTargetPreference: PPlayTargetPreference = UserDefaultsPlayTargetPreferenceStore()
+    lazy var externalEmulatorHandoffStore: PExternalEmulatorHandoffStore = UserDefaultsExternalEmulatorHandoffStore()
+    lazy var externalAppLauncher: PExternalAppLauncher = UIExternalAppLauncher()
 
     // MARK: - Controller Skins
 

--- a/romm/romm/UI/DI/MockDependencyFactory.swift
+++ b/romm/romm/UI/DI/MockDependencyFactory.swift
@@ -38,6 +38,11 @@ class MockDependencyFactory: PDependencyFactory {
     lazy var externalDisplayPreference: PExternalDisplayPreference = InMemoryExternalDisplayPreference()
     lazy var screenBrightness: PScreenBrightness = UIScreenBrightness()
 
+    // External emulator apps
+    lazy var playTargetPreference: PPlayTargetPreference = UserDefaultsPlayTargetPreferenceStore()
+    lazy var externalEmulatorHandoffStore: PExternalEmulatorHandoffStore = UserDefaultsExternalEmulatorHandoffStore()
+    lazy var externalAppLauncher: PExternalAppLauncher = UIExternalAppLauncher()
+
     // Controller skins
     private lazy var controllerSkinInspector: PControllerSkinInspector = DeltaControllerSkinInspector()
     private lazy var controllerSkinRepository: PControllerSkinRepository = ControllerSkinRepository(inspector: controllerSkinInspector)

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -183,7 +183,13 @@ struct RomDetailView: View {
                     ), onDismiss: {
                         viewModel.cleanupShareTemp()
                     }) { item in
-                        ShareSheet(activityItems: item.urls)
+                        ShareSheet(activityItems: item.urls) { activityType in
+                            guard let activityType else { return }
+                            viewModel.handoffDidComplete(
+                                romId: currentSelectedRom.id,
+                                receivingBundleIdentifier: activityType
+                            )
+                        }
                     }
                     .sheet(isPresented: $showingSFTPUpload) {
                         SFTPUploadView(rom: currentSelectedRom)
@@ -297,6 +303,7 @@ struct RomDetailView: View {
                     await viewModel.loadRomDetails(romId: rom.id)
                 }
                 viewModel.refreshDownloadState(romId: rom.id)
+                viewModel.refreshPlayTarget()
             }
             .toast(
                 isPresented: $viewModel.showAddedToast,
@@ -498,10 +505,12 @@ struct RomDetailView: View {
 
                 // Only offered for a ROM that is already on the device, on a
                 // platform we can emulate, and with the in-app emulator switched
-                // on, so it never leads to a dead end.
+                // on, so it never leads to a dead end. Handing the ROM to an
+                // external app has none of those limits: the other emulator
+                // decides what it supports.
                 if downloadState == .downloaded
-                    && viewModel.canPlayEmulator
-                    && experimentalSettings.isEmulatorEnabled {
+                    && (viewModel.playsExternally
+                        || (viewModel.canPlayEmulator && experimentalSettings.isEmulatorEnabled)) {
                     Button(action: { startPlay() }) {
                         Group {
                             if viewModel.isLaunchingEmulator {
@@ -522,8 +531,24 @@ struct RomDetailView: View {
                     }
                     .disabled(viewModel.isLaunchingEmulator)
                     .accessibilityLabel("Play")
-                    .accessibility(hint: Text("Play this ROM on this device"))
+                    .accessibility(hint: Text(viewModel.playsExternally
+                        ? "Play this ROM in the external emulator set in Settings"
+                        : "Play this ROM on this device"))
                     .transition(.scale.combined(with: .opacity))
+                    // Anchors the "Open in" popover on iPad to the Play button.
+                    .background(
+                        OpenInMenuPresenter(
+                            item: viewModel.openInItem,
+                            onSent: { bundleIdentifier in
+                                viewModel.handoffDidComplete(
+                                    romId: currentSelectedRom.id,
+                                    receivingBundleIdentifier: bundleIdentifier
+                                )
+                            },
+                            onDismiss: { viewModel.openInItem = nil },
+                            onNoTargets: { viewModel.handoffFoundNoTargets() }
+                        )
+                    )
                 }
             }
             .animation(.easeOut(duration: 0.25), value: downloadState == .downloaded)
@@ -568,6 +593,9 @@ struct RomDetailView: View {
     /// actually load them, otherwise boot straight into a fresh session.
     private func startPlay() {
         Task {
+            // An external emulator owns the whole launch, including its own
+            // save states, so the resume dialog below never applies to it.
+            if await viewModel.playExternally(rom: currentSelectedRom) { return }
             guard let decision = await viewModel.resolveLaunch(rom: currentSelectedRom) else { return }
             let states = (try? saveStore.listStates(romId: rom.id)) ?? []
             guard decision.supportsSaveStates, !states.isEmpty else {

--- a/romm/romm/UI/RomDetail/RomDetailViewModel.swift
+++ b/romm/romm/UI/RomDetail/RomDetailViewModel.swift
@@ -47,6 +47,12 @@ class RomDetailViewModel {
     var shareItem: ShareURLsItem? = nil
     var showAddedToast: Bool = false
 
+    // External emulator handoff
+    /// File waiting to be handed to an external emulator through the "Open in" menu.
+    var openInItem: OpenInItem? = nil
+    /// Play destination, mirrored into state so the button reacts to a settings change.
+    var playTarget: PlayTarget = .builtIn
+
     /// Shared, app-wide download queue. Downloads keep running after this screen
     /// is dismissed; the queue is viewable from the Downloads tab.
     let downloadQueue = DownloadQueueManager.shared
@@ -84,6 +90,9 @@ class RomDetailViewModel {
     private let updateLastPlayedUseCase: PUpdateLastPlayedUseCase
     private let getDownloadedROMUseCase: PGetDownloadedROMUseCase
     private let getROMShareFilesUseCase: PGetROMShareFilesUseCase
+    private let playTargetPreference: PPlayTargetPreference
+    private let externalEmulatorHandoffStore: PExternalEmulatorHandoffStore
+    private let externalAppLauncher: PExternalAppLauncher
 
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared,
          apiClient: PRommAPIClient = RommAPIClient.shared) {
@@ -98,6 +107,10 @@ class RomDetailViewModel {
         self.updateLastPlayedUseCase = factory.makeUpdateLastPlayedUseCase()
         self.getDownloadedROMUseCase = factory.makeGetDownloadedROMUseCase()
         self.getROMShareFilesUseCase = factory.makeGetROMShareFilesUseCase()
+        self.playTargetPreference = factory.playTargetPreference
+        self.externalEmulatorHandoffStore = factory.externalEmulatorHandoffStore
+        self.externalAppLauncher = factory.externalAppLauncher
+        self.playTarget = factory.playTargetPreference.current
     }
     
     func loadRomDetails(romId: Int) async {
@@ -373,11 +386,16 @@ class RomDetailViewModel {
     func present(_ decision: LaunchDecision, rom: Rom) {
         logger.info("Launching emulator for ROM: \(rom.name) — decision: \(String(describing: decision))")
         self.launchDecision = decision
+        markPlayed(romId: rom.id)
+    }
+
+    /// Reports the ROM as played to the server, best effort.
+    private func markPlayed(romId: Int) {
         Task { [updateLastPlayedUseCase, logger] in
             do {
-                try await updateLastPlayedUseCase.execute(romId: rom.id)
+                try await updateLastPlayedUseCase.execute(romId: romId)
             } catch {
-                logger.warning("Failed to update last_played for ROM \(rom.id): \(error)")
+                logger.warning("Failed to update last_played for ROM \(romId): \(error)")
             }
         }
     }
@@ -417,11 +435,117 @@ class RomDetailViewModel {
         }
     }
 
-    /// Cleans up the temporary directory created for sharing.
+    /// Dismisses the share sheet.
+    ///
+    /// The temp copy is deliberately left behind: apps that open documents in
+    /// place (RetroArch) still read from it while importing, and deleting it here
+    /// would truncate the import. `GetROMShareFilesUseCase` collects old copies on
+    /// the next share instead.
     func cleanupShareTemp() {
-        if let dir = shareItem?.tempDirectory {
-            try? FileManager.default.removeItem(at: dir)
-        }
         shareItem = nil
+    }
+
+    // MARK: - External Emulator
+
+    /// True when Play hands the ROM to another app instead of emulating it here.
+    var playsExternally: Bool { playTarget.externalEmulator != nil }
+
+    /// Re-reads the Play destination, e.g. after coming back from settings.
+    func refreshPlayTarget() {
+        playTarget = playTargetPreference.current
+    }
+
+    /// Routes a Play tap to the configured external emulator.
+    ///
+    /// The first launch has to go through the system "Open in" menu because iOS
+    /// does not let us preselect a target; once the app has imported the ROM, its
+    /// URL scheme boots it directly.
+    ///
+    /// - Returns: false when the built-in emulator should take over instead.
+    func playExternally(rom: Rom) async -> Bool {
+        guard let target = playTarget.externalEmulator else { return false }
+
+        guard externalAppLauncher.isInstalled(target) else {
+            errorMessage = "\(target.displayName) is not installed. Install it, or switch Play back to the built-in emulator in Settings."
+            return true
+        }
+
+        guard let resolved = try? getDownloadedROMUseCase.execute(romId: rom.id) else {
+            errorMessage = "Download this ROM before opening it in \(target.displayName)."
+            return true
+        }
+
+        if externalEmulatorHandoffStore.hasHandedOff(romId: rom.id, to: target),
+           let fileName = primaryFileName(of: resolved.rom) {
+            if await externalAppLauncher.launch(target, fileName: fileName) {
+                logger.info("Launched ROM \(rom.id) in \(target.displayName)")
+                markPlayed(romId: rom.id)
+                return true
+            }
+            // The app turned the link down, so its library no longer holds the
+            // ROM. Hand it over again rather than leaving Play dead.
+            logger.info("\(target.displayName) rejected the deep link, handing the ROM over again")
+            externalEmulatorHandoffStore.forget(romId: rom.id)
+        }
+
+        await presentHandoff(of: resolved.rom, to: target)
+        return true
+    }
+
+    /// Records that an "Open in" menu actually delivered the ROM, so the next Play
+    /// tap can deep link instead of asking again.
+    func handoffDidComplete(romId: Int, receivingBundleIdentifier: String) {
+        guard let target = playTarget.externalEmulator else { return }
+        guard target.matches(bundleIdentifier: receivingBundleIdentifier) else {
+            logger.info("ROM \(romId) went to \(receivingBundleIdentifier), not \(target.displayName) — not remembered")
+            return
+        }
+        externalEmulatorHandoffStore.markHandedOff(romId: romId, to: target)
+        markPlayed(romId: romId)
+    }
+
+    /// No installed app claims this file type, so the "Open in" menu stayed empty.
+    func handoffFoundNoTargets() {
+        let name = playTarget.externalEmulator?.displayName ?? "the external emulator"
+        errorMessage = "No app on this device can open this ROM. Make sure \(name) is installed and supports this file type."
+        openInItem = nil
+    }
+
+    // MARK: - Private
+
+    private func presentHandoff(of rom: DownloadedROM, to target: ExternalEmulator) async {
+        // Handing a file over means copying it out of the ROM folder first, which
+        // for a disc image is not instant. Show the Play spinner while it runs.
+        isLaunchingEmulator = true
+        await Task.yield()
+        let result = getROMShareFilesUseCase.execute(rom: rom)
+        isLaunchingEmulator = false
+
+        guard !result.files.isEmpty else {
+            errorMessage = "No files available to open."
+            return
+        }
+        // The "Open in" menu carries a single document. Multi-file ROMs such as
+        // cue/bin need every part, so those go through the share sheet, which the
+        // user then has to point at the emulator themselves.
+        if result.files.count == 1, let url = result.files.first {
+            openInItem = OpenInItem(url: url, tempDirectory: result.tempDirectory)
+        } else {
+            shareItem = ShareURLsItem(urls: result.files, tempDirectory: result.tempDirectory)
+        }
+    }
+
+    /// The file an external emulator should be pointed at.
+    ///
+    /// Disc-based ROMs ship a playlist or sheet next to the data tracks, and that
+    /// is the file emulators expect — a raw `.bin` boots nothing.
+    private func primaryFileName(of rom: DownloadedROM) -> String? {
+        let preferredExtensions = ["m3u", "cue"]
+        for ext in preferredExtensions {
+            if let match = rom.files.first(where: { $0.fileName.lowercased().hasSuffix(".\(ext)") }) {
+                return match.fileName
+            }
+        }
+        return rom.files.first?.fileName
     }
 }

--- a/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
+++ b/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
@@ -3,8 +3,12 @@ import SwiftUI
 struct EmulatorEngineSettingsView: View {
     @State private var selection: EmulatorEngine
     @State private var menuShortcut: EmulatorMenuShortcut
+    @State private var playTarget: PlayTarget
+    @State private var installedEmulators: [ExternalEmulator] = []
     private let preference: PEmulatorEnginePreference
     private let menuShortcutPreference: PEmulatorMenuShortcutPreference
+    private let playTargetPreference: PPlayTargetPreference
+    private let externalAppLauncher: PExternalAppLauncher
 
     #if DEBUG
     @State private var simulateController = EmulatorControllerState.simulateConnected
@@ -13,8 +17,11 @@ struct EmulatorEngineSettingsView: View {
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
         self.preference = factory.enginePreference
         self.menuShortcutPreference = factory.emulatorMenuShortcutPreference
+        self.playTargetPreference = factory.playTargetPreference
+        self.externalAppLauncher = factory.externalAppLauncher
         _selection = State(wrappedValue: factory.enginePreference.current)
         _menuShortcut = State(wrappedValue: factory.emulatorMenuShortcutPreference.current)
+        _playTarget = State(wrappedValue: factory.playTargetPreference.current)
     }
 
     var body: some View {
@@ -37,6 +44,8 @@ struct EmulatorEngineSettingsView: View {
                     }
                 }
             }
+
+            playTargetSection
 
             Section(footer: Text("When a physical controller is connected, the on-screen buttons hide and you can drag the game to reposition it — handy for gamepad cases that cover part of the screen. Set its size from the in-game menu.")) { EmptyView() }
 
@@ -64,7 +73,51 @@ struct EmulatorEngineSettingsView: View {
             #endif
         }
         .navigationTitle("Emulator")
+        .onAppear { refreshInstalledEmulators() }
         .onChange(of: selection) { _, new in preference.current = new }
         .onChange(of: menuShortcut) { _, new in menuShortcutPreference.current = new }
+        .onChange(of: playTarget) { _, new in playTargetPreference.current = new }
+    }
+
+    /// Lets Play hand the ROM to another emulator app instead of running it here.
+    @ViewBuilder
+    private var playTargetSection: some View {
+        if installedEmulators.isEmpty && playTarget == .builtIn {
+            Section(
+                header: Text("Play with"),
+                footer: Text("Install RetroArch to play ROMs there instead of in the built-in emulator.")
+            ) {
+                HStack {
+                    Text("Play with")
+                    Spacer()
+                    Text("Built-in emulator").foregroundStyle(.secondary)
+                }
+            }
+        } else {
+            Section(
+                header: Text("Play with"),
+                footer: Text("The first time a ROM goes to another app you pick it from the system menu, which also imports the file. Every Play after that opens it there directly. Save states are not shared between the apps.")
+            ) {
+                Picker("Play with", selection: $playTarget) {
+                    Text("Built-in emulator").tag(PlayTarget.builtIn)
+                    ForEach(pickableEmulators, id: \.self) { emulator in
+                        Text(emulator.displayName).tag(PlayTarget.external(emulator))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Installed apps, plus whatever is currently selected so an uninstalled
+    /// choice does not silently disappear from the picker.
+    private var pickableEmulators: [ExternalEmulator] {
+        guard let selected = playTarget.externalEmulator, !installedEmulators.contains(selected) else {
+            return installedEmulators
+        }
+        return installedEmulators + [selected]
+    }
+
+    private func refreshInstalledEmulators() {
+        installedEmulators = ExternalEmulator.allCases.filter(externalAppLauncher.isInstalled)
     }
 }

--- a/romm/romm/UI/Shared/Components/OpenInMenuPresenter.swift
+++ b/romm/romm/UI/Shared/Components/OpenInMenuPresenter.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import UIKit
+
+/// A single ROM file on its way to another app.
+struct OpenInItem: Identifiable, Equatable {
+    let id = UUID()
+    let url: URL
+    /// Temp directory holding the copy that was handed over.
+    let tempDirectory: URL?
+}
+
+/// Presents the system "Open in" menu for a single file.
+///
+/// Unlike `UIActivityViewController` this lists only apps that can actually open
+/// the document, which is what handing a ROM to an emulator should offer — no
+/// Mail, AirDrop or Save to Files in between. It also reports the receiving
+/// bundle identifier, the only reliable signal that the handoff happened.
+///
+/// Place it in a `.background()` of the control that triggers it: the anchor rect
+/// for the iPad popover is then the control itself.
+struct OpenInMenuPresenter: UIViewRepresentable {
+    /// Set to a value to present the menu, back to nil to reset.
+    let item: OpenInItem?
+    /// Bundle identifier of the app the file was sent to.
+    let onSent: (String) -> Void
+    /// Menu closed, either after sending or by cancelling.
+    let onDismiss: () -> Void
+    /// No installed app can open this file type.
+    let onNoTargets: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = .clear
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        let coordinator = context.coordinator
+        coordinator.onSent = onSent
+        coordinator.onDismiss = onDismiss
+        coordinator.onNoTargets = onNoTargets
+
+        guard let item else {
+            coordinator.reset()
+            return
+        }
+        // The view has just been handed to SwiftUI and may not be in a window
+        // yet; presenting from a window-less view silently fails.
+        DispatchQueue.main.async {
+            coordinator.present(item, from: uiView)
+        }
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, UIDocumentInteractionControllerDelegate {
+        var onSent: ((String) -> Void)?
+        var onDismiss: (() -> Void)?
+        var onNoTargets: (() -> Void)?
+
+        /// `UIDocumentInteractionController` is not retained by UIKit while the
+        /// menu is up, so it has to be held here.
+        private var controller: UIDocumentInteractionController?
+        private var presentedItemID: UUID?
+
+        func present(_ item: OpenInItem, from view: UIView) {
+            guard presentedItemID != item.id, view.window != nil else { return }
+            presentedItemID = item.id
+
+            let controller = UIDocumentInteractionController(url: item.url)
+            controller.delegate = self
+            self.controller = controller
+
+            if !controller.presentOpenInMenu(from: view.bounds, in: view, animated: true) {
+                self.controller = nil
+                onNoTargets?()
+            }
+        }
+
+        func reset() {
+            presentedItemID = nil
+            controller = nil
+        }
+
+        nonisolated func documentInteractionController(
+            _ controller: UIDocumentInteractionController,
+            didEndSendingToApplication application: String?
+        ) {
+            guard let application else { return }
+            MainActor.assumeIsolated { onSent?(application) }
+        }
+
+        nonisolated func documentInteractionControllerDidDismissOpenInMenu(
+            _ controller: UIDocumentInteractionController
+        ) {
+            MainActor.assumeIsolated {
+                self.controller = nil
+                onDismiss?()
+            }
+        }
+    }
+}

--- a/romm/romm/UI/Shared/Components/ShareSheet.swift
+++ b/romm/romm/UI/Shared/Components/ShareSheet.swift
@@ -5,6 +5,9 @@ import UniformTypeIdentifiers
 /// Shared component for presenting iOS share sheet
 struct ShareSheet: UIViewControllerRepresentable {
     let activityItems: [Any]
+    /// Called with the activity that handled the share. For "Open in <app>" this
+    /// is the receiving bundle identifier, which is how a handoff is confirmed.
+    var onCompleted: ((String?) -> Void)? = nil
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
         print("🔧 Creating UIActivityViewController with \(activityItems.count) items")
@@ -45,6 +48,7 @@ struct ShareSheet: UIViewControllerRepresentable {
                 print("❌ Share failed: \(error.localizedDescription)")
             } else if completed {
                 print("✅ Share completed with: \(activityType?.rawValue ?? "unknown")")
+                onCompleted?(activityType?.rawValue)
             } else {
                 print("⚠️ Share cancelled")
             }

--- a/romm/rommTests/ExternalEmulatorHandoffStoreTests.swift
+++ b/romm/rommTests/ExternalEmulatorHandoffStoreTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import Foundation
+@testable import romm
+
+struct ExternalEmulatorHandoffStoreTests {
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+    }
+
+    @Test func nothingIsHandedOffInitially() {
+        let store = UserDefaultsExternalEmulatorHandoffStore(userDefaults: makeDefaults())
+        #expect(!store.hasHandedOff(romId: 1, to: .retroarch))
+    }
+
+    @Test func remembersAHandoffPerRom() {
+        let store = UserDefaultsExternalEmulatorHandoffStore(userDefaults: makeDefaults())
+        store.markHandedOff(romId: 1, to: .retroarch)
+        #expect(store.hasHandedOff(romId: 1, to: .retroarch))
+        #expect(!store.hasHandedOff(romId: 2, to: .retroarch))
+    }
+
+    @Test func persistsAcrossInstances() {
+        let defaults = makeDefaults()
+        UserDefaultsExternalEmulatorHandoffStore(userDefaults: defaults)
+            .markHandedOff(romId: 7, to: .retroarch)
+        let reopened = UserDefaultsExternalEmulatorHandoffStore(userDefaults: defaults)
+        #expect(reopened.hasHandedOff(romId: 7, to: .retroarch))
+    }
+
+    @Test func markingTwiceKeepsASingleEntry() {
+        let store = UserDefaultsExternalEmulatorHandoffStore(userDefaults: makeDefaults())
+        store.markHandedOff(romId: 3, to: .retroarch)
+        store.markHandedOff(romId: 3, to: .retroarch)
+        #expect(store.hasHandedOff(romId: 3, to: .retroarch))
+    }
+
+    /// Called when a deep link is refused or the ROM is deleted, so the next Play
+    /// hands the file over again instead of dead-ending.
+    @Test func forgetDropsTheRomFromEveryTarget() {
+        let store = UserDefaultsExternalEmulatorHandoffStore(userDefaults: makeDefaults())
+        store.markHandedOff(romId: 4, to: .retroarch)
+        store.markHandedOff(romId: 5, to: .retroarch)
+
+        store.forget(romId: 4)
+
+        #expect(!store.hasHandedOff(romId: 4, to: .retroarch))
+        #expect(store.hasHandedOff(romId: 5, to: .retroarch))
+    }
+
+    @Test func forgettingAnUnknownRomIsHarmless() {
+        let store = UserDefaultsExternalEmulatorHandoffStore(userDefaults: makeDefaults())
+        store.markHandedOff(romId: 1, to: .retroarch)
+        store.forget(romId: 99)
+        #expect(store.hasHandedOff(romId: 1, to: .retroarch))
+    }
+}
+
+struct PlayTargetPreferenceTests {
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+    }
+
+    @Test func defaultsToTheBuiltInEmulator() {
+        let preference = UserDefaultsPlayTargetPreferenceStore(userDefaults: makeDefaults())
+        #expect(preference.current == .builtIn)
+    }
+
+    @Test func persistsAcrossInstances() {
+        let defaults = makeDefaults()
+        let preference = UserDefaultsPlayTargetPreferenceStore(userDefaults: defaults)
+        preference.current = .external(.retroarch)
+        let reopened = UserDefaultsPlayTargetPreferenceStore(userDefaults: defaults)
+        #expect(reopened.current == .external(.retroarch))
+    }
+
+    @Test func switchingBackToBuiltInSticks() {
+        let defaults = makeDefaults()
+        let preference = UserDefaultsPlayTargetPreferenceStore(userDefaults: defaults)
+        preference.current = .external(.retroarch)
+        preference.current = .builtIn
+        #expect(UserDefaultsPlayTargetPreferenceStore(userDefaults: defaults).current == .builtIn)
+    }
+
+    /// An emulator dropped in a later app version must not leave Play pointing at
+    /// something that no longer exists.
+    @Test func unknownEmulatorFallsBackToBuiltIn() {
+        let defaults = makeDefaults()
+        defaults.set("someRetiredEmulator", forKey: "emulator.playTarget")
+        let preference = UserDefaultsPlayTargetPreferenceStore(userDefaults: defaults)
+        #expect(preference.current == .builtIn)
+    }
+}

--- a/romm/rommTests/ExternalEmulatorTests.swift
+++ b/romm/rommTests/ExternalEmulatorTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+@testable import romm
+
+struct ExternalEmulatorTests {
+
+    @Test func retroArchLaunchURLUsesTheFileName() {
+        let url = ExternalEmulator.retroarch.launchURL(fileName: "Sonic.md")
+        #expect(url?.absoluteString == "retroarch://game/Sonic.md")
+    }
+
+    /// File names routinely contain spaces, brackets and hashes, all of which
+    /// break a URL that is glued together as a string.
+    @Test func retroArchLaunchURLEscapesSpecialCharacters() {
+        let url = ExternalEmulator.retroarch.launchURL(fileName: "Super Mario 64 (USA) #1.z64")
+        #expect(url?.absoluteString == "retroarch://game/Super%20Mario%2064%20(USA)%20%231.z64")
+    }
+
+    @Test func launchURLIsNilWithoutAFileName() {
+        #expect(ExternalEmulator.retroarch.launchURL(fileName: "") == nil)
+    }
+
+    @Test func probeURLIsTheBareScheme() {
+        #expect(ExternalEmulator.retroarch.probeURL?.absoluteString == "retroarch://")
+    }
+
+    /// RetroArch ships under several bundle identifiers, so the match is on the
+    /// substring rather than one fixed id.
+    @Test(arguments: [
+        "com.libretro.RetroArch",
+        "com.libretro.RetroArchiOS11",
+        "COM.LIBRETRO.RETROARCH"
+    ])
+    func recognisesRetroArchBundleIdentifiers(identifier: String) {
+        #expect(ExternalEmulator.retroarch.matches(bundleIdentifier: identifier))
+    }
+
+    @Test(arguments: ["com.rileytestut.Delta", "com.apple.mobilemail", ""])
+    func rejectsOtherBundleIdentifiers(identifier: String) {
+        #expect(!ExternalEmulator.retroarch.matches(bundleIdentifier: identifier))
+    }
+}


### PR DESCRIPTION
Erster Teil von #109: Play kann eine ROM an RetroArch übergeben statt sie selbst zu emulieren.

Weil iOS kein Share-Sheet-Ziel vorauswählen lässt, läuft die Übergabe zweistufig. Das erste Play öffnet das "Open in"-Menü und importiert die Datei, jedes weitere Play springt per `retroarch://game/<datei>` direkt rein. Das Ziel stellt man in Settings > Emulator unter "Play with" ein, der Picker zeigt nur installierte Apps.

Der Play-Button erscheint jetzt auch für Plattformen, die der eingebaute Emulator nicht kann, wenn ein externes Ziel gesetzt ist.

Nebenbei: Share-Kopien werden nicht mehr sofort nach dem Schließen des Sheets gelöscht. RetroArch liest die Datei in-place und noch während des Imports aus dem Temp-Ordner, der Cleanup passiert jetzt beim nächsten Share.

Getestet: Build und Unit-Tests grün. Der Handoff selbst braucht ein Gerät mit RetroArch, das steht noch aus.