### PR TITLE
Pace libretro cores against the audio clock

### DIFF
--- a/romm/romm/UI/Emulator/Libretro/LibretroABI.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroABI.swift
@@ -46,6 +46,12 @@ enum LibretroABI {
     static let ENVIRONMENT_GET_RUMBLE_INTERFACE: UInt32 = 23
     static let ENVIRONMENT_GET_LOG_INTERFACE: UInt32 = 27
     static let ENVIRONMENT_GET_SAVE_DIRECTORY: UInt32 = 31
+    /// Der Core meldet geänderte Timings/Geometrie zur Laufzeit. Flycast schickt
+    /// das bei jedem Videomodus-Wechsel (spg.cpp: CalculateSync ->
+    /// retro_refresh_av_info), PPSSPP bei geänderter interner Auflösung.
+    static let ENVIRONMENT_SET_SYSTEM_AV_INFO: UInt32 = 32
+    /// Wie oben, aber nur Geometrie – Timings bleiben.
+    static let ENVIRONMENT_SET_GEOMETRY: UInt32 = 37
     static let ENVIRONMENT_GET_INPUT_BITMASKS: UInt32 = 51 | 0x10000
 
     // MARK: - Memory types (retro_get_memory_data/size)

--- a/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Audio.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Audio.swift
@@ -31,10 +31,60 @@ extension LibretroFrontend {
     private static let audioTrimThresholdMs: Double = 80
     private static let audioTrimTargetMs: Double = 50
 
+    /// Fill level from which the core counts as running ahead of the audio
+    /// clock.
+    ///
+    /// Note what this cannot do, measured rather than assumed: the trim below
+    /// runs inside `enqueueAudio`, so the level is already back at the target
+    /// by the time the next tick reads it. With a core handing over 33 ms per
+    /// call the level sawtooths between roughly 33 and 50 ms and never reaches
+    /// this limit — the device log showed exactly that, `0 throttled` while the
+    /// game ran at double speed. Back pressure is a safety net against a core
+    /// that outruns us in bursts, not a speed regulator; getting the emulated
+    /// time per `retro_run` right is the frontend's job (see the PPSSPP
+    /// `ppsspp_frame_duplication` answer in LibretroFrontend+Environment).
+    private static let audioRunAheadLimitMs: Double = 70
+
+    /// Whether the next `retro_run` would only produce samples the trim is going
+    /// to throw away again.
+    ///
+    /// The samples a core hands over are proportional to *emulated* time, which
+    /// makes a ring that keeps filling the one reliable signal that the core is
+    /// running faster than real time — the frame counter cannot see it, because
+    /// a core that advances two emulated frames per call still looks like a
+    /// perfect 60 fps from the outside.
+    ///
+    /// Only meaningful while the engine actually drains the ring. With no
+    /// consumer the trim in `enqueueAudio` parks the fill level inside the
+    /// window all by itself, and reading it would stall the core for good.
+    func coreIsAheadOfAudio() -> Bool {
+        guard audioEngine.isRunning else { return false }
+        return audioBufferedMilliseconds() >= Self.audioRunAheadLimitMs
+    }
+
     /// Incremented whenever the render callback runs out of samples and has to
     /// emit silence. Anything above zero during steady play means the trim window
     /// is too tight.
     nonisolated(unsafe) static var audioUnderruns: Int = 0
+
+    /// Frames (sample pairs) handed over by the core since the last pacing
+    /// report, and frames the trim threw away again in the same window.
+    ///
+    /// The production rate is the only direct measure of *emulated* time we get:
+    /// cores schedule their mixer off the emulated clock (PPSSPP every 64
+    /// samples, `__sceAudio.cpp:63`), so 44100 frames per real second means the
+    /// core is running at real time and 88200 means double speed. The frame
+    /// counter cannot show this, because a core that advances two emulated
+    /// frames per `retro_run` still looks like a clean 60 fps from outside.
+    ///
+    /// The trim counter belongs next to it: while it is discarding samples the
+    /// fill level says nothing about the production rate, and every regulation
+    /// built on that level — `coreIsAheadOfAudio()` included — is reading a
+    /// number the trim itself has pinned inside its window.
+    ///
+    /// Counted per batch (about 60 calls a second), not per sample.
+    nonisolated(unsafe) static var audioFramesProduced: Int = 0
+    nonisolated(unsafe) static var audioFramesTrimmed: Int = 0
 
     /// How much audio is waiting to be played. This, not the ring's size, is the
     /// audio latency: the ring is 2 seconds deep, what matters is how full it is.
@@ -48,6 +98,8 @@ extension LibretroFrontend {
     func startAudio(sampleRate: Double) {
         Self.audioActiveSampleRate = sampleRate > 0 ? sampleRate : Double(Self.audioSampleRateHz)
         Self.audioUnderruns = 0
+        Self.audioFramesProduced = 0
+        Self.audioFramesTrimmed = 0
         // Ask for a short hardware buffer. The default under .playback is around
         // 20 ms, chosen for power rather than latency, and every millisecond here
         // is a millisecond between the core producing a sample and it being
@@ -56,9 +108,13 @@ extension LibretroFrontend {
         // over AirPlay it usually ignores this entirely, hence the log below.
         EmulatorAudioSession.activate(preferredIOBufferDuration: 0.005)
         let session = AVAudioSession.sharedInstance()
+        // Core rate and hardware rate are logged side by side because they
+        // differ on every iPhone (cores are 44.1 kHz, the built-in speaker runs
+        // at 48 kHz). The conversion is the mixer's job below, and this line is
+        // what shows whether it is actually happening.
         print(String(
-            format: "[Libretro] audio out: io buffer %.1f ms, route latency %.1f ms",
-            session.ioBufferDuration * 1000, session.outputLatency * 1000
+            format: "[Libretro] audio out: core %.0f Hz, hardware %.0f Hz, io buffer %.1f ms, route latency %.1f ms",
+            sampleRate, session.sampleRate, session.ioBufferDuration * 1000, session.outputLatency * 1000
         ))
 
         let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 2)!
@@ -71,7 +127,17 @@ extension LibretroFrontend {
         audioEngine.connect(node, to: audioEngine.mainMixerNode, format: format)
         do {
             try audioEngine.start()
-            print("[Libretro] audio engine started @\(sampleRate)Hz")
+            // The source node is created without a format, so the render block
+            // is driven at the connection format above — the mixer resamples to
+            // the output rate. If those two ever printed the same rate while the
+            // hardware ran at another, the block would be pulled at the wrong
+            // speed and everything would play sharp.
+            print(String(
+                format: "[Libretro] audio graph: source %.0f Hz -> mixer out %.0f Hz -> device %.0f Hz",
+                sampleRate,
+                audioEngine.mainMixerNode.outputFormat(forBus: 0).sampleRate,
+                audioEngine.outputNode.outputFormat(forBus: 0).sampleRate
+            ))
         } catch {
             print("[Libretro] audio start failed: \(error)")
         }
@@ -110,6 +176,7 @@ extension LibretroFrontend {
     func enqueueAudio(_ samples: UnsafePointer<Int16>, frames: Int) {
         let count = frames * 2 // stereo
         Self.audioRingLock.lock()
+        Self.audioFramesProduced += frames
         for i in 0..<count {
             Self.audioRing[Self.audioWriteIdx] = samples[i]
             Self.audioWriteIdx = (Self.audioWriteIdx + 1) % Self.audioRing.count
@@ -133,6 +200,7 @@ extension LibretroFrontend {
         if queued > threshold {
             // Advance the reader rather than rewinding the writer: the newest
             // audio is the part that belongs with the picture on screen now.
+            Self.audioFramesTrimmed += (queued - target) / Self.audioChannelCount
             Self.audioReadIdx = (Self.audioWriteIdx - target + Self.audioRing.count) % Self.audioRing.count
         }
         Self.audioRingLock.unlock()

--- a/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Environment.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Environment.swift
@@ -151,6 +151,23 @@ extension LibretroFrontend {
             v.pointee.value = nil
             return false
 
+        case LibretroABI.ENVIRONMENT_SET_SYSTEM_AV_INFO:
+            // Timing-relevant, nicht kosmetisch: Flycast rechnet die echte
+            // Bildrate aus den SPG-Registern und meldet sie bei jedem
+            // Videomodus-Wechsel nach (spg.cpp:67). Ohne Antwort pacen wir
+            // ewig gegen die Rate, die beim Laden galt.
+            guard let data = data else { return false }
+            applyAVInfo(data.assumingMemoryBound(to: LibretroABI.SystemAVInfo.self).pointee)
+            return true
+
+        case LibretroABI.ENVIRONMENT_SET_GEOMETRY:
+            // Nur Geometrie, die Timings bleiben stehen. PPSSPP reicht hier eine
+            // ganze retro_system_av_info herein (libretro.cpp:1134) — die
+            // beginnt mit der Geometrie, der Cast passt also fuer beide Cores.
+            guard let data = data else { return false }
+            applyGeometry(data.assumingMemoryBound(to: LibretroABI.GameGeometry.self).pointee)
+            return true
+
         case LibretroABI.ENVIRONMENT_SET_PERFORMANCE_LEVEL,
              LibretroABI.ENVIRONMENT_SET_VARIABLES,
              LibretroABI.ENVIRONMENT_SET_INPUT_DESCRIPTORS,

--- a/romm/romm/UI/Emulator/Libretro/LibretroFrontend.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroFrontend.swift
@@ -320,6 +320,8 @@ final class LibretroFrontend {
         #if DEBUG
         frameRateWindowStart = 0
         frameRateWindowCount = 0
+        frameRateWindowThrottled = 0
+        frameRateWindowFrameBase = frameCount
         #endif
         let driver = DisplayLinkDriver { [weak self] displayFrameDuration in
             MainActor.assumeIsolated {
@@ -331,7 +333,33 @@ final class LibretroFrontend {
     }
 
     private var coreFPS: Double {
-        avInfo.timing.fps > 0 ? avInfo.timing.fps : 60
+        // Bounded rather than just checked against zero: the rate can now be
+        // rewritten at runtime by the core (SET_SYSTEM_AV_INFO), and a bogus
+        // value would either freeze the run loop or fast-forward it.
+        (1...1000).contains(avInfo.timing.fps) ? avInfo.timing.fps : 60
+    }
+
+    /// Takes over the timings a core reports after loading. Flycast recomputes
+    /// its frame rate from the SPG registers on every video mode change, so the
+    /// value from `retro_get_system_av_info` is only the starting point.
+    func applyAVInfo(_ info: LibretroABI.SystemAVInfo) {
+        let previousFPS = avInfo.timing.fps
+        avInfo = info
+        if info.timing.fps != previousFPS {
+            print(String(format: "[Libretro] core retimed: %.4f Hz -> %.4f Hz", previousFPS, info.timing.fps))
+            // The backlog was measured against the old interval.
+            frameAccumulator = 0
+        }
+        // Retuning the engine would mean tearing down and rebuilding the source
+        // node mid-frame. Neither core actually does this — both are pinned to
+        // 44.1 kHz — so log it rather than carry the machinery for it.
+        if info.timing.sample_rate > 0, info.timing.sample_rate != Self.audioActiveSampleRate {
+            print("[Libretro] core changed sample rate to \(info.timing.sample_rate)Hz, engine stays at \(Self.audioActiveSampleRate)Hz")
+        }
+    }
+
+    func applyGeometry(_ geometry: LibretroABI.GameGeometry) {
+        avInfo.geometry = geometry
     }
 
     /// Runs as many core frames as the elapsed display time calls for. Usually
@@ -344,9 +372,22 @@ final class LibretroFrontend {
         // Capped so that after a stall (a load, a resume) the backlog is not
         // burned off in one burst, which would fast-forward the game.
         var runs = 0
+        var throttled = 0
         while frameAccumulator >= coreInterval && runs < 4 {
-            retro_run?()
+            // Debited before the check on purpose: a frame we decide not to run
+            // is dropped, not owed. Otherwise the accumulator would saturate and
+            // the next tick would burst.
             frameAccumulator -= coreInterval
+            // The display clock alone only paces cores where one `retro_run` is
+            // exactly one video frame of emulated time — PCSX ReARMed, Beetle
+            // PCE and Genesis Plus GX all are. PPSSPP and Flycast instead run
+            // until the game presents a frame (sceDisplay.cpp:670,
+            // Renderer_if.cpp:270), so a title drawing at 30 Hz advances two
+            // frames of emulated time per call and calling it at the reported
+            // ~60 Hz runs it at double speed. Skipping the call is what pins
+            // those back to real time.
+            guard !coreIsAheadOfAudio() else { throttled += 1; break }
+            retro_run?()
             runs += 1
         }
 
@@ -359,7 +400,7 @@ final class LibretroFrontend {
         }
 
         #if DEBUG
-        countFrames(ran: runs)
+        countFrames(ran: runs, throttled: throttled)
         #endif
     }
 
@@ -368,27 +409,57 @@ final class LibretroFrontend {
 
     private var frameRateWindowStart: CFTimeInterval = 0
     private var frameRateWindowCount = 0
+    private var frameRateWindowThrottled = 0
+    private var frameRateWindowFrameBase: UInt64 = 0
 
     /// Reports the rate the core actually achieves versus what it asked for, plus
     /// how much audio is queued and how often the render callback ran dry. A gap
     /// between measured and expected is the first thing to look at when audio
     /// drifts, since the core produces its samples per frame.
-    private func countFrames(ran: Int) {
+    ///
+    /// `throttled` tells the two reasons for a low measured rate apart: a core
+    /// that cannot keep up shows zero there, one that was held back by the audio
+    /// clock because it advances more than a frame per call shows the difference.
+    ///
+    /// `runs` and `video` are counted separately because they are not the same
+    /// question. `runs` is how often we called the core, `video` how many frames
+    /// it handed back — PPSSPP and Flycast may return zero or several per call,
+    /// and only the second line below can say how much *emulated* time went by
+    /// while that happened.
+    private func countFrames(ran: Int, throttled: Int) {
         frameRateWindowCount += ran
+        frameRateWindowThrottled += throttled
         let now = CACurrentMediaTime()
         if frameRateWindowStart == 0 {
             frameRateWindowStart = now
+            frameRateWindowFrameBase = frameCount
             return
         }
         let elapsed = now - frameRateWindowStart
-        guard elapsed >= 3 else { return }
-        let measured = Double(frameRateWindowCount) / elapsed
+        guard elapsed >= 1 else { return }
+        let runs = Double(frameRateWindowCount) / elapsed
+        let video = Double(frameCount - frameRateWindowFrameBase) / elapsed
         print(String(
-            format: "[Libretro] pacing: %.2f fps measured, %.2f expected, audio buffered %.0f ms, underruns %d",
-            measured, coreFPS, audioBufferedMilliseconds(), Self.audioUnderruns
+            format: "[Libretro] pacing: %.2f runs/s, %.2f expected, %.2f video/s, %d throttled, audio buffered %.0f ms, underruns %d",
+            runs, coreFPS, video, frameRateWindowThrottled, audioBufferedMilliseconds(), Self.audioUnderruns
+        ))
+        // Second line on purpose: this is the one number that measures emulated
+        // time rather than call counts. Roughly the core's sample rate means the
+        // core runs at real time; double it means double speed; a non-zero trim
+        // figure means the fill level is being held in place by force and cannot
+        // be trusted as a speed signal.
+        print(String(
+            format: "[Libretro] audio rate: %.0f Hz from core, %.0f Hz expected, %.0f Hz trimmed away",
+            Double(Self.audioFramesProduced) / elapsed,
+            Self.audioActiveSampleRate,
+            Double(Self.audioFramesTrimmed) / elapsed
         ))
         frameRateWindowStart = now
         frameRateWindowCount = 0
+        frameRateWindowThrottled = 0
+        frameRateWindowFrameBase = frameCount
+        Self.audioFramesProduced = 0
+        Self.audioFramesTrimmed = 0
     }
     #endif
 


### PR DESCRIPTION
Improves frame pacing and makes the timing behaviour measurable.

Replaces #120, which GitHub auto-closed when its base branch was deleted on merge of #119.

## What it does

- Answers `RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO` (32) and `SET_GEOMETRY` (37). Cores that recompute their refresh rate at runtime (Flycast does this on every video mode change) were previously ignored, so the frontend kept pacing against the rate reported at load time.
- Adds audio back pressure: the emulation step is skipped while the core is ahead of the audio clock.
- Adds per-second instrumentation that separates causes which used to look identical in the log:
  - `runs/s` vs `video/s` — a `retro_run` call does not always produce exactly one frame
  - `audio rate … from core` — the real production rate, which measures emulated time rather than call counts
  - `… Hz trimmed away` — how much audio the ring buffer trim discards, since a trimmed buffer level is useless as a speed signal

## Why the instrumentation is worth keeping

Chasing a speed bug through frame counters alone was misleading: the measured frame rate was correct while the game ran at double speed, because the frame counter counts calls, not emulated frames. The three values above distinguish "core is too slow", "core was throttled" and "core emulates too much per call" directly.
