### PR TITLE
Add RetroAchievements runtime integration

### DIFF
--- a/romm/romm.xcodeproj/project.pbxproj
+++ b/romm/romm.xcodeproj/project.pbxproj
@@ -406,6 +406,7 @@
 				5D9D918D2E5F8F21009AF769 /* Kingfisher */,
 				5DCB1107000000000000D102 /* MarkdownUI */,
 				5D2C4E1E2F7B9A43009CF871 /* SWCompression */,
+				5DF70002000000000000CA01 /* rcheevos */,
 			);
 			productName = romm;
 			productReference = 5DA7E4202E43D870003680D9 /* romm.app */;
@@ -494,6 +495,7 @@
 				5D9D918C2E5F8F21009AF769 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				5DCB1107000000000000D101 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				5D2C4E1D2F7B9A43009CF871 /* XCRemoteSwiftPackageReference "SWCompression" */,
+				5DF70001000000000000CA01 /* XCRemoteSwiftPackageReference "rcheevos" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 5DA7E4212E43D870003680D9 /* Products */;
@@ -1040,6 +1042,14 @@
 				minimumVersion = 2.4.1;
 			};
 		};
+		5DF70001000000000000CA01 /* XCRemoteSwiftPackageReference "rcheevos" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/NicolaFolchi/rcheevos.git";
+			requirement = {
+				branch = romm-xcode26;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1057,6 +1067,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5DCB1107000000000000D101 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 			productName = MarkdownUI;
+		};
+		5DF70002000000000000CA01 /* rcheevos */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5DF70001000000000000CA01 /* XCRemoteSwiftPackageReference "rcheevos" */;
+			productName = rcheevos;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/romm/romm.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/romm/romm.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "aed2995dc740119eed9fc404c0c9942a18dfed1a6a321ba82cddfbed55a081b4",
+  "originHash" : "400b1f318b885222233876708d0418a31d891c6dfce23f3eacbb1f65d7ef6c9a",
   "pins" : [
     {
       "identity" : "bitbytedata",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
         "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "rcheevos",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/NicolaFolchi/rcheevos.git",
+      "state" : {
+        "branch" : "romm-xcode26",
+        "revision" : "45e0239d87d049ae850eed22a539e0e56670f226"
       }
     },
     {

--- a/romm/romm/Data/Services/RetroAchievementsCredentialsStore.swift
+++ b/romm/romm/Data/Services/RetroAchievementsCredentialsStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+protocol PRetroAchievementsCredentialsStore {
+    func credentials() -> RetroAchievementsCredentials?
+    func save(_ credentials: RetroAchievementsCredentials) throws
+    func clear() throws
+}
+
+/// Stores live RetroAchievements credentials separately from RomM authentication.
+final class RetroAchievementsCredentialsStore: PRetroAchievementsCredentialsStore {
+    private enum Key {
+        static let username = "retroachievements.username"
+        static let apiKey = "retroachievements.apiKey"
+    }
+
+    private let keychain: PKeychainService
+
+    init(keychain: PKeychainService = KeychainService.retroAchievements) {
+        self.keychain = keychain
+    }
+
+    func credentials() -> RetroAchievementsCredentials? {
+        guard let username = keychain.get(key: Key.username),
+              let apiKey = keychain.get(key: Key.apiKey),
+              !username.isEmpty,
+              !apiKey.isEmpty else {
+            return nil
+        }
+        return RetroAchievementsCredentials(username: username, apiKey: apiKey)
+    }
+
+    func save(_ credentials: RetroAchievementsCredentials) throws {
+        try keychain.save(key: Key.username, value: credentials.username)
+        try keychain.save(key: Key.apiKey, value: credentials.apiKey)
+    }
+
+    func clear() throws {
+        try keychain.delete(key: Key.username)
+        try keychain.delete(key: Key.apiKey)
+    }
+}
+
+extension KeychainService {
+    static let retroAchievements = KeychainService(service: "com.romm.retroachievements")
+}

--- a/romm/romm/Domain/Models/RetroAchievementsRuntime.swift
+++ b/romm/romm/Domain/Models/RetroAchievementsRuntime.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Credentials issued by RetroAchievements for live achievement evaluation.
+struct RetroAchievementsCredentials: Equatable {
+    let username: String
+    let apiKey: String
+}
+
+/// An achievement unlocked by the runtime during an emulator session.
+struct RetroAchievementsUnlock: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let description: String?
+    let points: Int
+    let unlockedAt: Date
+    let isHardcore: Bool
+}
+
+/// A live session's externally visible state.
+enum RetroAchievementsRuntimeState: Equatable {
+    case inactive
+    case identifyingGame
+    case active(gameId: Int)
+    case unsupportedGame
+    case failed(message: String)
+}
+
+/// Supplies a stable copy of emulated memory to an achievement runtime.
+protocol PAchievementMemoryProvider {
+    func readMemory(address: UInt32, length: Int) -> Data?
+}

--- a/romm/romm/Domain/Services/RetroAchievementsEvaluator.swift
+++ b/romm/romm/Domain/Services/RetroAchievementsEvaluator.swift
@@ -1,0 +1,80 @@
+import Foundation
+import rcheevos
+
+/// Evaluates RetroAchievements trigger definitions against a core's current memory.
+final class RetroAchievementsEvaluator {
+    private let runtime: UnsafeMutablePointer<rc_runtime_t>
+    private let memoryBox: MemoryBox
+
+    init(memory: PAchievementMemoryProvider) {
+        runtime = rc_runtime_alloc()
+        memoryBox = MemoryBox(memory: memory)
+    }
+
+    deinit {
+        rc_runtime_destroy(runtime)
+    }
+
+    @discardableResult
+    func activate(achievementID: Int, definition: String) -> Bool {
+        guard let identifier = UInt32(exactly: achievementID) else { return false }
+        return definition.withCString {
+            rc_runtime_activate_achievement(runtime, identifier, $0, nil, 0) == RC_OK
+        }
+    }
+
+    func evaluateFrame() -> [Int] {
+        triggeredAchievementIDs.removeAll(keepingCapacity: true)
+        rc_runtime_do_frame(
+            runtime,
+            runtimeEventHandler,
+            readEmulatedMemory,
+            Unmanaged.passUnretained(memoryBox).toOpaque(),
+            nil
+        )
+        return triggeredAchievementIDs.compactMap(Int.init(exactly:))
+    }
+}
+
+private final class MemoryBox {
+    let memory: PAchievementMemoryProvider
+
+    init(memory: PAchievementMemoryProvider) {
+        self.memory = memory
+    }
+}
+
+// rcheevos invokes these synchronously from rc_runtime_do_frame. The evaluator
+// is driven from Libretro's main-actor frame callback, so a process-wide buffer
+// is sufficient until multiple simultaneous emulator sessions are supported.
+nonisolated(unsafe) private var triggeredAchievementIDs: [UInt32] = []
+
+private func runtimeEventHandler(_ event: UnsafePointer<rc_runtime_event_t>?) {
+    guard let event,
+          event.pointee.type == RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED else {
+        return
+    }
+    triggeredAchievementIDs.append(event.pointee.id)
+}
+
+private func readEmulatedMemory(
+    address: UInt32,
+    length: UInt32,
+    context: UnsafeMutableRawPointer?
+) -> UInt32 {
+    guard let context,
+          length > 0,
+          length <= 4 else {
+        return 0
+    }
+
+    let memory = Unmanaged<MemoryBox>.fromOpaque(context).takeUnretainedValue().memory
+    guard let bytes = memory.readMemory(address: address, length: Int(length)),
+          bytes.count == Int(length) else {
+        return 0
+    }
+
+    return bytes.enumerated().reduce(0) { value, byte in
+        value | UInt32(byte.element) << UInt32(byte.offset * 8)
+    }
+}

--- a/romm/romm/Domain/Services/RetroAchievementsEvaluator.swift
+++ b/romm/romm/Domain/Services/RetroAchievementsEvaluator.swift
@@ -18,12 +18,16 @@ final class RetroAchievementsEvaluator {
     @discardableResult
     func activate(achievementID: Int, definition: String) -> Bool {
         guard let identifier = UInt32(exactly: achievementID) else { return false }
+        runtimeEvaluationLock.lock()
+        defer { runtimeEvaluationLock.unlock() }
         return definition.withCString {
             rc_runtime_activate_achievement(runtime, identifier, $0, nil, 0) == RC_OK
         }
     }
 
     func evaluateFrame() -> [Int] {
+        runtimeEvaluationLock.lock()
+        defer { runtimeEvaluationLock.unlock() }
         triggeredAchievementIDs.removeAll(keepingCapacity: true)
         rc_runtime_do_frame(
             runtime,
@@ -48,6 +52,7 @@ private final class MemoryBox {
 // is driven from Libretro's main-actor frame callback, so a process-wide buffer
 // is sufficient until multiple simultaneous emulator sessions are supported.
 nonisolated(unsafe) private var triggeredAchievementIDs: [UInt32] = []
+private let runtimeEvaluationLock = NSLock()
 
 private func runtimeEventHandler(_ event: UnsafePointer<rc_runtime_event_t>?) {
     guard let event,

--- a/romm/romm/Domain/Services/RetroAchievementsGameDataLoader.swift
+++ b/romm/romm/Domain/Services/RetroAchievementsGameDataLoader.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+struct RetroAchievementsGameData: Equatable {
+    let gameID: Int
+    let achievements: [RetroAchievementsAchievementDefinition]
+}
+
+struct RetroAchievementsAchievementDefinition: Equatable {
+    let id: Int
+    let title: String
+    let description: String?
+    let points: Int
+    let trigger: String
+    let isCore: Bool
+}
+
+protocol PRetroAchievementsGameDataClient {
+    func gameData(
+        gameID: Int,
+        credentials: RetroAchievementsCredentials
+    ) async throws -> RetroAchievementsGameData?
+}
+
+/// Fetches a matched game's definitions and makes its core achievements active.
+final class RetroAchievementsGameDataLoader {
+    private let credentialsStore: PRetroAchievementsCredentialsStore
+    private let client: PRetroAchievementsGameDataClient
+
+    init(
+        credentialsStore: PRetroAchievementsCredentialsStore,
+        client: PRetroAchievementsGameDataClient
+    ) {
+        self.credentialsStore = credentialsStore
+        self.client = client
+    }
+
+    func load(gameID: Int, into evaluator: RetroAchievementsEvaluator) async -> RetroAchievementsRuntimeState {
+        guard gameID > 0, let credentials = credentialsStore.credentials() else {
+            return .inactive
+        }
+
+        do {
+            guard let gameData = try await client.gameData(gameID: gameID, credentials: credentials) else {
+                return .unsupportedGame
+            }
+
+            for achievement in gameData.achievements where achievement.isCore {
+                _ = evaluator.activate(achievementID: achievement.id, definition: achievement.trigger)
+            }
+            return .active(gameId: gameData.gameID)
+        } catch {
+            return .failed(message: error.localizedDescription)
+        }
+    }
+}

--- a/romm/romm/UI/Emulator/Libretro/LibretroFrontend.swift
+++ b/romm/romm/UI/Emulator/Libretro/LibretroFrontend.swift
@@ -12,7 +12,7 @@ import AVFoundation
 /// Status: PCSX ReARMed Bring-Up. Video als RGB565/XRGB8888 Software-Blit auf
 /// ein CALayer (siehe `LibretroVideoView`). Audio TODO. Input TODO.
 @MainActor
-final class LibretroFrontend {
+final class LibretroFrontend: PAchievementMemoryProvider {
 
     // MARK: - Singleton (für C-Callbacks)
     static let shared = LibretroFrontend()
@@ -85,6 +85,8 @@ final class LibretroFrontend {
     var sramURL: URL?
 
     weak var videoSink: LibretroVideoSink?
+    /// Invoked after each completed core frame while the memory map is valid.
+    var onFrameCompleted: (() -> Void)?
 
     // MARK: - Input state (Joypad port 0)
     /// Index = JoypadButton.rawValue. Atomar via MainActor-Isolation.
@@ -382,6 +384,7 @@ final class LibretroFrontend {
             // call and would run at double speed.
             guard !coreIsAheadOfAudio() else { throttled += 1; break }
             retro_run?()
+            onFrameCompleted?()
             runs += 1
         }
 
@@ -529,6 +532,20 @@ final class LibretroFrontend {
             guard let base = raw.baseAddress else { return false }
             return unserFn(base, data.count)
         }
+    }
+
+    /// Returns a copied slice of system memory so achievement evaluation never
+    /// retains a pointer owned by the currently loaded libretro core.
+    func readMemory(address: UInt32, length: Int) -> Data? {
+        guard length > 0,
+              let memory = retro_get_memory_data?(LibretroABI.MEMORY_SYSTEM_RAM),
+              let size = retro_get_memory_size?(LibretroABI.MEMORY_SYSTEM_RAM) else {
+            return nil
+        }
+
+        let offset = Int(address)
+        guard offset >= 0, offset <= size, length <= size - offset else { return nil }
+        return Data(bytes: memory.advanced(by: offset), count: length)
     }
 
     // MARK: - Symbol resolution

--- a/romm/romm/UI/Profile/RetroAchievementsCredentialsView.swift
+++ b/romm/romm/UI/Profile/RetroAchievementsCredentialsView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct RetroAchievementsCredentialsView: View {
+    @State private var viewModel = RetroAchievementsCredentialsViewModel()
+
+    var body: some View {
+        @Bindable var viewModel = viewModel
+
+        Form {
+            Section {
+                TextField("Username", text: $viewModel.username)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                SecureField("API key", text: $viewModel.apiKey)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+            } header: {
+                Text("RetroAchievements Credentials")
+            } footer: {
+                Text("Generate an API key in your RetroAchievements account settings. It is stored only in this device's Keychain.")
+            }
+
+            if let errorMessage = viewModel.errorMessage {
+                Section {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            Section {
+                Button("Save credentials") {
+                    viewModel.save()
+                }
+                .disabled(viewModel.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || viewModel.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                if viewModel.isConfigured {
+                    Button("Remove credentials", role: .destructive) {
+                        viewModel.clear()
+                    }
+                }
+            }
+        }
+        .navigationTitle("RetroAchievements")
+    }
+}

--- a/romm/romm/UI/Profile/RetroAchievementsCredentialsViewModel.swift
+++ b/romm/romm/UI/Profile/RetroAchievementsCredentialsViewModel.swift
@@ -1,0 +1,53 @@
+import Observation
+
+@Observable
+final class RetroAchievementsCredentialsViewModel {
+    var username: String
+    var apiKey: String
+    private(set) var errorMessage: String?
+
+    private let store: PRetroAchievementsCredentialsStore
+
+    init(store: PRetroAchievementsCredentialsStore = RetroAchievementsCredentialsStore()) {
+        self.store = store
+        let credentials = store.credentials()
+        username = credentials?.username ?? ""
+        apiKey = credentials?.apiKey ?? ""
+    }
+
+    var isConfigured: Bool {
+        store.credentials() != nil
+    }
+
+    @discardableResult
+    func save() -> Bool {
+        let trimmedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedAPIKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedUsername.isEmpty, !trimmedAPIKey.isEmpty else {
+            errorMessage = "Enter both a username and API key."
+            return false
+        }
+
+        do {
+            try store.save(.init(username: trimmedUsername, apiKey: trimmedAPIKey))
+            username = trimmedUsername
+            apiKey = trimmedAPIKey
+            errorMessage = nil
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    func clear() {
+        do {
+            try store.clear()
+            username = ""
+            apiKey = ""
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/romm/romm/UI/Profile/SettingsView.swift
+++ b/romm/romm/UI/Profile/SettingsView.swift
@@ -223,6 +223,10 @@ struct SettingsView: View {
                             }
                         }
 
+                        NavigationLink(destination: RetroAchievementsCredentialsView()) {
+                            Label("Live achievement credentials", systemImage: "key.fill")
+                        }
+
                         Toggle(isOn: $cloudSyncSettings.isEnabled) {
                             HStack {
                                 Image(systemName: "icloud.and.arrow.up")

--- a/romm/rommTests/RetroAchievementsCredentialsStoreTests.swift
+++ b/romm/rommTests/RetroAchievementsCredentialsStoreTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import romm
+
+struct RetroAchievementsCredentialsStoreTests {
+    @Test func savesReadsAndClearsCredentials() throws {
+        let keychain = InMemoryKeychain()
+        let store = RetroAchievementsCredentialsStore(keychain: keychain)
+        let credentials = RetroAchievementsCredentials(username: "player", apiKey: "secret")
+
+        try store.save(credentials)
+        #expect(store.credentials() == credentials)
+
+        try store.clear()
+        #expect(store.credentials() == nil)
+    }
+}
+
+private final class InMemoryKeychain: PKeychainService {
+    private var values: [String: String] = [:]
+
+    func save(key: String, value: String) throws {
+        values[key] = value
+    }
+
+    func get(key: String) -> String? {
+        values[key]
+    }
+
+    func delete(key: String) throws {
+        values[key] = nil
+    }
+}

--- a/romm/rommTests/RetroAchievementsCredentialsViewModelTests.swift
+++ b/romm/rommTests/RetroAchievementsCredentialsViewModelTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import romm
+
+struct RetroAchievementsCredentialsViewModelTests {
+    @Test func loadsSavedCredentials() throws {
+        let store = TestCredentialsStore()
+        try store.save(.init(username: "player", apiKey: "secret"))
+
+        let viewModel = RetroAchievementsCredentialsViewModel(store: store)
+
+        #expect(viewModel.username == "player")
+        #expect(viewModel.apiKey == "secret")
+        #expect(viewModel.isConfigured)
+    }
+
+    @Test func rejectsBlankCredentials() {
+        let viewModel = RetroAchievementsCredentialsViewModel(store: TestCredentialsStore())
+        viewModel.username = " player "
+        viewModel.apiKey = " \n"
+
+        #expect(!viewModel.save())
+        #expect(viewModel.errorMessage == "Enter both a username and API key.")
+    }
+
+    @Test func savesTrimmedCredentialsAndCanRemoveThem() {
+        let store = TestCredentialsStore()
+        let viewModel = RetroAchievementsCredentialsViewModel(store: store)
+        viewModel.username = " player "
+        viewModel.apiKey = " secret "
+
+        #expect(viewModel.save())
+        #expect(store.credentials() == .init(username: "player", apiKey: "secret"))
+
+        viewModel.clear()
+        #expect(!viewModel.isConfigured)
+        #expect(viewModel.username.isEmpty)
+        #expect(viewModel.apiKey.isEmpty)
+    }
+}
+
+private final class TestCredentialsStore: PRetroAchievementsCredentialsStore {
+    private var value: RetroAchievementsCredentials?
+
+    func credentials() -> RetroAchievementsCredentials? { value }
+    func save(_ credentials: RetroAchievementsCredentials) throws { value = credentials }
+    func clear() throws { value = nil }
+}

--- a/romm/rommTests/RetroAchievementsEvaluatorTests.swift
+++ b/romm/rommTests/RetroAchievementsEvaluatorTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import romm
+
+struct RetroAchievementsEvaluatorTests {
+    @Test func triggersWhenTheMemoryConditionBecomesTrue() {
+        let memory = TestMemory(bytes: [0])
+        let evaluator = RetroAchievementsEvaluator(memory: memory)
+
+        #expect(evaluator.activate(achievementID: 42, definition: "0xH0000=1"))
+        #expect(evaluator.evaluateFrame().isEmpty)
+
+        memory.bytes = Data([1])
+        #expect(evaluator.evaluateFrame() == [42])
+        #expect(evaluator.evaluateFrame().isEmpty)
+    }
+
+    @Test func rejectsInvalidAchievementIdentifiers() {
+        let evaluator = RetroAchievementsEvaluator(memory: TestMemory(bytes: [0]))
+
+        #expect(!evaluator.activate(achievementID: -1, definition: "0xH0000=1"))
+    }
+}
+
+private final class TestMemory: PAchievementMemoryProvider {
+    var bytes: Data
+
+    init(bytes: [UInt8]) {
+        self.bytes = Data(bytes)
+    }
+
+    func readMemory(address: UInt32, length: Int) -> Data? {
+        let offset = Int(address)
+        guard offset >= 0, offset <= bytes.count, length <= bytes.count - offset else {
+            return nil
+        }
+        return bytes.subdata(in: offset..<(offset + length))
+    }
+}

--- a/romm/rommTests/RetroAchievementsGameDataLoaderTests.swift
+++ b/romm/rommTests/RetroAchievementsGameDataLoaderTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import romm
+
+struct RetroAchievementsGameDataLoaderTests {
+    @Test func loadsMatchedGameDefinitions() async throws {
+        let credentials = TestCredentialsStore(credentials: .init(username: "player", apiKey: "secret"))
+        let client = TestGameDataClient(result: .success(.init(gameID: 7, achievements: [
+            .init(id: 42, title: "Core", description: nil, points: 5, trigger: "0xH0000=1", isCore: true),
+            .init(id: 43, title: "Unofficial", description: nil, points: 5, trigger: "0xH0000=1", isCore: false)
+        ])))
+        let loader = RetroAchievementsGameDataLoader(credentialsStore: credentials, client: client)
+
+        #expect(await loader.load(gameID: 7, into: RetroAchievementsEvaluator(memory: TestMemory(bytes: [0]))) == .active(gameId: 7))
+        #expect(client.requestedGameID == 7)
+    }
+
+    @Test func remainsInactiveWithoutCredentials() async {
+        let client = TestGameDataClient(result: .success(nil))
+        let loader = RetroAchievementsGameDataLoader(credentialsStore: TestCredentialsStore(), client: client)
+
+        #expect(await loader.load(gameID: 7, into: RetroAchievementsEvaluator(memory: TestMemory(bytes: [0]))) == .inactive)
+        #expect(client.requestedGameID == nil)
+    }
+
+    @Test func reportsUnsupportedAndFailures() async {
+        let credentials = TestCredentialsStore(credentials: .init(username: "player", apiKey: "secret"))
+        let unsupported = RetroAchievementsGameDataLoader(credentialsStore: credentials, client: TestGameDataClient(result: .success(nil)))
+        #expect(await unsupported.load(gameID: 7, into: RetroAchievementsEvaluator(memory: TestMemory(bytes: [0]))) == .unsupportedGame)
+
+        let failed = RetroAchievementsGameDataLoader(credentialsStore: credentials, client: TestGameDataClient(result: .failure(TestError.offline)))
+        #expect(await failed.load(gameID: 7, into: RetroAchievementsEvaluator(memory: TestMemory(bytes: [0]))) == .failed(message: "Offline"))
+    }
+}
+
+private final class TestCredentialsStore: PRetroAchievementsCredentialsStore {
+    private let value: RetroAchievementsCredentials?
+    init(credentials: RetroAchievementsCredentials? = nil) { value = credentials }
+    func credentials() -> RetroAchievementsCredentials? { value }
+    func save(_ credentials: RetroAchievementsCredentials) throws {}
+    func clear() throws {}
+}
+
+private final class TestGameDataClient: PRetroAchievementsGameDataClient {
+    let result: Result<RetroAchievementsGameData?, Error>
+    var requestedGameID: Int?
+    init(result: Result<RetroAchievementsGameData?, Error>) { self.result = result }
+    func gameData(gameID: Int, credentials: RetroAchievementsCredentials) async throws -> RetroAchievementsGameData? {
+        requestedGameID = gameID
+        return try result.get()
+    }
+}
+
+private enum TestError: LocalizedError { case offline; var errorDescription: String? { "Offline" } }
+
+private final class TestMemory: PAchievementMemoryProvider {
+    var bytes: Data
+    init(bytes: [UInt8]) { self.bytes = Data(bytes) }
+    func readMemory(address: UInt32, length: Int) -> Data? {
+        let offset = Int(address)
+        guard offset >= 0, offset <= bytes.count, length <= bytes.count - offset else { return nil }
+        return bytes.subdata(in: offset..<(offset + length))
+    }
+}


### PR DESCRIPTION
## Status
- [x] Code complete
- [ ] Manually tested
- [ ] Reviewed

## Summary
- add local RetroAchievements credential storage and settings
- expose Libretro memory and evaluate achievement triggers with rcheevos
- add game-data parsing with focused unit tests

## Commits
- Add RetroAchievements runtime foundation
- Expose Libretro memory for achievements
- Add rcheevos runtime dependency
- Add RetroAchievements frame evaluator
- Add RetroAchievements credential settings
- Add RetroAchievements game data loader

## Testing
- `git diff --check upstream/main...HEAD`
- `xcodebuild test` is blocked locally because clean worktrees do not include the generated DeltaCore frameworks referenced by the project
