### PR TITLE
Pace libretro cores against the audio clock

### DIFF
--- a/romm/romm/UI/Emulator/Libretro/LibretroABI.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroABI.swift
@@ -46,6 +46,10 @@ enum LibretroABI {
     static let ENVIRONMENT_GET_RUMBLE_INTERFACE: UInt32 = 23
     static let ENVIRONMENT_GET_LOG_INTERFACE: UInt32 = 27
     static let ENVIRONMENT_GET_SAVE_DIRECTORY: UInt32 = 31
+    /// Core reports changed timings at runtime, Flycast on every video mode change.
+    static let ENVIRONMENT_SET_SYSTEM_AV_INFO: UInt32 = 32
+    /// As above, geometry only — timings stay.
+    static let ENVIRONMENT_SET_GEOMETRY: UInt32 = 37
     static let ENVIRONMENT_GET_INPUT_BITMASKS: UInt32 = 51 | 0x10000
 
     // MARK: - Memory types (retro_get_memory_data/size)

--- a/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Audio.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Audio.swift
@@ -31,10 +31,35 @@ extension LibretroFrontend {
     private static let audioTrimThresholdMs: Double = 80
     private static let audioTrimTargetMs: Double = 50
 
+    /// Fill level from which the core counts as running ahead of the audio clock.
+    /// A safety net against a core that outruns us in bursts, not a speed
+    /// regulator: the trim keeps the level inside its own window, so this limit
+    /// is rarely reached. Emulated time per `retro_run` is a matter of core
+    /// options instead, see the answers in LibretroFrontend+Environment.
+    private static let audioRunAheadLimitMs: Double = 70
+
+    /// Only meaningful while the engine drains the ring: without a consumer the
+    /// trim parks the fill level inside its window by itself, and reading it
+    /// would stall the core for good.
+    func coreIsAheadOfAudio() -> Bool {
+        guard audioEngine.isRunning else { return false }
+        return audioBufferedMilliseconds() >= Self.audioRunAheadLimitMs
+    }
+
     /// Incremented whenever the render callback runs out of samples and has to
     /// emit silence. Anything above zero during steady play means the trim window
     /// is too tight.
     nonisolated(unsafe) static var audioUnderruns: Int = 0
+
+    /// Frames handed over by the core since the last pacing report, and frames
+    /// the trim threw away again. The production rate measures *emulated* time:
+    /// 44100 frames per real second means real time, 88200 means double speed.
+    /// The frame counter cannot show this, because a core advancing two emulated
+    /// frames per `retro_run` still looks like a clean 60 fps from outside.
+    /// While the trim discards samples the fill level says nothing about the
+    /// production rate, so both numbers only make sense side by side.
+    nonisolated(unsafe) static var audioFramesProduced: Int = 0
+    nonisolated(unsafe) static var audioFramesTrimmed: Int = 0
 
     /// How much audio is waiting to be played. This, not the ring's size, is the
     /// audio latency: the ring is 2 seconds deep, what matters is how full it is.
@@ -48,6 +73,8 @@ extension LibretroFrontend {
     func startAudio(sampleRate: Double) {
         Self.audioActiveSampleRate = sampleRate > 0 ? sampleRate : Double(Self.audioSampleRateHz)
         Self.audioUnderruns = 0
+        Self.audioFramesProduced = 0
+        Self.audioFramesTrimmed = 0
         // Ask for a short hardware buffer. The default under .playback is around
         // 20 ms, chosen for power rather than latency, and every millisecond here
         // is a millisecond between the core producing a sample and it being
@@ -56,9 +83,12 @@ extension LibretroFrontend {
         // over AirPlay it usually ignores this entirely, hence the log below.
         EmulatorAudioSession.activate(preferredIOBufferDuration: 0.005)
         let session = AVAudioSession.sharedInstance()
-        print(String(
-            format: "[Libretro] audio out: io buffer %.1f ms, route latency %.1f ms",
-            session.ioBufferDuration * 1000, session.outputLatency * 1000
+        // Core rate and hardware rate side by side: they differ on every iPhone
+        // (cores run at 44.1 kHz, the built-in speaker at 48 kHz), and the mixer
+        // below is what has to bridge them.
+        Logger.performance.info(String(
+            format: "audio out: core %.0f Hz, hardware %.0f Hz, io buffer %.1f ms, route latency %.1f ms",
+            sampleRate, session.sampleRate, session.ioBufferDuration * 1000, session.outputLatency * 1000
         ))
 
         let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 2)!
@@ -71,9 +101,18 @@ extension LibretroFrontend {
         audioEngine.connect(node, to: audioEngine.mainMixerNode, format: format)
         do {
             try audioEngine.start()
-            print("[Libretro] audio engine started @\(sampleRate)Hz")
+            // The source node has no explicit format, so the render block runs at
+            // the connection format and the mixer resamples to the device rate.
+            // Source and device showing different rates here is what confirms the
+            // conversion happens; without it everything would play sharp.
+            Logger.performance.info(String(
+                format: "audio graph: source %.0f Hz -> mixer out %.0f Hz -> device %.0f Hz",
+                sampleRate,
+                audioEngine.mainMixerNode.outputFormat(forBus: 0).sampleRate,
+                audioEngine.outputNode.outputFormat(forBus: 0).sampleRate
+            ))
         } catch {
-            print("[Libretro] audio start failed: \(error)")
+            Logger.general.error("audio start failed: \(error)")
         }
     }
 
@@ -110,6 +149,7 @@ extension LibretroFrontend {
     func enqueueAudio(_ samples: UnsafePointer<Int16>, frames: Int) {
         let count = frames * 2 // stereo
         Self.audioRingLock.lock()
+        Self.audioFramesProduced += frames
         for i in 0..<count {
             Self.audioRing[Self.audioWriteIdx] = samples[i]
             Self.audioWriteIdx = (Self.audioWriteIdx + 1) % Self.audioRing.count
@@ -133,6 +173,7 @@ extension LibretroFrontend {
         if queued > threshold {
             // Advance the reader rather than rewinding the writer: the newest
             // audio is the part that belongs with the picture on screen now.
+            Self.audioFramesTrimmed += (queued - target) / Self.audioChannelCount
             Self.audioReadIdx = (Self.audioWriteIdx - target + Self.audioRing.count) % Self.audioRing.count
         }
         Self.audioRingLock.unlock()

--- a/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Environment.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroFrontend+Environment.swift
@@ -151,6 +151,20 @@ extension LibretroFrontend {
             v.pointee.value = nil
             return false
 
+        case LibretroABI.ENVIRONMENT_SET_SYSTEM_AV_INFO:
+            // Ignoring this leaves us pacing against the rate that applied at
+            // load time; Flycast renegotiates on every video mode change.
+            guard let data = data else { return false }
+            applyAVInfo(data.assumingMemoryBound(to: LibretroABI.SystemAVInfo.self).pointee)
+            return true
+
+        case LibretroABI.ENVIRONMENT_SET_GEOMETRY:
+            // PPSSPP passes a full retro_system_av_info here, which starts with
+            // the geometry, so the cast holds for both cores.
+            guard let data = data else { return false }
+            applyGeometry(data.assumingMemoryBound(to: LibretroABI.GameGeometry.self).pointee)
+            return true
+
         case LibretroABI.ENVIRONMENT_SET_PERFORMANCE_LEVEL,
              LibretroABI.ENVIRONMENT_SET_VARIABLES,
              LibretroABI.ENVIRONMENT_SET_INPUT_DESCRIPTORS,

--- a/romm/romm/UI/Emulator/Libretro/LibretroFrontend.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroFrontend.swift
@@ -320,6 +320,8 @@ final class LibretroFrontend {
         #if DEBUG
         frameRateWindowStart = 0
         frameRateWindowCount = 0
+        frameRateWindowThrottled = 0
+        frameRateWindowFrameBase = frameCount
         #endif
         let driver = DisplayLinkDriver { [weak self] displayFrameDuration in
             MainActor.assumeIsolated {
@@ -331,7 +333,33 @@ final class LibretroFrontend {
     }
 
     private var coreFPS: Double {
-        avInfo.timing.fps > 0 ? avInfo.timing.fps : 60
+        // Bounded, not just checked against zero: the core can rewrite the rate
+        // at runtime and a bogus value would freeze or fast-forward the loop.
+        (1...1000).contains(avInfo.timing.fps) ? avInfo.timing.fps : 60
+    }
+
+    /// Takes over the timings a core reports after loading. Flycast recomputes
+    /// its frame rate from the SPG registers on every video mode change, so the
+    /// value from `retro_get_system_av_info` is only the starting point.
+    func applyAVInfo(_ info: LibretroABI.SystemAVInfo) {
+        let previousFPS = avInfo.timing.fps
+        avInfo = info
+        if info.timing.fps != previousFPS {
+            Logger.performance.info(String(
+                format: "core retimed: %.4f Hz -> %.4f Hz", previousFPS, info.timing.fps
+            ))
+            // The backlog was measured against the old interval.
+            frameAccumulator = 0
+        }
+        // Retuning would mean rebuilding the source node mid-frame. No core we
+        // ship does this, so log it instead of carrying the machinery.
+        if info.timing.sample_rate > 0, info.timing.sample_rate != Self.audioActiveSampleRate {
+            Logger.general.notice("core changed sample rate to \(info.timing.sample_rate)Hz, engine stays at \(Self.audioActiveSampleRate)Hz")
+        }
+    }
+
+    func applyGeometry(_ geometry: LibretroABI.GameGeometry) {
+        avInfo.geometry = geometry
     }
 
     /// Runs as many core frames as the elapsed display time calls for. Usually
@@ -344,9 +372,16 @@ final class LibretroFrontend {
         // Capped so that after a stall (a load, a resume) the backlog is not
         // burned off in one burst, which would fast-forward the game.
         var runs = 0
+        var throttled = 0
         while frameAccumulator >= coreInterval && runs < 4 {
-            retro_run?()
+            // Debited before the check: a frame we skip is dropped, not owed.
             frameAccumulator -= coreInterval
+            // The display clock only paces cores where one `retro_run` is exactly
+            // one video frame of emulated time. PPSSPP and Flycast instead run
+            // until the game presents, so a 30 Hz title advances two frames per
+            // call and would run at double speed.
+            guard !coreIsAheadOfAudio() else { throttled += 1; break }
+            retro_run?()
             runs += 1
         }
 
@@ -359,7 +394,7 @@ final class LibretroFrontend {
         }
 
         #if DEBUG
-        countFrames(ran: runs)
+        countFrames(ran: runs, throttled: throttled)
         #endif
     }
 
@@ -368,27 +403,48 @@ final class LibretroFrontend {
 
     private var frameRateWindowStart: CFTimeInterval = 0
     private var frameRateWindowCount = 0
+    private var frameRateWindowThrottled = 0
+    private var frameRateWindowFrameBase: UInt64 = 0
 
-    /// Reports the rate the core actually achieves versus what it asked for, plus
-    /// how much audio is queued and how often the render callback ran dry. A gap
-    /// between measured and expected is the first thing to look at when audio
-    /// drifts, since the core produces its samples per frame.
-    private func countFrames(ran: Int) {
+    /// Reports what the core achieves versus what it asked for.
+    ///
+    /// The three values exist to tell causes apart that otherwise look alike:
+    /// `throttled` separates a core that cannot keep up (zero) from one held back
+    /// by the audio clock; `runs` versus `video` shows cores that return zero or
+    /// several frames per call; the audio rate is the only figure measuring
+    /// emulated time rather than call counts.
+    private func countFrames(ran: Int, throttled: Int) {
         frameRateWindowCount += ran
+        frameRateWindowThrottled += throttled
         let now = CACurrentMediaTime()
         if frameRateWindowStart == 0 {
             frameRateWindowStart = now
+            frameRateWindowFrameBase = frameCount
             return
         }
         let elapsed = now - frameRateWindowStart
-        guard elapsed >= 3 else { return }
-        let measured = Double(frameRateWindowCount) / elapsed
-        print(String(
-            format: "[Libretro] pacing: %.2f fps measured, %.2f expected, audio buffered %.0f ms, underruns %d",
-            measured, coreFPS, audioBufferedMilliseconds(), Self.audioUnderruns
+        guard elapsed >= 1 else { return }
+        let runs = Double(frameRateWindowCount) / elapsed
+        let video = Double(frameCount - frameRateWindowFrameBase) / elapsed
+        Logger.performance.debug(String(
+            format: "pacing: %.2f runs/s, %.2f expected, %.2f video/s, %d throttled, audio buffered %.0f ms, underruns %d",
+            runs, coreFPS, video, frameRateWindowThrottled, audioBufferedMilliseconds(), Self.audioUnderruns
+        ))
+        // Roughly the core's sample rate means real time, double means double
+        // speed. A non-zero trim figure means the fill level is being held in
+        // place and cannot be read as a speed signal.
+        Logger.performance.debug(String(
+            format: "audio rate: %.0f Hz from core, %.0f Hz expected, %.0f Hz trimmed away",
+            Double(Self.audioFramesProduced) / elapsed,
+            Self.audioActiveSampleRate,
+            Double(Self.audioFramesTrimmed) / elapsed
         ))
         frameRateWindowStart = now
         frameRateWindowCount = 0
+        frameRateWindowThrottled = 0
+        frameRateWindowFrameBase = frameCount
+        Self.audioFramesProduced = 0
+        Self.audioFramesTrimmed = 0
     }
     #endif
 


### PR DESCRIPTION
Improves frame pacing and makes the timing behaviour measurable.

Replaces #120, which GitHub auto-closed when its base branch was deleted on merge of #119.

## What it does

- Answers `RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO` (32) and `SET_GEOMETRY` (37). Cores that recompute their refresh rate at runtime (Flycast does this on every video mode change) were previously ignored, so the frontend kept pacing against the rate reported at load time.
- Adds audio back pressure: the emulation step is skipped while the core is ahead of the audio clock.
- Adds per-second instrumentation that separates causes which used to look identical in the log:
  - `runs/s` vs `video/s` — a `retro_run` call does not always produce exactly one frame
  - `audio rate … from core` — the real production rate, which measures emulated time rather than call counts
  - `… Hz trimmed away` — how much audio the ring buffer trim discards, since a trimmed buffer level is useless as a speed signal

## Why the instrumentation is worth keeping

Chasing a speed bug through frame counters alone was misleading: the measured frame rate was correct while the game ran at double speed, because the frame counter counts calls, not emulated frames. The three values above distinguish "core is too slow", "core was throttled" and "core emulates too much per call" directly.
