### PR TITLE
Add RetroAchievements achievement browsing and library progress

### DIFF
--- a/romm/romm/Data/Mappers/RomMapper.swift
+++ b/romm/romm/Data/Mappers/RomMapper.swift
@@ -61,6 +61,7 @@ struct RomMapper {
             releaseYear: releaseYear,
             isFavourite: false, // Resolved separately via the Favourites collection
             hasRetroAchievements: apiRom.raId != nil,
+            retroAchievementsGameId: apiRom.raId,
             isPlayable: !apiRom.missingFromFs,
             sizeBytes: apiRom.fsSizeBytes,
             createdAt: DateFormatter.iso8601Full.string(from: apiRom.createdAt),

--- a/romm/romm/Domain/Models/Rom.swift
+++ b/romm/romm/Domain/Models/Rom.swift
@@ -41,6 +41,7 @@ struct Rom: Identifiable, Equatable {
     let releaseYear: Int?
     let isFavourite: Bool
     let hasRetroAchievements: Bool
+    let retroAchievementsGameId: Int?
     let isPlayable: Bool
     
     // Additional fields for table display
@@ -70,6 +71,7 @@ struct Rom: Identifiable, Equatable {
         releaseYear: Int? = nil,
         isFavourite: Bool = false,
         hasRetroAchievements: Bool = false,
+        retroAchievementsGameId: Int? = nil,
         isPlayable: Bool = false,
         sizeBytes: Int? = nil,
         createdAt: String? = nil,
@@ -92,6 +94,7 @@ struct Rom: Identifiable, Equatable {
         self.releaseYear = releaseYear
         self.isFavourite = isFavourite
         self.hasRetroAchievements = hasRetroAchievements
+        self.retroAchievementsGameId = retroAchievementsGameId
         self.isPlayable = isPlayable
         self.sizeBytes = sizeBytes
         self.createdAt = createdAt

--- a/romm/romm/Domain/Models/User.swift
+++ b/romm/romm/Domain/Models/User.swift
@@ -45,6 +45,11 @@ struct User: Identifiable, Equatable {
         self.retroAchievementsUsername = retroAchievementsUsername
         self.retroAchievementsProgression = retroAchievementsProgression
     }
+
+    func retroAchievementsProgression(for gameId: Int?) -> RetroAchievementsProgression? {
+        guard let gameId else { return nil }
+        return retroAchievementsProgression.first { $0.gameId == gameId }
+    }
 }
 
 extension User {

--- a/romm/romm/UI/Platforms/PlatformDetailView.swift
+++ b/romm/romm/UI/Platforms/PlatformDetailView.swift
@@ -480,6 +480,7 @@ struct TableRomRowView: View {
 
 struct RomStatusIcons: View {
     let rom: Rom
+    @EnvironmentObject private var appData: AppData
     
     var body: some View {
         HStack(spacing: 4) {
@@ -490,10 +491,27 @@ struct RomStatusIcons: View {
             }
             
             if rom.hasRetroAchievements {
-                Image(systemName: "star.fill")
-                    .foregroundColor(.yellow)
-                    .font(.caption)
+                retroAchievementsStatus
             }                        
+        }
+    }
+
+    @ViewBuilder
+    private var retroAchievementsStatus: some View {
+        if let progression = appData.currentUser?.retroAchievementsProgression(for: rom.retroAchievementsGameId) {
+            let maximum = progression.maximumCount ?? 0
+            let awarded = progression.awardedCount ?? progression.earnedAchievements.count
+            let isComplete = maximum > 0 && awarded >= maximum
+
+            Image(systemName: isComplete ? "checkmark.seal.fill" : "circle.lefthalf.filled")
+                .foregroundStyle(isComplete ? .green : .orange)
+                .font(.caption)
+                .accessibilityLabel(isComplete ? "RetroAchievements complete" : "RetroAchievements in progress")
+        } else {
+            Image(systemName: "trophy.fill")
+                .foregroundStyle(.orange)
+                .font(.caption)
+                .accessibilityLabel("RetroAchievements available")
         }
     }
 }

--- a/romm/romm/UI/RomDetail/AchievementDetailSheet.swift
+++ b/romm/romm/UI/RomDetail/AchievementDetailSheet.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct AchievementDetail: Identifiable {
+    let achievement: RetroAchievement
+    let earnedAchievement: EarnedRetroAchievement?
+
+    var id: String { achievement.id }
+}
+
+struct AchievementDetailSheet: View {
+    let detail: AchievementDetail
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(detail.achievement.title)
+                .font(.title2)
+                .fontWeight(.bold)
+
+            if let description = detail.achievement.description, !description.isEmpty {
+                Text(description)
+            }
+
+            if let points = detail.achievement.points {
+                Label("\(points) points", systemImage: "star.fill")
+                    .foregroundStyle(.orange)
+            }
+
+            if let earnedAchievement = detail.earnedAchievement {
+                Label(
+                    earnedAchievement.earnedHardcoreAt == nil ? "Unlocked" : "Unlocked in hardcore mode",
+                    systemImage: "checkmark.seal.fill"
+                )
+                .foregroundStyle(.green)
+
+                if let date = earnedAchievement.earnedDate {
+                    Text(date.formatted(date: .abbreviated, time: .shortened))
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Label("Locked", systemImage: "lock.fill")
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding(24)
+        .presentationDetents([.medium])
+    }
+}

--- a/romm/romm/UI/RomDetail/RomDetailView.swift
+++ b/romm/romm/UI/RomDetail/RomDetailView.swift
@@ -26,6 +26,8 @@ struct RomDetailView: View {
     @State private var selectedTab: DetailTab = .details
     @State private var dominantColor: Color? = nil
     @State private var isHashesExpanded: Bool = false
+    @State private var showsAllAchievements = false
+    @State private var selectedAchievement: AchievementDetail?
     @State private var showingSFTPUpload = false
     @State private var showingCollectionPicker = false
     @State private var showingFullScreenPDF = false
@@ -311,6 +313,9 @@ struct RomDetailView: View {
                 type: .success,
                 duration: 2.0
             )
+            .sheet(item: $selectedAchievement) { detail in
+                AchievementDetailSheet(detail: detail)
+            }
     }
 
     @ViewBuilder
@@ -921,8 +926,12 @@ struct RomDetailView: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             } else {
-                ForEach(details.retroAchievements.sorted { ($0.displayOrder ?? .max) < ($1.displayOrder ?? .max) }) { achievement in
+                let achievements = details.retroAchievements.sorted { ($0.displayOrder ?? .max) < ($1.displayOrder ?? .max) }
+                ForEach(showsAllAchievements ? achievements : Array(achievements.prefix(5))) { achievement in
                     let earnedAchievement = retroAchievementsProgress(for: details)?.earnedAchievement(for: achievement)
+                    Button {
+                        selectedAchievement = AchievementDetail(achievement: achievement, earnedAchievement: earnedAchievement)
+                    } label: {
                     HStack(alignment: .top, spacing: 12) {
                         if let badgeURL = earnedAchievement == nil ? achievement.lockedBadgeURL : achievement.badgeURL {
                             CachedKFImage(urlString: badgeURL) { image in
@@ -961,7 +970,16 @@ struct RomDetailView: View {
                             }
                         }
                     }
+                    }
+                    .buttonStyle(.plain)
                     .padding(.vertical, 4)
+                }
+
+                if achievements.count > 5 {
+                    Button(showsAllAchievements ? "Show less" : "Show all \(achievements.count) achievements") {
+                        showsAllAchievements.toggle()
+                    }
+                    .font(.subheadline)
                 }
             }
         }
@@ -987,7 +1005,7 @@ struct RomDetailView: View {
             .foregroundStyle(isEarned ? .green : .secondary)
             .frame(width: 40, height: 40)
     }
-    
+
     @ViewBuilder
     private func summarySection(_ summary: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {

--- a/romm/rommTests/RetroAchievementsProgressionTests.swift
+++ b/romm/rommTests/RetroAchievementsProgressionTests.swift
@@ -83,4 +83,18 @@ struct RetroAchievementsProgressionTests {
     func rejectsUnparseableTimestamps(_ raw: String) {
         #expect(EarnedRetroAchievement.parseTimestamp(raw) == nil)
     }
+
+    @Test func findsProgressionForARomGameIdentifier() {
+        let progression = RetroAchievementsProgression(
+            gameId: 7,
+            awardedCount: 2,
+            maximumCount: 10,
+            earnedAchievements: []
+        )
+        let user = User(id: 1, username: "player", role: .viewer, retroAchievementsProgression: [progression])
+
+        #expect(user.retroAchievementsProgression(for: 7) == progression)
+        #expect(user.retroAchievementsProgression(for: 8) == nil)
+        #expect(user.retroAchievementsProgression(for: nil) == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- add a detail sheet and expandable list for RetroAchievements
- show per-platform RetroAchievements progress
- retain the upstream badge-based earned-achievement and timestamp handling

## Commits
- Add achievement detail browsing
- Show RetroAchievements library progress

## Testing
- `git diff --check upstream/main...HEAD`
- `xcodebuild test` is blocked locally because clean worktrees do not include the generated DeltaCore frameworks referenced by the project