### PR TITLE
Swap the face buttons on a physical controller

### DIFF
--- a/romm/romm/Data/Preferences/UserDefaultsGamepadFaceButtonPreferenceStore.swift
+++ b/romm/romm/Data/Preferences/UserDefaultsGamepadFaceButtonPreferenceStore.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+final class UserDefaultsGamepadFaceButtonPreferenceStore: PGamepadFaceButtonPreference {
+    private let key = "emulator.gamepad.swapFaceButtons"
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    var isSwapped: Bool {
+        get { userDefaults.bool(forKey: key) }
+        set { userDefaults.set(newValue, forKey: key) }
+    }
+}

--- a/romm/romm/Domain/Models/GamepadFaceButtonPreference.swift
+++ b/romm/romm/Domain/Models/GamepadFaceButtonPreference.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Whether the two pairs of face buttons are swapped before they reach a core.
+///
+/// GameController reports face buttons by position, never by the label printed
+/// on the pad, so a Nintendo-style controller (B at the bottom, A on the right)
+/// arrives mirrored against what the player reads on the hardware. Flipping A/B
+/// and X/Y puts the labels back in place.
+///
+/// One switch instead of a free remapper, same reasoning as
+/// `EmulatorMenuShortcut`: it covers the layout players actually run into
+/// without turning input into a configuration surface.
+protocol PGamepadFaceButtonPreference: AnyObject {
+    /// `false` leaves each engine on the mapping it has always used.
+    var isSwapped: Bool { get set }
+}

--- a/romm/romm/Info.plist
+++ b/romm/romm/Info.plist
@@ -47,6 +47,15 @@
 		<key>NSExceptionRequiresForwardSecrecy</key>
 		<false/>
 	</dict>
+	<key>GCSupportsControllerUserInteraction</key>
+	<true/>
+	<key>GCSupportedGameControllers</key>
+	<array>
+		<dict>
+			<key>ProfileName</key>
+			<string>ExtendedGamepad</string>
+		</dict>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -124,6 +124,7 @@ protocol PDependencyFactory {
     var libretroAspectRatioPreference: PLibretroAspectRatioPreference { get }
     var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference { get }
     var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference { get }
+    var gamepadFaceButtonPreference: PGamepadFaceButtonPreference { get }
     var externalDisplayPreference: PExternalDisplayPreference { get }
     var screenBrightness: PScreenBrightness { get }
 
@@ -413,6 +414,7 @@ class DefaultDependencyFactory: PDependencyFactory {
     lazy var libretroAspectRatioPreference: PLibretroAspectRatioPreference = UserDefaultsLibretroAspectRatioPreferenceStore()
     lazy var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference = UserDefaultsEmulatorScreenPositionPreferenceStore()
     lazy var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference = UserDefaultsEmulatorMenuShortcutPreferenceStore()
+    lazy var gamepadFaceButtonPreference: PGamepadFaceButtonPreference = UserDefaultsGamepadFaceButtonPreferenceStore()
     lazy var externalDisplayPreference: PExternalDisplayPreference = UserDefaultsExternalDisplayPreferenceStore()
     lazy var screenBrightness: PScreenBrightness = UIScreenBrightness()
 

--- a/romm/romm/UI/DI/MockDependencyFactory.swift
+++ b/romm/romm/UI/DI/MockDependencyFactory.swift
@@ -35,6 +35,7 @@ class MockDependencyFactory: PDependencyFactory {
     lazy var libretroAspectRatioPreference: PLibretroAspectRatioPreference = InMemoryLibretroAspectRatioPreference()
     lazy var emulatorScreenPositionPreference: PEmulatorScreenPositionPreference = InMemoryEmulatorScreenPositionPreference()
     lazy var emulatorMenuShortcutPreference: PEmulatorMenuShortcutPreference = UserDefaultsEmulatorMenuShortcutPreferenceStore()
+    lazy var gamepadFaceButtonPreference: PGamepadFaceButtonPreference = UserDefaultsGamepadFaceButtonPreferenceStore()
     lazy var externalDisplayPreference: PExternalDisplayPreference = InMemoryExternalDisplayPreference()
     lazy var screenBrightness: PScreenBrightness = UIScreenBrightness()
 

--- a/romm/romm/UI/Emulator/Libretro/LibretroControllerInput.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroControllerInput.swift
@@ -9,6 +9,8 @@ import GameController
 /// is RETRO_DEVICE_ID_JOYPAD_B (index 0) and the right face button is
 /// RETRO_DEVICE_ID_JOYPAD_A (index 8), so physical A/B and X/Y are
 /// cross-mapped from the Xbox-style GCController naming to the SNES layout.
+/// `PGamepadFaceButtonPreference` flips those two pairs back for pads whose
+/// labels run the other way round.
 ///
 /// Writes go straight to `buttonState` from the handler, exactly like the touch
 /// path in LibretroTouchControllerView. The core reads that array from the
@@ -19,6 +21,7 @@ final class LibretroControllerInput {
 
     private weak var frontend: LibretroFrontend?
     private let menuShortcutPreference: PEmulatorMenuShortcutPreference?
+    private let faceButtonPreference: PGamepadFaceButtonPreference?
     var onMenuRequested: (() -> Void)?
 
     /// Digital buttons currently held, used to detect the menu shortcut combo.
@@ -27,9 +30,14 @@ final class LibretroControllerInput {
     /// while the buttons stay held.
     private var comboLatched = false
 
-    init(frontend: LibretroFrontend, menuShortcutPreference: PEmulatorMenuShortcutPreference? = nil) {
+    init(
+        frontend: LibretroFrontend,
+        menuShortcutPreference: PEmulatorMenuShortcutPreference? = nil,
+        faceButtonPreference: PGamepadFaceButtonPreference? = nil
+    ) {
         self.frontend = frontend
         self.menuShortcutPreference = menuShortcutPreference
+        self.faceButtonPreference = faceButtonPreference
     }
 
     // MARK: - Connect / Disconnect
@@ -52,11 +60,13 @@ final class LibretroControllerInput {
 
         // Face buttons (SNES/libretro layout: bottom = B, right = A, left = Y, top = X)
         // GCController uses Xbox names: buttonA = bottom, buttonB = right,
-        // buttonX = left, buttonY = top.
-        pad.buttonA.valueChangedHandler = handler(for: .b)
-        pad.buttonB.valueChangedHandler = handler(for: .a)
-        pad.buttonX.valueChangedHandler = handler(for: .y)
-        pad.buttonY.valueChangedHandler = handler(for: .x)
+        // buttonX = left, buttonY = top. The pairs flip when the player has told
+        // us their pad is labelled the other way round.
+        let swapped = faceButtonPreference?.isSwapped ?? false
+        pad.buttonA.valueChangedHandler = handler(for: Self.faceButton(.bottom, swapped: swapped))
+        pad.buttonB.valueChangedHandler = handler(for: Self.faceButton(.right, swapped: swapped))
+        pad.buttonX.valueChangedHandler = handler(for: Self.faceButton(.left, swapped: swapped))
+        pad.buttonY.valueChangedHandler = handler(for: Self.faceButton(.top, swapped: swapped))
 
         // Shoulders
         pad.leftShoulder.valueChangedHandler  = handler(for: .l)
@@ -86,6 +96,24 @@ final class LibretroControllerInput {
         pressedButtons.removeAll()
         comboLatched = false
         frontend?.clearAllButtons()
+    }
+
+    // MARK: - Face button layout
+
+    /// Where a face button sits on the pad, independent of what is printed on it.
+    enum FaceButtonPosition {
+        case bottom, right, left, top
+    }
+
+    /// The libretro button a physical face button drives. `swapped` exchanges
+    /// the two pairs for pads whose labels run the other way round.
+    nonisolated static func faceButton(_ position: FaceButtonPosition, swapped: Bool) -> LibretroABI.JoypadButton {
+        switch position {
+        case .bottom: return swapped ? .a : .b
+        case .right:  return swapped ? .b : .a
+        case .left:   return swapped ? .x : .y
+        case .top:    return swapped ? .y : .x
+        }
     }
 
     // MARK: - Private helpers

--- a/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroEmulatorViewModel.swift
@@ -97,6 +97,7 @@ final class LibretroEmulatorViewModel {
                 aspectRatioPreference: aspectRatioPreference,
                 screenPositionPreference: screenPositionPreference,
                 menuShortcutPreference: menuShortcutPreference,
+                faceButtonPreference: factory.gamepadFaceButtonPreference,
                 cloudSync: cloudSync
             )
             s.onMenuRequested = { [weak self] in self?.onMenuRequested?() }

--- a/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroSession.swift
@@ -38,6 +38,7 @@ final class LibretroSession: NSObject {
         aspectRatioPreference: PLibretroAspectRatioPreference,
         screenPositionPreference: PEmulatorScreenPositionPreference,
         menuShortcutPreference: PEmulatorMenuShortcutPreference? = nil,
+        faceButtonPreference: PGamepadFaceButtonPreference? = nil,
         cloudSync: CloudSaveSyncService? = nil
     ) {
         self.gameURL = gameURL
@@ -59,7 +60,8 @@ final class LibretroSession: NSObject {
         // onMenuRequested is wired after super.init() once self is available.
         self.controllerInput = LibretroControllerInput(
             frontend: LibretroFrontend.shared,
-            menuShortcutPreference: menuShortcutPreference
+            menuShortcutPreference: menuShortcutPreference,
+            faceButtonPreference: faceButtonPreference
         )
         super.init()
         self.viewController.controllerView.onMenuTapped = { [weak self] in

--- a/romm/romm/UI/Emulator/Native/FaceButtonInputMapping.swift
+++ b/romm/romm/UI/Emulator/Native/FaceButtonInputMapping.swift
@@ -1,0 +1,36 @@
+import DeltaCore
+
+/// Rewrites a DeltaCore input mapping so the two pairs of face buttons drive
+/// each other's inputs.
+///
+/// DeltaCore feeds a core through a controller-specific mapping, so the swap
+/// belongs there rather than in the cores: change the mapping once and every
+/// system the native engine runs picks it up.
+enum FaceButtonInputMapping {
+
+    private static let pairs = [("a", "b"), ("x", "y")]
+
+    /// Returns `mapping` with A/B and X/Y exchanged, or the mapping untouched
+    /// when it is not one we can rewrite (a custom mapping type, or nil).
+    static func swappingFaceButtons(
+        of mapping: GameControllerInputMappingProtocol?
+    ) -> GameControllerInputMappingProtocol? {
+        guard var mapping = mapping as? GameControllerInputMapping else { return mapping }
+
+        let inputType = mapping.gameControllerInputType
+        func controllerInput(_ identifier: String) -> AnyInput {
+            AnyInput(stringValue: identifier, intValue: nil, type: .controller(inputType))
+        }
+
+        for (first, second) in pairs {
+            let firstInput = controllerInput(first)
+            let secondInput = controllerInput(second)
+            let firstTarget = mapping.input(forControllerInput: firstInput)
+            let secondTarget = mapping.input(forControllerInput: secondInput)
+            mapping.set(secondTarget, forControllerInput: firstInput)
+            mapping.set(firstTarget, forControllerInput: secondInput)
+        }
+
+        return mapping
+    }
+}

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorSession.swift
@@ -185,6 +185,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
     private let cloudSync: CloudSaveSyncService?
     private let logger = Logger.ui
     let screenPositionPreference: PEmulatorScreenPositionPreference
+    private let faceButtonPreference: PGamepadFaceButtonPreference?
 
     var onMenuRequested: (() -> Void)?
     /// Reports whether the on-screen touch controls are currently hidden, so the
@@ -209,13 +210,14 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         viewController.emulatorCore
     }
 
-    init(gameURL: URL, gameType: GameType, romId: Int, saveStates: PEmulatorSaveStatesUseCase, screenPositionPreference: PEmulatorScreenPositionPreference, controllerSkinURL: URL? = nil, cloudSync: CloudSaveSyncService? = nil) {
+    init(gameURL: URL, gameType: GameType, romId: Int, saveStates: PEmulatorSaveStatesUseCase, screenPositionPreference: PEmulatorScreenPositionPreference, controllerSkinURL: URL? = nil, faceButtonPreference: PGamepadFaceButtonPreference? = nil, cloudSync: CloudSaveSyncService? = nil) {
         self.gameURL = gameURL
         self.gameType = gameType
         self.romId = romId
         self.saveStates = saveStates
         self.cloudSync = cloudSync
         self.screenPositionPreference = screenPositionPreference
+        self.faceButtonPreference = faceButtonPreference
 
         let vc = RommGameViewController()
         vc.screenPositionPreference = screenPositionPreference
@@ -364,11 +366,21 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         var nextIndex = 0
         for controller in ExternalGameControllerManager.shared.connectedControllers {
             controller.playerIndex = nextIndex
-            controller.addReceiver(core)
-            controller.addReceiver(viewController)
+            attach(controller, to: core)
             nextIndex += 1
         }
         updateOnScreenControlsVisibility()
+    }
+
+    /// Wires one controller to the core and the view controller. Passing the
+    /// default mapping through is exactly what `addReceiver(_:)` does, so with
+    /// the swap off this stays the behaviour the app always had.
+    private func attach(_ controller: GameController, to core: EmulatorCore) {
+        let mapping = (faceButtonPreference?.isSwapped ?? false)
+            ? FaceButtonInputMapping.swappingFaceButtons(of: controller.defaultInputMapping)
+            : controller.defaultInputMapping
+        controller.addReceiver(core, inputMapping: mapping)
+        controller.addReceiver(viewController, inputMapping: mapping)
     }
 
     private func detachExternalControllers() {
@@ -416,8 +428,7 @@ final class NativeEmulatorSession: NSObject, GameViewControllerDelegate {
         var nextIndex = 0
         while usedIndexes.contains(nextIndex) { nextIndex += 1 }
         controller.playerIndex = nextIndex
-        controller.addReceiver(core)
-        controller.addReceiver(viewController)
+        attach(controller, to: core)
         updateOnScreenControlsVisibility()
     }
 

--- a/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
+++ b/romm/romm/UI/Emulator/Native/NativeEmulatorViewModel.swift
@@ -77,6 +77,7 @@ final class NativeEmulatorViewModel {
                 romId: rom.id, saveStates: saveStates,
                 screenPositionPreference: factory.emulatorScreenPositionPreference,
                 controllerSkinURL: skinURL,
+                faceButtonPreference: factory.gamepadFaceButtonPreference,
                 cloudSync: cloudSync
             )
             session?.onControlsHiddenChanged = { [weak self] hidden in

--- a/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
+++ b/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
@@ -28,9 +28,11 @@ private enum PlayChoice: Hashable {
 struct EmulatorEngineSettingsView: View {
     @State private var playChoice: PlayChoice
     @State private var menuShortcut: EmulatorMenuShortcut
+    @State private var swapFaceButtons: Bool
     @State private var installedEmulators: [ExternalEmulatorID] = []
     private let preference: PEmulatorEnginePreference
     private let menuShortcutPreference: PEmulatorMenuShortcutPreference
+    private let faceButtonPreference: PGamepadFaceButtonPreference
     private let playTargetPreference: PPlayTargetPreference
     private let externalAppLauncher: PExternalAppLauncher
 
@@ -41,9 +43,11 @@ struct EmulatorEngineSettingsView: View {
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
         self.preference = factory.enginePreference
         self.menuShortcutPreference = factory.emulatorMenuShortcutPreference
+        self.faceButtonPreference = factory.gamepadFaceButtonPreference
         self.playTargetPreference = factory.playTargetPreference
         self.externalAppLauncher = factory.externalAppLauncher
         _menuShortcut = State(wrappedValue: factory.emulatorMenuShortcutPreference.current)
+        _swapFaceButtons = State(wrappedValue: factory.gamepadFaceButtonPreference.isSwapped)
         _playChoice = State(wrappedValue: PlayChoice(
             engine: factory.enginePreference.current,
             target: factory.playTargetPreference.current
@@ -67,6 +71,10 @@ struct EmulatorEngineSettingsView: View {
                 }
             }
 
+            Section(footer: Text("Face buttons are read by position, never by the label printed on them, so a Nintendo-style pad ends up with A and B the wrong way round. Turn this on if the buttons in a game don't match your controller.")) {
+                Toggle("Swap A/B and X/Y", isOn: $swapFaceButtons)
+            }
+
             #if DEBUG
             Section(
                 header: Text("Debug"),
@@ -82,6 +90,7 @@ struct EmulatorEngineSettingsView: View {
         .navigationTitle("Emulator")
         .onAppear { refreshInstalledEmulators() }
         .onChange(of: menuShortcut) { _, new in menuShortcutPreference.current = new }
+        .onChange(of: swapFaceButtons) { _, new in faceButtonPreference.isSwapped = new }
         .onChange(of: playChoice) { _, new in apply(new) }
     }
 

--- a/romm/rommTests/GamepadFaceButtonTests.swift
+++ b/romm/rommTests/GamepadFaceButtonTests.swift
@@ -1,0 +1,94 @@
+import Testing
+import Foundation
+import DeltaCore
+@testable import romm
+
+struct GamepadFaceButtonPreferenceStoreTests {
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+    }
+
+    @Test func facesAreNotSwappedInitially() {
+        let store = UserDefaultsGamepadFaceButtonPreferenceStore(userDefaults: makeDefaults())
+        #expect(!store.isSwapped)
+    }
+
+    @Test func persistsAcrossInstances() {
+        let defaults = makeDefaults()
+        UserDefaultsGamepadFaceButtonPreferenceStore(userDefaults: defaults).isSwapped = true
+        let reopened = UserDefaultsGamepadFaceButtonPreferenceStore(userDefaults: defaults)
+        #expect(reopened.isSwapped)
+    }
+}
+
+struct LibretroFaceButtonLayoutTests {
+
+    /// The layout the app has always used: bottom is B, as on a SNES pad.
+    @Test func unswappedKeepsTheSNESLayout() {
+        #expect(LibretroControllerInput.faceButton(.bottom, swapped: false) == .b)
+        #expect(LibretroControllerInput.faceButton(.right, swapped: false) == .a)
+        #expect(LibretroControllerInput.faceButton(.left, swapped: false) == .y)
+        #expect(LibretroControllerInput.faceButton(.top, swapped: false) == .x)
+    }
+
+    @Test func swappingExchangesBothPairs() {
+        #expect(LibretroControllerInput.faceButton(.bottom, swapped: true) == .a)
+        #expect(LibretroControllerInput.faceButton(.right, swapped: true) == .b)
+        #expect(LibretroControllerInput.faceButton(.left, swapped: true) == .x)
+        #expect(LibretroControllerInput.faceButton(.top, swapped: true) == .y)
+    }
+}
+
+struct FaceButtonInputMappingTests {
+
+    private func makeMapping() -> GameControllerInputMapping {
+        var mapping = GameControllerInputMapping(gameControllerInputType: .mfi)
+        mapping.set(StandardGameControllerInput.a, forControllerInput: MFiGameController.Input.a)
+        mapping.set(StandardGameControllerInput.b, forControllerInput: MFiGameController.Input.b)
+        mapping.set(StandardGameControllerInput.x, forControllerInput: MFiGameController.Input.x)
+        mapping.set(StandardGameControllerInput.y, forControllerInput: MFiGameController.Input.y)
+        mapping.set(StandardGameControllerInput.start, forControllerInput: MFiGameController.Input.menu)
+        return mapping
+    }
+
+    private func target(_ mapping: GameControllerInputMappingProtocol?, _ input: MFiGameController.Input) -> String? {
+        mapping?.input(forControllerInput: input)?.stringValue
+    }
+
+    @Test func swapsBothFaceButtonPairs() {
+        let swapped = FaceButtonInputMapping.swappingFaceButtons(of: makeMapping())
+        #expect(target(swapped, .a) == "b")
+        #expect(target(swapped, .b) == "a")
+        #expect(target(swapped, .x) == "y")
+        #expect(target(swapped, .y) == "x")
+    }
+
+    @Test func leavesEveryOtherInputAlone() {
+        let swapped = FaceButtonInputMapping.swappingFaceButtons(of: makeMapping())
+        #expect(target(swapped, .menu) == "start")
+    }
+
+    /// Swapping twice has to land back on the original, otherwise the mapping
+    /// would drift every time a controller reconnects.
+    @Test func swappingTwiceRestoresTheOriginal() {
+        let once = FaceButtonInputMapping.swappingFaceButtons(of: makeMapping())
+        let twice = FaceButtonInputMapping.swappingFaceButtons(of: once)
+        #expect(target(twice, .a) == "a")
+        #expect(target(twice, .b) == "b")
+        #expect(target(twice, .x) == "x")
+        #expect(target(twice, .y) == "y")
+    }
+
+    /// A mapping that leaves a face button unassigned must not gain one.
+    @Test func keepsUnmappedButtonsUnmapped() {
+        var mapping = GameControllerInputMapping(gameControllerInputType: .mfi)
+        mapping.set(StandardGameControllerInput.a, forControllerInput: MFiGameController.Input.a)
+        let swapped = FaceButtonInputMapping.swappingFaceButtons(of: mapping)
+        #expect(target(swapped, .a) == nil)
+        #expect(target(swapped, .b) == "a")
+    }
+
+    @Test func passesNilThrough() {
+        #expect(FaceButtonInputMapping.swappingFaceButtons(of: nil) == nil)
+    }
+}


### PR DESCRIPTION
GameController reports face buttons by position, never by the label printed on them, so a Nintendo-style pad plays with A and B the wrong way round and there was nothing in the app to fix it.

Settings → Emulator now has a "Swap A/B and X/Y" switch. It flips both pairs in either engine: libretro picks the other button per position, the native engine hands the cores a rewritten DeltaCore input mapping. Off by default, so both engines keep the mapping they always had.

Also declares `GCSupportsControllerUserInteraction`, without it the app never appeared under Settings → General → Game Controller → Customizations.

Verified on device with a real pad, both engines, including disconnect/reconnect and a restart.

Closes #112