### PR TITLE
Say what actually went wrong when a server cannot be reached

### DIFF
--- a/romm/romm/Data/API/RommAPIClient+Heartbeat.swift
+++ b/romm/romm/Data/API/RommAPIClient+Heartbeat.swift
@@ -9,6 +9,27 @@ import Foundation
 
 // MARK: - Heartbeat API Wrapper
 extension RommAPIClient {
+
+    /// Own session for the reachability check during setup.
+    ///
+    /// The shared session allows an hour per resource, which is right for a ROM
+    /// download and wrong here: a mistyped or unreachable address does not fail,
+    /// it just never answers, and the user watches a spinner until they give up.
+    /// A short, self-contained budget turns that into an error message.
+    private static let setupSession: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = RommAPIClient.setupTimeout
+        configuration.timeoutIntervalForResource = RommAPIClient.setupTimeout
+        // Queueing the request until the network looks better would bring the
+        // endless spinner back in another shape.
+        configuration.waitsForConnectivity = false
+        return URLSession(configuration: configuration)
+    }()
+
+    /// Long enough for a slow home server behind a proxy, short enough that
+    /// nobody wonders whether the app is still doing anything.
+    private static let setupTimeout: TimeInterval = 15
+
     func getHeartbeat() async throws -> HeartbeatResponse {
         return try await get("api/heartbeat", responseType: HeartbeatResponse.self)
     }
@@ -23,12 +44,12 @@ extension RommAPIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.timeoutInterval = 30.0
+        request.timeoutInterval = Self.setupTimeout
 
         logger.info("🔍 [Network] - Fetching heartbeat from: \(url.absoluteString)")
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await Self.setupSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.error("Invalid response type for heartbeat")

--- a/romm/romm/UI/App/SetupViewModel.swift
+++ b/romm/romm/UI/App/SetupViewModel.swift
@@ -247,6 +247,13 @@ final class SetupViewModel {
     }
 
     func parseConnectionError(_ error: Error) -> (message: String, details: String?) {
+        // The heartbeat wraps the API error, and unwrapping it is what makes the
+        // specific cases below reachable at all. Without this everything falls
+        // through to `localizedDescription`, which for an HTTP error is the
+        // entire response body — users were shown raw HTML of a 404 page.
+        if let heartbeatError = error as? HeartbeatError, case .networkError(let underlying) = heartbeatError {
+            return parseConnectionError(underlying)
+        }
         if let apiError = error as? APIClientError {
             switch apiError {
             case .cloudflareProtection:
@@ -260,6 +267,13 @@ final class SetupViewModel {
             case .noCredentials:
                 return ("Credentials missing", "Please provide username and password")
             case .invalidResponse(let code, _):
+                // Something answered, so the address and port are reachable, but
+                // it does not serve RomM. Usually a different service on that
+                // port, or a proxy that routes elsewhere.
+                if code == 404 {
+                    return ("No RomM server at this address",
+                            "Something answered, but it is not RomM. Check the port and whether your reverse proxy points at RomM.")
+                }
                 return ("Server error (\(code))", "The server returned an error response")
             case .decodingError:
                 return ("Invalid response", "The server did not return a valid RomM response")
@@ -270,7 +284,45 @@ final class SetupViewModel {
         return parseGeneralConnectionError(error)
     }
 
+    /// The failures a self-hosted setup actually produces, keyed by code so the
+    /// phone's language cannot change the outcome.
+    private func messageForURLError(_ code: URLError.Code) -> (message: String, details: String?)? {
+        switch code {
+        case .timedOut:
+            return ("Connection timed out",
+                    "The server did not answer in time. Check that the address and port are right and that the server is reachable from this network.")
+        case .cannotConnectToHost, .networkConnectionLost:
+            return ("Connection failed",
+                    "Nothing is listening at that address. Check the port, and whether the server is running.")
+        case .cannotFindHost, .dnsLookupFailed:
+            return ("Server not found",
+                    "The address could not be resolved. Check the spelling, and whether this network can see your server.")
+        case .notConnectedToInternet:
+            return ("No connection",
+                    "This device is not connected to a network.")
+        case .secureConnectionFailed, .serverCertificateUntrusted, .serverCertificateHasBadDate,
+             .serverCertificateHasUnknownRoot, .serverCertificateNotYetValid, .clientCertificateRejected:
+            return ("Certificate problem",
+                    "The secure connection could not be established. A self-signed certificate has to be trusted on this device, or use http:// instead.")
+        case .unsupportedURL, .badURL:
+            return ("Invalid address",
+                    "Start the address with http:// or https://, for example http://192.168.1.50:8080.")
+        case .appTransportSecurityRequiresSecureConnection:
+            return ("Insecure connection blocked",
+                    "iOS refused the plain http connection to this address.")
+        default:
+            return nil
+        }
+    }
+
     func parseGeneralConnectionError(_ error: Error) -> (message: String, details: String?) {
+        // Match the error code before its text. `localizedDescription` is
+        // localized, so on a phone that is not set to English none of the string
+        // checks below can ever match and every failure looks identical.
+        if let urlError = error as? URLError, let known = messageForURLError(urlError.code) {
+            return known
+        }
+
         let errorString = error.localizedDescription
 
         if errorString.contains("certificate") || errorString.contains("SSL") || errorString.contains("TLS") {

--- a/romm/rommTests/ConnectionErrorMessageTests.swift
+++ b/romm/rommTests/ConnectionErrorMessageTests.swift
@@ -1,0 +1,98 @@
+import Testing
+import Foundation
+
+@testable import romm
+
+/// The setup screen is where most support cases start, so the message it shows
+/// has to name the actual problem.
+@MainActor
+struct ConnectionErrorMessageTests {
+
+    /// The regression this guards: the heartbeat wraps the API error, and
+    /// without unwrapping it every case fell through to `localizedDescription`,
+    /// which for an HTTP error is the whole response body. Users were shown the
+    /// raw HTML of a 404 page.
+    @Test func unwrapsHeartbeatErrorInsteadOfShowingTheResponseBody() {
+        let body = """
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
+        <html><head><title>404 Not Found</title></head><body>
+        <h1>Not Found</h1><address>Apache/2.4.67 (Debian) Server</address>
+        </body></html>
+        """
+        let error = HeartbeatError.networkError(APIClientError.invalidResponse(404, body))
+
+        let (message, details) = SetupViewModel().parseConnectionError(error)
+
+        #expect(!message.contains("<"))
+        #expect(!(details ?? "").contains("<"))
+        #expect(!message.contains("Apache"))
+        #expect(!(details ?? "").contains("Apache"))
+    }
+
+    /// A 404 means something answered but it is not RomM, usually the wrong port
+    /// or a proxy pointing elsewhere. That is worth saying, since it rules out
+    /// the address being unreachable.
+    @Test func namesAMissingRommServerOnA404() {
+        let error = HeartbeatError.networkError(APIClientError.invalidResponse(404, "not found"))
+
+        let (message, details) = SetupViewModel().parseConnectionError(error)
+
+        #expect(message == "No RomM server at this address")
+        #expect(details?.contains("port") == true)
+    }
+
+    @Test func reportsOtherStatusCodesWithTheirCode() {
+        let error = HeartbeatError.networkError(APIClientError.invalidResponse(502, "bad gateway"))
+
+        let (message, _) = SetupViewModel().parseConnectionError(error)
+
+        #expect(message.contains("502"))
+    }
+
+    @Test func recognisesATimeoutThroughBothWrappers() {
+        let error = HeartbeatError.networkError(APIClientError.networkError(URLError(.timedOut)))
+
+        let (message, _) = SetupViewModel().parseConnectionError(error)
+
+        #expect(message == "Connection timed out")
+    }
+
+    /// Codes, not text: `localizedDescription` follows the phone's language, so
+    /// classifying on English substrings left every non-English user with the
+    /// same generic message no matter what went wrong.
+    @Test(arguments: [
+        (URLError.Code.cannotConnectToHost, "Connection failed"),
+        (URLError.Code.cannotFindHost, "Server not found"),
+        (URLError.Code.dnsLookupFailed, "Server not found"),
+        (URLError.Code.notConnectedToInternet, "No connection"),
+        (URLError.Code.secureConnectionFailed, "Certificate problem"),
+        (URLError.Code.serverCertificateUntrusted, "Certificate problem"),
+        (URLError.Code.unsupportedURL, "Invalid address"),
+    ])
+    func classifiesByCodeNotByLocalizedText(code: URLError.Code, expected: String) {
+        let error = HeartbeatError.networkError(APIClientError.networkError(URLError(code)))
+
+        let (message, details) = SetupViewModel().parseConnectionError(error)
+
+        #expect(message == expected)
+        #expect(details?.isEmpty == false)
+    }
+
+    @Test func keepsRecognisingCloudflare() {
+        let error = HeartbeatError.networkError(APIClientError.cloudflareProtection("blocked"))
+
+        let (message, _) = SetupViewModel().parseConnectionError(error)
+
+        #expect(message.contains("Cloudflare"))
+    }
+
+    /// Authentication errors have to survive the unwrapping too, otherwise the
+    /// most common case of all loses its message.
+    @Test func keepsRecognisingAuthenticationFailure() {
+        let error = HeartbeatError.networkError(APIClientError.authenticationRequired)
+
+        let (message, _) = SetupViewModel().parseConnectionError(error)
+
+        #expect(message == "Authentication failed")
+    }
+}


### PR DESCRIPTION
Beim Testen der Hilfe-Seite auf dem Simulator sind drei Probleme auf dem Setup-Screen aufgefallen, also genau dort, wo der größte Meldungs-Cluster entsteht.

Die Erreichbarkeitsprüfung lief über die geteilte Session, die eine Stunde pro Ressource erlaubt, weil ein ROM-Download das braucht. Eine unerreichbare Adresse scheiterte deshalb nie, das Rad drehte einfach weiter, gemessen über fünf Minuten. Jetzt eigene Session, Fehler nach 15 Sekunden, nachgemessen: 16s statt 306s.

Der Heartbeat verpackt den API-Fehler und niemand hat ihn ausgepackt, also fiel alles auf localizedDescription durch. Bei einem HTTP-Fehler ist das der komplette Response-Body, Nutzer sahen das rohe HTML einer 404-Seite.

Klassifiziert wurde dann per englischer Teilstring-Suche in genau diesem lokalisierten Text. Auf einem nicht-englischen iPhone greift davon nichts, jeder Fehler sah gleich aus. Läuft jetzt über Fehlercodes, und ein 404 sagt, dass etwas geantwortet hat, aber kein RomM ist.

25 Tests dazu, Suite grün.