### PR TITLE
Add RetroAchievements metadata display

### DIFF
--- a/romm/romm/Data/Mappers/RomMapper.swift
+++ b/romm/romm/Data/Mappers/RomMapper.swift
@@ -152,6 +152,17 @@ struct RomMapper {
             platformId: apiRom.platformId,
             isFavourite: false, // Will be loaded separately via user properties
             hasRetroAchievements: apiRom.raId != nil,
+            retroAchievementsGameId: apiRom.raId,
+            retroAchievements: (apiRom.mergedRaMetadata?.achievements ?? []).compactMap { achievement in
+                guard let id = achievement.raId else { return nil }
+                return RetroAchievement(
+                    id: String(id),
+                    title: achievement.title ?? "Untitled Achievement",
+                    description: achievement.description,
+                    points: achievement.points,
+                    displayOrder: achievement.displayOrder
+                )
+            },
             genre: genres,
             developer: developer,
             publisher: publisher,

--- a/romm/romm/Data/Mappers/RomMapper.swift
+++ b/romm/romm/Data/Mappers/RomMapper.swift
@@ -160,6 +160,8 @@ struct RomMapper {
                     title: achievement.title ?? "Untitled Achievement",
                     description: achievement.description,
                     points: achievement.points,
+                    badgeURL: achievement.badgeUrl,
+                    lockedBadgeURL: achievement.badgeUrlLock,
                     displayOrder: achievement.displayOrder
                 )
             },

--- a/romm/romm/Data/Mappers/UserMapper.swift
+++ b/romm/romm/Data/Mappers/UserMapper.swift
@@ -25,7 +25,13 @@ struct UserMapper {
                     gameId: gameId,
                     awardedCount: progression.numAwarded,
                     maximumCount: progression.maxPossible,
-                    earnedAchievementIds: Set(progression.earnedAchievements.map(\.id))
+                    earnedAchievements: progression.earnedAchievements.map {
+                        EarnedRetroAchievement(
+                            id: $0.id,
+                            earnedAt: $0.date,
+                            earnedHardcoreAt: $0.dateHardcore
+                        )
+                    }
                 )
             }
         )

--- a/romm/romm/Data/Mappers/UserMapper.swift
+++ b/romm/romm/Data/Mappers/UserMapper.swift
@@ -17,7 +17,17 @@ struct UserMapper {
             email: apiUser.email,
             role: role,
             avatarPath: apiUser.avatarPath,
-            enabled: apiUser.enabled
+            enabled: apiUser.enabled,
+            retroAchievementsUsername: apiUser.raUsername,
+            retroAchievementsProgression: (apiUser.raProgression?.results ?? []).compactMap { progression in
+                guard let gameId = progression.romRaId else { return nil }
+                return RetroAchievementsProgression(
+                    gameId: gameId,
+                    awardedCount: progression.numAwarded,
+                    maximumCount: progression.maxPossible,
+                    earnedAchievementIds: Set(progression.earnedAchievements.map(\.id))
+                )
+            }
         )
     }
 }

--- a/romm/romm/Domain/Models/Rom.swift
+++ b/romm/romm/Domain/Models/Rom.swift
@@ -113,6 +113,8 @@ struct RetroAchievement: Identifiable, Equatable {
     let title: String
     let description: String?
     let points: Int?
+    let badgeURL: String?
+    let lockedBadgeURL: String?
     let displayOrder: Int?
 }
 

--- a/romm/romm/Domain/Models/Rom.swift
+++ b/romm/romm/Domain/Models/Rom.swift
@@ -41,6 +41,8 @@ struct Rom: Identifiable, Equatable {
     let releaseYear: Int?
     let isFavourite: Bool
     let hasRetroAchievements: Bool
+    let retroAchievementsGameId: Int?
+    let retroAchievements: [RetroAchievement]
     let isPlayable: Bool
     
     // Additional fields for table display
@@ -70,6 +72,8 @@ struct Rom: Identifiable, Equatable {
         releaseYear: Int? = nil,
         isFavourite: Bool = false,
         hasRetroAchievements: Bool = false,
+        retroAchievementsGameId: Int? = nil,
+        retroAchievements: [RetroAchievement] = [],
         isPlayable: Bool = false,
         sizeBytes: Int? = nil,
         createdAt: String? = nil,
@@ -92,6 +96,8 @@ struct Rom: Identifiable, Equatable {
         self.releaseYear = releaseYear
         self.isFavourite = isFavourite
         self.hasRetroAchievements = hasRetroAchievements
+        self.retroAchievementsGameId = retroAchievementsGameId
+        self.retroAchievements = retroAchievements
         self.isPlayable = isPlayable
         self.sizeBytes = sizeBytes
         self.createdAt = createdAt
@@ -107,6 +113,15 @@ struct Rom: Identifiable, Equatable {
     }
 }
 
+/// Metadata for an achievement supplied by RetroAchievements through RomM.
+struct RetroAchievement: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let description: String?
+    let points: Int?
+    let displayOrder: Int?
+}
+
 struct RomDetails: Identifiable, Equatable {
     let id: Int
     let name: String
@@ -118,6 +133,8 @@ struct RomDetails: Identifiable, Equatable {
     let platformId: Int
     let isFavourite: Bool
     let hasRetroAchievements: Bool
+    let retroAchievementsGameId: Int?
+    let retroAchievements: [RetroAchievement]
     let genre: [String]
     let developer: String?
     let publisher: String?
@@ -148,6 +165,8 @@ struct RomDetails: Identifiable, Equatable {
         platformId: Int,
         isFavourite: Bool = false,
         hasRetroAchievements: Bool = false,
+        retroAchievementsGameId: Int? = nil,
+        retroAchievements: [RetroAchievement] = [],
         genre: [String] = [],
         developer: String? = nil,
         publisher: String? = nil,
@@ -175,6 +194,8 @@ struct RomDetails: Identifiable, Equatable {
         self.platformId = platformId
         self.isFavourite = isFavourite
         self.hasRetroAchievements = hasRetroAchievements
+        self.retroAchievementsGameId = retroAchievementsGameId
+        self.retroAchievements = retroAchievements
         self.genre = genre
         self.developer = developer
         self.publisher = publisher

--- a/romm/romm/Domain/Models/Rom.swift
+++ b/romm/romm/Domain/Models/Rom.swift
@@ -41,8 +41,6 @@ struct Rom: Identifiable, Equatable {
     let releaseYear: Int?
     let isFavourite: Bool
     let hasRetroAchievements: Bool
-    let retroAchievementsGameId: Int?
-    let retroAchievements: [RetroAchievement]
     let isPlayable: Bool
     
     // Additional fields for table display
@@ -72,8 +70,6 @@ struct Rom: Identifiable, Equatable {
         releaseYear: Int? = nil,
         isFavourite: Bool = false,
         hasRetroAchievements: Bool = false,
-        retroAchievementsGameId: Int? = nil,
-        retroAchievements: [RetroAchievement] = [],
         isPlayable: Bool = false,
         sizeBytes: Int? = nil,
         createdAt: String? = nil,
@@ -96,8 +92,6 @@ struct Rom: Identifiable, Equatable {
         self.releaseYear = releaseYear
         self.isFavourite = isFavourite
         self.hasRetroAchievements = hasRetroAchievements
-        self.retroAchievementsGameId = retroAchievementsGameId
-        self.retroAchievements = retroAchievements
         self.isPlayable = isPlayable
         self.sizeBytes = sizeBytes
         self.createdAt = createdAt

--- a/romm/romm/Domain/Models/User.swift
+++ b/romm/romm/Domain/Models/User.swift
@@ -43,7 +43,18 @@ struct RetroAchievementsProgression: Equatable {
     let gameId: Int
     let awardedCount: Int?
     let maximumCount: Int?
-    let earnedAchievementIds: Set<String>
+    let earnedAchievements: [EarnedRetroAchievement]
+
+    func earnedAchievement(id: String) -> EarnedRetroAchievement? {
+        earnedAchievements.first { $0.id == id }
+    }
+}
+
+/// A RetroAchievements unlock reported by the RomM server.
+struct EarnedRetroAchievement: Equatable {
+    let id: String
+    let earnedAt: String
+    let earnedHardcoreAt: String?
 }
 
 enum UserRole: String, CaseIterable {

--- a/romm/romm/Domain/Models/User.swift
+++ b/romm/romm/Domain/Models/User.swift
@@ -14,6 +14,8 @@ struct User: Identifiable, Equatable {
     let role: UserRole
     let avatarPath: String?
     let enabled: Bool
+    let retroAchievementsUsername: String?
+    let retroAchievementsProgression: [RetroAchievementsProgression]
     
     init(
         id: Int,
@@ -21,7 +23,9 @@ struct User: Identifiable, Equatable {
         email: String? = nil,
         role: UserRole,
         avatarPath: String? = nil,
-        enabled: Bool = true
+        enabled: Bool = true,
+        retroAchievementsUsername: String? = nil,
+        retroAchievementsProgression: [RetroAchievementsProgression] = []
     ) {
         self.id = id
         self.username = username
@@ -29,7 +33,17 @@ struct User: Identifiable, Equatable {
         self.role = role
         self.avatarPath = avatarPath
         self.enabled = enabled
+        self.retroAchievementsUsername = retroAchievementsUsername
+        self.retroAchievementsProgression = retroAchievementsProgression
     }
+}
+
+/// A user's server-supplied RetroAchievements progress for one game.
+struct RetroAchievementsProgression: Equatable {
+    let gameId: Int
+    let awardedCount: Int?
+    let maximumCount: Int?
+    let earnedAchievementIds: Set<String>
 }
 
 enum UserRole: String, CaseIterable {

--- a/romm/romm/UI/App/AppViewModel.swift
+++ b/romm/romm/UI/App/AppViewModel.swift
@@ -55,6 +55,7 @@ class AppViewModel {
     private let clearServerVersionUseCase: ClearServerVersionUseCase
     private let saveServerVersionUseCase: SaveServerVersionUseCase
     private let getHeartbeatUseCase: GetHeartbeatUseCase
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
 
     private let factory: PDependencyFactory
 
@@ -72,6 +73,7 @@ class AppViewModel {
         self.clearServerVersionUseCase = factory.makeClearServerVersionUseCase()
         self.saveServerVersionUseCase = factory.makeSaveServerVersionUseCase()
         self.getHeartbeatUseCase = factory.makeGetHeartbeatUseCase()
+        self.getCurrentUserUseCase = factory.makeGetCurrentUserUseCase()
 
         // Listen for restart setup requests
         NotificationCenter.default.addObserver(
@@ -128,6 +130,7 @@ class AppViewModel {
                 logger.info("Authentication state: \(appData.isAuthenticated) (method: \(authMethod.displayName))")
                 updateAppConfig(config)
                 appState = .authenticated
+                await loadCurrentUser()
                 // Verify the server version right after launch, not only on foreground.
                 await checkServerVersionOnForeground()
             } else {
@@ -169,6 +172,7 @@ class AppViewModel {
             appData.updateLoading(false)
             isHandlingSessionExpiration = false
             appState = .authenticated
+            await loadCurrentUser()
         } catch {
             logger.error("Setup configuration failed: \(error)")
             appData.updateLoading(false)
@@ -205,6 +209,15 @@ class AppViewModel {
         appData.updateAuthState(false)
         appData.updateUser(nil)
         appData.updateError(nil)
+    }
+
+    /// Keeps app-wide user data, including RetroAchievements progress, current.
+    private func loadCurrentUser() async {
+        do {
+            appData.updateUser(try await getCurrentUserUseCase.execute())
+        } catch {
+            logger.warning("Unable to load current user: \(error.localizedDescription)")
+        }
     }
 
     func clearError() {

--- a/romm/romm/UI/Profile/SettingsView.swift
+++ b/romm/romm/UI/Profile/SettingsView.swift
@@ -60,6 +60,21 @@ struct SettingsView: View {
                     }
                 }
             }
+
+            if let retroAchievementsUsername = appData.currentUser?.retroAchievementsUsername {
+                Section("RetroAchievements") {
+                    HStack {
+                        Image(systemName: "trophy.fill")
+                            .foregroundStyle(.orange)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(retroAchievementsUsername)
+                            Text("Connected account")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
             
             // Server Section
             if let config = appData.currentConfiguration {

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -902,7 +902,7 @@ struct RomDetailView: View {
 
             if let progress = retroAchievementsProgress(for: details) {
                 let maximum = progress.maximumCount ?? details.retroAchievements.count
-                let awarded = progress.awardedCount ?? progress.earnedAchievementIds.count
+                let awarded = progress.awardedCount ?? progress.earnedAchievements.count
                 VStack(alignment: .leading, spacing: 6) {
                     Text("\(awarded) of \(maximum) earned")
                         .font(.subheadline)
@@ -922,11 +922,11 @@ struct RomDetailView: View {
                     .foregroundStyle(.secondary)
             } else {
                 ForEach(details.retroAchievements.sorted { ($0.displayOrder ?? .max) < ($1.displayOrder ?? .max) }) { achievement in
-                    let isEarned = retroAchievementsProgress(for: details)?.earnedAchievementIds.contains(achievement.id) == true
+                    let earnedAchievement = retroAchievementsProgress(for: details)?.earnedAchievement(id: achievement.id)
                     HStack(alignment: .top, spacing: 12) {
-                        Image(systemName: isEarned ? "checkmark.seal.fill" : "seal")
+                        Image(systemName: earnedAchievement != nil ? "checkmark.seal.fill" : "seal")
                             .font(.title3)
-                            .foregroundStyle(isEarned ? .green : .secondary)
+                            .foregroundStyle(earnedAchievement != nil ? .green : .secondary)
                             .frame(width: 24)
                         VStack(alignment: .leading, spacing: 3) {
                             HStack {
@@ -944,6 +944,16 @@ struct RomDetailView: View {
                                 Text(description)
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
+                            }
+
+                            if let earnedAchievement {
+                                Text(
+                                    earnedAchievement.earnedHardcoreAt == nil
+                                        ? "Unlocked \(earnedAchievement.earnedAt)"
+                                        : "Unlocked in hardcore mode \(earnedAchievement.earnedAt)"
+                                )
+                                    .font(.caption)
+                                    .foregroundStyle(.green)
                             }
                         }
                     }

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -924,10 +924,18 @@ struct RomDetailView: View {
                 ForEach(details.retroAchievements.sorted { ($0.displayOrder ?? .max) < ($1.displayOrder ?? .max) }) { achievement in
                     let earnedAchievement = retroAchievementsProgress(for: details)?.earnedAchievement(id: achievement.id)
                     HStack(alignment: .top, spacing: 12) {
-                        Image(systemName: earnedAchievement != nil ? "checkmark.seal.fill" : "seal")
-                            .font(.title3)
-                            .foregroundStyle(earnedAchievement != nil ? .green : .secondary)
-                            .frame(width: 24)
+                        if let badgeURL = earnedAchievement == nil ? achievement.lockedBadgeURL : achievement.badgeURL {
+                            CachedKFImage(urlString: badgeURL) { image in
+                                image
+                                    .resizable()
+                                    .scaledToFit()
+                            } placeholder: {
+                                achievementStatusIcon(isEarned: earnedAchievement != nil)
+                            }
+                            .frame(width: 40, height: 40)
+                        } else {
+                            achievementStatusIcon(isEarned: earnedAchievement != nil)
+                        }
                         VStack(alignment: .leading, spacing: 3) {
                             HStack {
                                 Text(achievement.title)
@@ -966,6 +974,13 @@ struct RomDetailView: View {
     private func retroAchievementsProgress(for details: RomDetails) -> RetroAchievementsProgression? {
         guard let gameId = details.retroAchievementsGameId else { return nil }
         return appData.currentUser?.retroAchievementsProgression.first { $0.gameId == gameId }
+    }
+
+    private func achievementStatusIcon(isEarned: Bool) -> some View {
+        Image(systemName: isEarned ? "checkmark.seal.fill" : "seal")
+            .font(.title3)
+            .foregroundStyle(isEarned ? .green : .secondary)
+            .frame(width: 40, height: 40)
     }
     
     @ViewBuilder

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -699,6 +699,10 @@ struct RomDetailView: View {
                 
                 // Game Information Section
                 gameInfoSection
+
+                if details.hasRetroAchievements {
+                    retroAchievementsSection(details)
+                }
             }
                         
             if let summary = rom.summary, !summary.isEmpty {
@@ -880,6 +884,78 @@ struct RomDetailView: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func retroAchievementsSection(_ details: RomDetails) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("RetroAchievements", systemImage: "trophy.fill")
+                    .font(.headline)
+                    .foregroundStyle(.orange)
+                Spacer()
+                Text("\(details.retroAchievements.count) achievements")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 16)
+
+            if let progress = retroAchievementsProgress(for: details) {
+                let maximum = progress.maximumCount ?? details.retroAchievements.count
+                let awarded = progress.awardedCount ?? progress.earnedAchievementIds.count
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("\(awarded) of \(maximum) earned")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    ProgressView(value: Double(awarded), total: Double(max(maximum, 1)))
+                        .tint(.orange)
+                }
+            } else if appData.currentUser?.retroAchievementsUsername != nil {
+                Text("No progress has been reported for this game yet.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            if details.retroAchievements.isEmpty {
+                Text("Achievement details are not available from this server.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(details.retroAchievements.sorted { ($0.displayOrder ?? .max) < ($1.displayOrder ?? .max) }) { achievement in
+                    let isEarned = retroAchievementsProgress(for: details)?.earnedAchievementIds.contains(achievement.id) == true
+                    HStack(alignment: .top, spacing: 12) {
+                        Image(systemName: isEarned ? "checkmark.seal.fill" : "seal")
+                            .font(.title3)
+                            .foregroundStyle(isEarned ? .green : .secondary)
+                            .frame(width: 24)
+                        VStack(alignment: .leading, spacing: 3) {
+                            HStack {
+                                Text(achievement.title)
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                Spacer()
+                                if let points = achievement.points {
+                                    Text("\(points) pts")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            if let description = achievement.description, !description.isEmpty {
+                                Text(description)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+
+    private func retroAchievementsProgress(for details: RomDetails) -> RetroAchievementsProgression? {
+        guard let gameId = details.retroAchievementsGameId else { return nil }
+        return appData.currentUser?.retroAchievementsProgression.first { $0.gameId == gameId }
     }
     
     @ViewBuilder

--- a/romm/romm/UI/RomDetail/RomDetailViewModel.swift
+++ b/romm/romm/UI/RomDetail/RomDetailViewModel.swift
@@ -188,6 +188,8 @@ class RomDetailViewModel {
                         platformId: romDetails.platformId,
                         isFavourite: newFavoriteState,
                         hasRetroAchievements: romDetails.hasRetroAchievements,
+                        retroAchievementsGameId: romDetails.retroAchievementsGameId,
+                        retroAchievements: romDetails.retroAchievements,
                         genre: romDetails.genre,
                         developer: romDetails.developer,
                         publisher: romDetails.publisher,

--- a/romm/rommTests/RetroAchievementsProgressionTests.swift
+++ b/romm/rommTests/RetroAchievementsProgressionTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import romm
+
+struct RetroAchievementsProgressionTests {
+    @Test func findsAnEarnedAchievementByIdentifier() {
+        let achievement = EarnedRetroAchievement(
+            id: "42",
+            earnedAt: "2026-08-29T10:00:00Z",
+            earnedHardcoreAt: nil
+        )
+        let progression = RetroAchievementsProgression(
+            gameId: 7,
+            awardedCount: 1,
+            maximumCount: 10,
+            earnedAchievements: [achievement]
+        )
+
+        #expect(progression.earnedAchievement(id: "42") == achievement)
+        #expect(progression.earnedAchievement(id: "99") == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- map RetroAchievements game metadata and user progression into domain models
- show achievement progress and earned status on ROM details
- load the authenticated user into app state so server-provided progress is available

## Testing
- `xcodebuild test -project romm.xcodeproj -scheme romm -destination 'platform=iOS Simulator,id=E929F6F8-4BBD-4ED6-A03B-006B2DCE1189' -quiet`