### PR TITLE
Let a button under the d-pad slop win the touch

### DIFF
--- a/romm/romm/UI/Emulator/Libretro/LibretroTouchControllerView.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroTouchControllerView.swift
@@ -429,8 +429,11 @@ final class LibretroTouchControllerView: UIView {
 
         // D-Pad ownership: claimed by first touch that lands inside dpad.frame
         // (mit dpadSlop), released when that touch lifts (slide outside is allowed).
+        // Ein Touch, der direkt auf einem Button liegt, gehoert diesem Button:
+        // sonst verschluckt der dpadSlop-Rand angrenzende Buttons (z.B. Start).
         if dpadTouch == nil, !ended,
-           dpad.frame.insetBy(dx: -dpadSlop, dy: -dpadSlop).contains(point) {
+           dpad.frame.insetBy(dx: -dpadSlop, dy: -dpadSlop).contains(point),
+           !faceButtons.contains(where: { $0.frame.contains(point) }) {
             dpadTouch = touch
         }
         if dpadTouch === touch {


### PR DESCRIPTION
Fixes touch input being swallowed near the d-pad.

The d-pad claims any touch landing inside its frame plus 32pt of slop and then returns early, so buttons are never checked. Where a button overlaps that slop margin, it simply does not respond — noticed with Start on the Dreamcast layout, where the left half of the button sits inside the d-pad's slop area.

A touch that lands directly on a button frame now belongs to that button. The d-pad keeps its slop for everything else, so its own feel is unchanged.

This also affects the existing layouts, where Select sits even deeper inside the slop area — Select and Start should react more reliably there now.
