### PR TITLE
Read saves out of external emulator apps, and preview a sync

### DIFF
--- a/romm/romm/Data/Repositories/LocalSaveStoreRepository.swift
+++ b/romm/romm/Data/Repositories/LocalSaveStoreRepository.swift
@@ -12,6 +12,20 @@ final class LocalSaveStoreRepository: PSaveStore {
         self.init(rootDirectory: SaveStorePaths.defaultRootDirectory())
     }
 
+    // MARK: - Library
+
+    func listRomIds() throws -> [Int] {
+        guard fileManager.fileExists(atPath: rootDirectory.path) else { return [] }
+        let entries = try fileManager.contentsOfDirectory(
+            at: rootDirectory,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        )
+        // The layout is one directory per ROM id, so anything whose name is not
+        // a number was not put there by this store and is skipped rather than
+        // guessed at.
+        return entries.compactMap { Int($0.lastPathComponent) }.sorted()
+    }
+
     // MARK: - Battery
 
     func readBattery(romId: Int) throws -> Data? {

--- a/romm/romm/Domain/Models/ExternalEmulators/DeltaExternalEmulator.swift
+++ b/romm/romm/Domain/Models/ExternalEmulators/DeltaExternalEmulator.swift
@@ -15,6 +15,22 @@ struct DeltaExternalEmulator: PExternalEmulator {
     var identifierKind: ExternalGameIdentifierKind { .sha1OfROMData }
     var wantsUnpackedROM: Bool { true }
 
+    /// Delta names a save after the same SHA-1 it addresses the game by, which is
+    /// the one certain thing about its storage: that identifier is already
+    /// resolved for the deep link, so nothing new has to be worked out.
+    ///
+    /// Where the file sits is not certain. Issue #144 reports `Delta/Database/`
+    /// and notes the naming looks internal; the save has elsewhere been described
+    /// as sitting beside the ROM. Both are offered as hints and neither is
+    /// required, so a wrong guess costs a folder walk rather than the feature.
+    var saveLayout: ExternalSaveLayout? {
+        ExternalSaveLayout(
+            naming: .gameIdentifier,
+            batteryExtensions: ["sav"],
+            searchHints: ["Database", "Games"]
+        )
+    }
+
     /// Sideloaded builds get a team id appended to the bundle identifier, so this
     /// matches on the prefix rather than the exact App Store one.
     func matches(bundleIdentifier: String) -> Bool {

--- a/romm/romm/Domain/Models/ExternalEmulators/ExternalEmulator.swift
+++ b/romm/romm/Domain/Models/ExternalEmulators/ExternalEmulator.swift
@@ -23,6 +23,9 @@ protocol PExternalEmulator: Sendable {
     var wantsUnpackedROM: Bool { get }
     /// The route a ROM takes into this app on its first handoff.
     var romDelivery: ExternalROMDelivery { get }
+    /// How this app names and files the battery saves it writes, or nil when
+    /// that is not known well enough to go looking for them.
+    var saveLayout: ExternalSaveLayout? { get }
     /// ROM extensions this app accepts on platforms the built-in engines have no
     /// `DeltaGameType` for, or nil to support only the platforms they do.
     ///
@@ -51,6 +54,9 @@ extension PExternalEmulator {
     /// The "Open in" menu is the only route that reports which app took the file,
     /// so it stays the default and anything else has to opt out deliberately.
     var romDelivery: ExternalROMDelivery { .openInMenu }
+
+    /// Saves are only read out of an app that has described where it writes them.
+    var saveLayout: ExternalSaveLayout? { nil }
 
     /// Every supported app resolves a game as `<scheme>://game/<identifier>`, they
     /// only disagree on what the identifier is.

--- a/romm/romm/Domain/Models/ExternalEmulators/ExternalEmulator.swift
+++ b/romm/romm/Domain/Models/ExternalEmulators/ExternalEmulator.swift
@@ -58,6 +58,20 @@ extension PExternalEmulator {
     /// Saves are only read out of an app that has described where it writes them.
     var saveLayout: ExternalSaveLayout? { nil }
 
+    /// What the user has to do the first time a ROM goes to this app.
+    ///
+    /// Worth saying out loud during setup, because the first handoff is the one
+    /// step this app cannot complete on the user's behalf, and an app that
+    /// silently waits for a paste looks like a Play button that does nothing.
+    var handoffExplanation: String {
+        switch romDelivery {
+        case .openInMenu:
+            return String(localized: "The first time you play a game, pick \(displayName) from the share sheet that appears. After that it opens there straight away.")
+        case .pasteboard:
+            return String(localized: "\(displayName) cannot take games from the share sheet, so the first time you play one it goes to the clipboard instead. Open \(displayName) and paste it to add it to your library. After that it opens there straight away.")
+        }
+    }
+
     /// Every supported app resolves a game as `<scheme>://game/<identifier>`, they
     /// only disagree on what the identifier is.
     func launchURL(gameIdentifier: String) -> URL? {

--- a/romm/romm/Domain/Models/ExternalEmulators/ExternalEmulatorSetup.swift
+++ b/romm/romm/Domain/Models/ExternalEmulators/ExternalEmulatorSetup.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Remembers which emulator apps the user has finished setting up.
+///
+/// Being installed is not the same as being set up: the app also has to be
+/// understood (how a ROM gets there) and, for syncing, pointed at a folder.
+/// Without this the settings list could only offer every installed app at once,
+/// which is what it used to do and why nothing explained the Manic handoff.
+protocol PExternalEmulatorSetupStore: AnyObject {
+    func isConfigured(_ emulator: ExternalEmulatorID) -> Bool
+    func markConfigured(_ emulator: ExternalEmulatorID)
+    func forget(_ emulator: ExternalEmulatorID)
+    /// In the order they were added, so the settings list does not reshuffle.
+    func configuredEmulators() -> [ExternalEmulatorID]
+}
+
+final class UserDefaultsExternalEmulatorSetupStore: PExternalEmulatorSetupStore {
+
+    private let key = "externalEmulator.configured"
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    private var stored: [String] {
+        get { userDefaults.stringArray(forKey: key) ?? [] }
+        set { userDefaults.set(newValue, forKey: key) }
+    }
+
+    func isConfigured(_ emulator: ExternalEmulatorID) -> Bool {
+        stored.contains(emulator.rawValue)
+    }
+
+    func markConfigured(_ emulator: ExternalEmulatorID) {
+        guard !isConfigured(emulator) else { return }
+        stored.append(emulator.rawValue)
+    }
+
+    func forget(_ emulator: ExternalEmulatorID) {
+        stored.removeAll { $0 == emulator.rawValue }
+    }
+
+    func configuredEmulators() -> [ExternalEmulatorID] {
+        // Unknown values are skipped rather than dropped from storage: a build
+        // that no longer knows an app should not erase the user's setup for a
+        // build that does.
+        stored.compactMap(ExternalEmulatorID.init(rawValue:))
+    }
+}
+
+/// One step of setting up an emulator app.
+///
+/// Which steps apply depends on the app and on what is already true, so the
+/// sequence is worked out rather than fixed: an installed app skips the install
+/// step, and an app whose saves cannot be located has no folder step.
+enum ExternalEmulatorSetupStep: Equatable, Hashable {
+    /// The app is not on the device yet.
+    case install
+    /// How a ROM gets into this app the first time, which differs per app and is
+    /// the step that stops Manic from looking broken.
+    case handoff
+    /// Point at the folder its saves live in, so they can be synced.
+    case saveFolder
+    /// Hand a real ROM over once and see whether it arrives.
+    case testRun
+
+    var title: String {
+        switch self {
+        case .install: return String(localized: "Install the app")
+        case .handoff: return String(localized: "How games get there")
+        case .saveFolder: return String(localized: "Find its saves")
+        case .testRun: return String(localized: "Try it once")
+        }
+    }
+
+    /// Whether this step offers a way past it besides doing it.
+    ///
+    /// Only the steps that ask for something: pointing at a folder, handing a
+    /// ROM over. A user who does not want save syncing should not be blocked
+    /// from playing, and a test run needs a downloaded ROM that may not exist.
+    ///
+    /// Reading is not one of them. The handoff step asks for nothing, so a skip
+    /// next to Continue would be a second button doing the same thing, and
+    /// install cannot be skipped at all.
+    var isSkippable: Bool {
+        self == .saveFolder || self == .testRun
+    }
+}
+
+/// Works out what still has to happen for one app.
+struct ExternalEmulatorSetupPlan: Equatable {
+    let emulator: ExternalEmulatorID
+    let steps: [ExternalEmulatorSetupStep]
+
+    init(emulator: ExternalEmulatorID, isInstalled: Bool, hasSaveFolder: Bool) {
+        self.emulator = emulator
+        var steps: [ExternalEmulatorSetupStep] = []
+        if !isInstalled { steps.append(.install) }
+        steps.append(.handoff)
+        // An app whose save layout is unknown has nothing to point at, so
+        // offering a folder picker would ask the user for something that cannot
+        // be used.
+        if emulator.emulator.saveLayout != nil, !hasSaveFolder { steps.append(.saveFolder) }
+        steps.append(.testRun)
+        self.steps = steps
+    }
+}

--- a/romm/romm/Domain/Models/ExternalEmulators/ExternalSaveFolder.swift
+++ b/romm/romm/Domain/Models/ExternalEmulators/ExternalSaveFolder.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Remembers the folders the user granted access to, one per external emulator
+/// app.
+///
+/// A picked folder is only readable through a security-scoped bookmark, and the
+/// grant has to survive relaunches or the user would be re-picking three folders
+/// every time they want to sync.
+protocol PExternalSaveFolderStore: AnyObject {
+    /// Stores the grant for a folder the user just picked.
+    func remember(folderURL: URL, for emulator: ExternalEmulatorID) throws
+    /// Resolves a previously granted folder, or nil when none was granted or the
+    /// grant no longer resolves.
+    func grantedFolder(for emulator: ExternalEmulatorID) -> ExternalSaveFolderGrant?
+    /// Drops a grant, e.g. when the user picks a different folder or revokes it.
+    func forget(_ emulator: ExternalEmulatorID)
+    /// Every app that currently has a usable grant.
+    func grantedEmulators() -> [ExternalEmulatorID]
+}
+
+/// A resolved folder plus the access it needs to actually be read.
+///
+/// Reading a security-scoped URL has to be bracketed by start/stop calls, and
+/// the stop is easy to forget, so the bracket lives here rather than at each
+/// call site: the folder can only be reached inside `withAccess`.
+struct ExternalSaveFolderGrant {
+    let url: URL
+    /// False for a bookmark that resolved but whose contents moved, which iOS
+    /// reports separately from failure. Worth surfacing, since the usual cause
+    /// is the user having moved or renamed the folder.
+    let isStale: Bool
+
+    private let scoped: Bool
+
+    init(url: URL, isStale: Bool, scoped: Bool = true) {
+        self.url = url
+        self.isStale = isStale
+        self.scoped = scoped
+    }
+
+    /// Runs `body` with the folder accessible, releasing the claim afterwards.
+    func withAccess<T>(_ body: (URL) throws -> T) rethrows -> T {
+        let accessed = scoped && url.startAccessingSecurityScopedResource()
+        defer {
+            if accessed { url.stopAccessingSecurityScopedResource() }
+        }
+        return try body(url)
+    }
+}
+
+final class UserDefaultsExternalSaveFolderStore: PExternalSaveFolderStore {
+
+    private let logger = Logger.emulator
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    private func key(for emulator: ExternalEmulatorID) -> String {
+        "externalSaveFolder.\(emulator.rawValue)"
+    }
+
+    func remember(folderURL: URL, for emulator: ExternalEmulatorID) throws {
+        // The picked URL is already scoped; the bookmark has to be taken while
+        // that claim is held or it cannot be resolved later.
+        let accessed = folderURL.startAccessingSecurityScopedResource()
+        defer {
+            if accessed { folderURL.stopAccessingSecurityScopedResource() }
+        }
+        // iOS has no security-scope option here: a plain bookmark of a picked
+        // URL is already scoped, and passing the macOS-only option throws.
+        let data = try folderURL.bookmarkData()
+        userDefaults.set(data, forKey: key(for: emulator))
+        logger.info("Remembered save folder for \(emulator.rawValue): \(folderURL.lastPathComponent)")
+    }
+
+    func grantedFolder(for emulator: ExternalEmulatorID) -> ExternalSaveFolderGrant? {
+        guard let data = userDefaults.data(forKey: key(for: emulator)) else { return nil }
+        var isStale = false
+        do {
+            let url = try URL(resolvingBookmarkData: data, bookmarkDataIsStale: &isStale)
+            if isStale {
+                logger.warning("Save folder bookmark for \(emulator.rawValue) is stale")
+            }
+            return ExternalSaveFolderGrant(url: url, isStale: isStale)
+        } catch {
+            // A grant that no longer resolves is dropped rather than kept and
+            // retried: it stays broken until the user picks the folder again,
+            // and keeping it would show the app as connected when it is not.
+            logger.warning("Save folder for \(emulator.rawValue) no longer resolves: \(error.localizedDescription)")
+            forget(emulator)
+            return nil
+        }
+    }
+
+    func forget(_ emulator: ExternalEmulatorID) {
+        userDefaults.removeObject(forKey: key(for: emulator))
+    }
+
+    func grantedEmulators() -> [ExternalEmulatorID] {
+        ExternalEmulatorID.allCases.filter { userDefaults.data(forKey: key(for: $0)) != nil }
+    }
+}

--- a/romm/romm/Domain/Models/ExternalEmulators/ExternalSaveLayout.swift
+++ b/romm/romm/Domain/Models/ExternalEmulators/ExternalSaveLayout.swift
@@ -68,10 +68,20 @@ struct ExternalSaveLayout: Sendable, Equatable {
 
     /// Whether a file with this name and extension is a battery save.
     func isBatterySave(fileName: String, matching key: String) -> Bool {
+        guard let found = batteryKey(forFileName: fileName) else { return false }
+        return found.caseInsensitiveCompare(key) == .orderedSame
+    }
+
+    /// What this file claims to be a save for, or nil when it is not a save.
+    ///
+    /// The counterpart to `isBatterySave` for the direction a scan actually
+    /// runs in: a folder is listed once and each name is asked what it belongs
+    /// to, rather than every known ROM asking the folder about itself. Going the
+    /// other way would mean deriving a key per ROM, and for the apps that name
+    /// saves after a content hash that is a hash of every ROM on the device.
+    func batteryKey(forFileName fileName: String) -> String? {
         let name = fileName as NSString
-        guard name.deletingPathExtension.caseInsensitiveCompare(key) == .orderedSame else {
-            return false
-        }
-        return batteryExtensions.contains(name.pathExtension.lowercased())
+        guard batteryExtensions.contains(name.pathExtension.lowercased()) else { return nil }
+        return name.deletingPathExtension
     }
 }

--- a/romm/romm/Domain/Models/ExternalEmulators/ExternalSaveLayout.swift
+++ b/romm/romm/Domain/Models/ExternalEmulators/ExternalSaveLayout.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// How an external emulator app names and stores the battery saves it writes,
+/// so a save the user made over there can be matched to a ROM over here.
+///
+/// Only battery saves (SRAM). Save states are deliberately out of scope: the
+/// three supported apps have nothing in common there. Delta writes
+/// `Save States/<sha1>/<uuid>` with no file extension and keeps the slot and
+/// name in Core Data, RetroArch writes `<base>.state<n>` in a parallel tree, and
+/// Manic keeps states as Realm blobs that are not files at all. Forcing those
+/// into one description would describe none of them.
+struct ExternalSaveLayout: Sendable, Equatable {
+
+    /// What the save file is named after.
+    ///
+    /// Every supported app names it after something the handoff already resolved,
+    /// which is why no extra bookkeeping is needed to find it again.
+    enum Naming: Sendable, Equatable {
+        /// `<gameIdentifier>.<ext>`, the identifier the deep link uses. Delta,
+        /// which names a save after the ROM's SHA-1.
+        case gameIdentifier
+        /// `<ROM file name minus its extension>.<ext>`. RetroArch and Manic, both
+        /// of which truncate at the last dot, so `Zelda.gba` becomes `Zelda.srm`.
+        case romBaseName
+    }
+
+    let naming: Naming
+
+    /// Extensions that count as a battery save for this app.
+    ///
+    /// A whitelist rather than "everything with a matching name", because these
+    /// files do not always sit in a folder of their own: Delta keeps `<sha1>.sav`
+    /// beside `<sha1>.gba` and `<sha1>.png`, so matching on the name alone would
+    /// offer to upload a ROM or a piece of box art as if it were a save.
+    let batteryExtensions: Set<String>
+
+    /// Directories to look in first, relative to the folder the user grants
+    /// access to, outermost path component first.
+    ///
+    /// A hint, never a requirement. These paths come from one user's report on
+    /// one device (issue #144), described there as not exhaustive, and two of
+    /// them contain a component that varies per system or per core. An app is
+    /// also free to move its files between releases. Treating them as the only
+    /// place to look would turn any of that into a feature that silently finds
+    /// nothing, so a search falls back to walking the granted folder.
+    ///
+    /// They still earn their place: walking straight to the right directory
+    /// avoids reading through a RetroArch folder that also holds the user's
+    /// entire ROM collection.
+    let searchHints: [String]
+
+    /// How deep to walk below a hint, or below the granted folder when no hint
+    /// matched. Enough to absorb one unexpected level of nesting without
+    /// descending into a whole library.
+    let maxSearchDepth: Int
+
+    init(
+        naming: Naming,
+        batteryExtensions: Set<String>,
+        searchHints: [String] = [],
+        maxSearchDepth: Int = 3
+    ) {
+        self.naming = naming
+        self.batteryExtensions = batteryExtensions
+        self.searchHints = searchHints
+        self.maxSearchDepth = maxSearchDepth
+    }
+
+    /// Whether a file with this name and extension is a battery save.
+    func isBatterySave(fileName: String, matching key: String) -> Bool {
+        let name = fileName as NSString
+        guard name.deletingPathExtension.caseInsensitiveCompare(key) == .orderedSame else {
+            return false
+        }
+        return batteryExtensions.contains(name.pathExtension.lowercased())
+    }
+}

--- a/romm/romm/Domain/Models/ExternalEmulators/ManicEmuExternalEmulator.swift
+++ b/romm/romm/Domain/Models/ExternalEmulators/ManicEmuExternalEmulator.swift
@@ -26,6 +26,20 @@ struct ManicEmuExternalEmulator: PExternalEmulator {
     /// over the pasteboard.
     var romDelivery: ExternalROMDelivery { .pasteboard }
 
+    /// Saves land under `3DS/sdmc/saves/`, in a directory named after the system
+    /// for gb/gba/gbc/nds and after the core for n64, per issue #144. Hence the
+    /// hint stopping at `saves`: the level below it is not one value.
+    ///
+    /// `srm` alongside `sav` for the same reason, since the n64 core writes the
+    /// libretro extension while the rest write `sav`.
+    var saveLayout: ExternalSaveLayout? {
+        ExternalSaveLayout(
+            naming: .romBaseName,
+            batteryExtensions: ["sav", "srm"],
+            searchHints: ["3DS/sdmc/saves"]
+        )
+    }
+
     /// Systems Manic plays that the built-in engines have no game type for.
     ///
     /// Extensions only, no archives: Manic unpacks those itself and hashes the

--- a/romm/romm/Domain/Models/ExternalEmulators/RetroArchExternalEmulator.swift
+++ b/romm/romm/Domain/Models/ExternalEmulators/RetroArchExternalEmulator.swift
@@ -12,6 +12,20 @@ struct RetroArchExternalEmulator: PExternalEmulator {
     var identifierKind: ExternalGameIdentifierKind { .fileName }
     var wantsUnpackedROM: Bool { false }
 
+    /// Saves sit under `RetroArch/saves/<core>/`, per issue #144. The hint stops
+    /// above the core directory, since that level is one entry per core.
+    ///
+    /// Getting the hint right matters more here than elsewhere: a RetroArch
+    /// folder usually holds the user's whole ROM collection too, so falling back
+    /// to walking it would mean reading through all of that.
+    var saveLayout: ExternalSaveLayout? {
+        ExternalSaveLayout(
+            naming: .romBaseName,
+            batteryExtensions: ["srm", "sav"],
+            searchHints: ["RetroArch/saves", "saves"]
+        )
+    }
+
     /// RetroArch ships under several identifiers (`com.libretro.RetroArch`,
     /// `…RetroArchiOS11`, plus ad-hoc builds), so match on the substring.
     func matches(bundleIdentifier: String) -> Bool {

--- a/romm/romm/Domain/Models/Sync/SaveSlot.swift
+++ b/romm/romm/Domain/Models/Sync/SaveSlot.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// The slot names this app pairs saves under on the server.
+///
+/// A slot is what RomM pairs saves by: `(rom_id, slot)`, with the file name and
+/// the emulator playing no part in it. That is what lets a save written by one
+/// app be picked up by another under a different name. The server takes any
+/// string here, defines no convention of its own, and treats a *missing* slot as
+/// an archival upload that is never paired with anything.
+///
+/// Two properties of these values matter more than what they say:
+///
+/// They must be sent byte for byte as written. The database collation is
+/// case-insensitive but negotiation pairs in a dictionary keyed on the raw
+/// string, so `"Battery"` against a stored `"battery"` yields an upload *and* a
+/// download for the same save. Never route these through a locale-aware case
+/// change, and never derive one from a display name.
+///
+/// And they can never change. A slot name is a migration contract: renaming one
+/// makes the server treat the entire existing history as absent, exactly as a
+/// null slot is treated today.
+enum SaveSlot {
+    /// Cartridge battery / SRAM, the save the game itself writes.
+    ///
+    /// Not `"autosave"`, which RomM's own docs use as their example: that reads
+    /// as an automatically taken save state, which is a different asset with a
+    /// different lifetime.
+    static let battery = "battery"
+}

--- a/romm/romm/Domain/Models/Sync/SyncPreview.swift
+++ b/romm/romm/Domain/Models/Sync/SyncPreview.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// What a sync would do, worked out without doing any of it.
+///
+/// Overwriting a save is close to unrepairable, so syncing shows this first and
+/// only acts once the user has agreed to it.
+struct SyncPreview {
+    /// This app's registered device on the server.
+    let deviceId: String
+    /// How many battery saves this device reported.
+    let reportedSaveCount: Int
+    /// Every operation the server planned, ours and other devices' alike.
+    let operations: [SyncPreviewOperation]
+
+    var uploads: [SyncPreviewOperation] { operations.filter { $0.direction == .upload } }
+    var downloads: [SyncPreviewOperation] { operations.filter { $0.direction == .download } }
+    var conflicts: [SyncPreviewOperation] { operations.filter { $0.direction == .conflict } }
+
+    /// True when server and device already agree and syncing would do nothing.
+    var isUpToDate: Bool { uploads.isEmpty && downloads.isEmpty && conflicts.isEmpty }
+}
+
+/// A single planned change, flattened from the server's operation list.
+struct SyncPreviewOperation: Identifiable, Equatable {
+    enum Direction: Equatable {
+        /// The device holds a save the server does not have, or a newer one.
+        case upload
+        /// The server holds a save this device does not have, or a newer one.
+        case download
+        /// Both sides changed since the last sync and neither can be preferred.
+        case conflict
+        /// Already in agreement.
+        case noOp
+    }
+
+    let id = UUID()
+    let romId: Int
+    let direction: Direction
+    /// The server's name for the file, which is not the local one: a slotted
+    /// save carries a datetime tag the server applies on upload.
+    let serverFileName: String?
+    let slot: String?
+    let emulator: String?
+    /// The server's own wording for why it planned this, shown as-is rather
+    /// than reworded, so a surprising plan can be traced back to the server.
+    let reason: String?
+    let serverUpdatedAt: Date?
+
+    static func == (lhs: SyncPreviewOperation, rhs: SyncPreviewOperation) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+/// Why a preview could not be produced. Each case is a state the sync screen
+/// has to explain rather than a failure to report as an error.
+enum SyncPreviewError: Error, LocalizedError, Equatable {
+    /// No server configured, or the user is not signed in.
+    case notConnected
+    /// The server predates the sync API (RomM 4.9).
+    case serverTooOld
+    /// Registration was refused, so there is no device to negotiate for.
+    case deviceRegistrationFailed
+    /// Negotiation itself failed.
+    case negotiationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConnected:
+            return String(localized: "Connect to a RomM server to sync saves.")
+        case .serverTooOld:
+            return String(localized: "This server is too old to sync saves. RomM 4.9 or newer is required.")
+        case .deviceRegistrationFailed:
+            return String(localized: "This device could not be registered with the server.")
+        case .negotiationFailed(let message):
+            return message
+        }
+    }
+}

--- a/romm/romm/Domain/RepositoryProtocols/PSaveStore.swift
+++ b/romm/romm/Domain/RepositoryProtocols/PSaveStore.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 protocol PSaveStore {
+    /// Every ROM this store holds something for.
+    ///
+    /// Sync negotiation is server-wide rather than per ROM, so a caller has to
+    /// be able to report the whole local library in one request; every other
+    /// read here needs a ROM id it does not yet know.
+    func listRomIds() throws -> [Int]
+
     func readBattery(romId: Int) throws -> Data?
     func writeBattery(romId: Int, data: Data) throws
     func batteryModifiedAt(romId: Int) -> Date?

--- a/romm/romm/Domain/UseCases/Sync/ScanExternalSavesUseCase.swift
+++ b/romm/romm/Domain/UseCases/Sync/ScanExternalSavesUseCase.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+/// A battery save found in another app's folder, matched to a ROM here.
+struct ExternalSaveFile: Identifiable, Equatable {
+    var id: URL { url }
+    let url: URL
+    let romId: Int
+    let fileName: String
+    let sizeBytes: Int
+    let modifiedAt: Date
+}
+
+/// What one app's folder holds.
+struct ExternalSaveScan: Equatable {
+    let emulator: ExternalEmulatorID
+    let matched: [ExternalSaveFile]
+    /// Files that look like saves but belong to no ROM this device knows.
+    ///
+    /// Counted rather than dropped, because this is the number that says whether
+    /// a scan is working: saves found but unmatched means the folder is right and
+    /// the matching is wrong, while nothing found at all means the folder or the
+    /// path hints are wrong. Those need different fixes.
+    let unmatchedFileNames: [String]
+    /// True when the granted folder resolved but has moved since.
+    let isStale: Bool
+
+    var isEmpty: Bool { matched.isEmpty && unmatchedFileNames.isEmpty }
+}
+
+protocol PScanExternalSavesUseCase {
+    /// Reads one app's granted folder. Returns nil when no folder was granted.
+    func execute(for emulator: ExternalEmulatorID) throws -> ExternalSaveScan?
+    /// Reads every app that has a granted folder.
+    func executeForAllGranted() -> [ExternalSaveScan]
+}
+
+/// Finds the battery saves another emulator app has written.
+///
+/// Read-only, and deliberately so for now: the entitlement is
+/// `user-selected.read-only`, which is enough to offer these saves to the server
+/// but not to write anything back.
+final class ScanExternalSavesUseCase: PScanExternalSavesUseCase {
+
+    private let logger = Logger.emulator
+    private let folderStore: PExternalSaveFolderStore
+    private let localROMs: PLocalROMRepository
+    private let handoffStore: PExternalEmulatorHandoffStore
+    private let fileManager: FileManager
+
+    init(
+        folderStore: PExternalSaveFolderStore,
+        localROMs: PLocalROMRepository,
+        handoffStore: PExternalEmulatorHandoffStore,
+        fileManager: FileManager = .default
+    ) {
+        self.folderStore = folderStore
+        self.localROMs = localROMs
+        self.handoffStore = handoffStore
+        self.fileManager = fileManager
+    }
+
+    func execute(for emulator: ExternalEmulatorID) throws -> ExternalSaveScan? {
+        guard let layout = emulator.emulator.saveLayout,
+              let grant = folderStore.grantedFolder(for: emulator) else { return nil }
+
+        let index = try romIndex(for: emulator, layout: layout)
+
+        return grant.withAccess { root in
+            var matched: [ExternalSaveFile] = []
+            var unmatched: [String] = []
+
+            for url in candidateFiles(under: root, layout: layout) {
+                guard let key = layout.batteryKey(forFileName: url.lastPathComponent) else { continue }
+                if let romId = index[key.lowercased()] {
+                    if let file = saveFile(at: url, romId: romId) {
+                        matched.append(file)
+                    }
+                } else {
+                    unmatched.append(url.lastPathComponent)
+                }
+            }
+
+            logger.info("Scanned \(emulator.rawValue): \(matched.count) matched, \(unmatched.count) unmatched")
+            return ExternalSaveScan(
+                emulator: emulator,
+                matched: matched,
+                unmatchedFileNames: unmatched,
+                isStale: grant.isStale
+            )
+        }
+    }
+
+    func executeForAllGranted() -> [ExternalSaveScan] {
+        folderStore.grantedEmulators().compactMap { try? execute(for: $0) }
+    }
+
+    // MARK: - Private
+
+    /// Maps what a save could be named after back to a ROM id, lowercased so
+    /// matching can ignore case without lowercasing on every comparison.
+    ///
+    /// For an app that names saves after a content hash this only covers ROMs
+    /// whose identifier is already known, which in practice means the ones handed
+    /// to that app at least once. Hashing the whole library to close that gap
+    /// would read every ROM on the device, and a save for a game never opened
+    /// over there cannot exist anyway.
+    private func romIndex(
+        for emulator: ExternalEmulatorID,
+        layout: ExternalSaveLayout
+    ) throws -> [String: Int] {
+        let roms = try localROMs.getAllDownloadedROMs()
+        var index: [String: Int] = [:]
+
+        for rom in roms {
+            switch layout.naming {
+            case .romBaseName:
+                // A multi-file ROM has no single name, so every part is offered:
+                // the target app named the save after whichever one it opened.
+                for file in rom.files {
+                    let base = (file.fileName as NSString).deletingPathExtension
+                    index[base.lowercased()] = rom.id
+                }
+            case .gameIdentifier:
+                let kind = emulator.emulator.identifierKind
+                if let identifier = handoffStore.cachedGameIdentifier(romId: rom.id, kind: kind) {
+                    index[identifier.lowercased()] = rom.id
+                }
+            }
+        }
+        return index
+    }
+
+    /// Files worth looking at, hints first and the whole folder only as a
+    /// fallback, never deeper than the layout allows.
+    private func candidateFiles(under root: URL, layout: ExternalSaveLayout) -> [URL] {
+        for hint in layout.searchHints {
+            let directory = hint.split(separator: "/").reduce(root) {
+                $0.appendingPathComponent(String($1), isDirectory: true)
+            }
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue else { continue }
+            let found = files(under: directory, depth: layout.maxSearchDepth)
+            if !found.isEmpty {
+                logger.debug("Using hint \(hint), \(found.count) candidates")
+                return found
+            }
+        }
+        logger.debug("No hint matched, walking the granted folder")
+        return files(under: root, depth: layout.maxSearchDepth)
+    }
+
+    private func files(under directory: URL, depth: Int) -> [URL] {
+        guard depth > 0 else { return [] }
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        return entries.flatMap { url -> [URL] in
+            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+            return isDirectory ? files(under: url, depth: depth - 1) : [url]
+        }
+    }
+
+    private func saveFile(at url: URL, romId: Int) -> ExternalSaveFile? {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
+        guard let size = values?.fileSize, size > 0 else { return nil }
+        return ExternalSaveFile(
+            url: url,
+            romId: romId,
+            fileName: url.lastPathComponent,
+            sizeBytes: size,
+            modifiedAt: values?.contentModificationDate ?? Date(timeIntervalSince1970: 0)
+        )
+    }
+}

--- a/romm/romm/Domain/UseCases/Sync/SyncPreviewUseCase.swift
+++ b/romm/romm/Domain/UseCases/Sync/SyncPreviewUseCase.swift
@@ -1,0 +1,132 @@
+import CryptoKit
+import Foundation
+
+protocol PSyncPreviewUseCase {
+    /// Asks the server what a sync would do, without changing anything.
+    func execute() async throws -> SyncPreview
+}
+
+/// Reports this device's battery saves to the server and returns the plan it
+/// answers with.
+///
+/// Read-only as far as saves go: negotiation only compares content hashes and
+/// timestamps, and nothing here acts on the result. It does open a sync session
+/// server-side, which is the server's own bookkeeping and touches no save.
+///
+/// Deliberately battery only. Save states are held per slot index and their id
+/// namespace overlaps with saves' over negotiation, which the existing
+/// per-emulator sync works around with a separate path; pulling that in here
+/// would mean reproducing the workaround before the screen shows anything.
+final class SyncPreviewUseCase: PSyncPreviewUseCase {
+
+    private let logger = Logger.sync
+    private let saveStore: PSaveStore
+    private let syncDevice: PSyncDeviceRepository
+    private let apiClient: PRommAPIClient
+    private let tokenProvider: PTokenProvider
+
+    init(
+        saveStore: PSaveStore,
+        syncDevice: PSyncDeviceRepository,
+        apiClient: PRommAPIClient,
+        tokenProvider: PTokenProvider
+    ) {
+        self.saveStore = saveStore
+        self.syncDevice = syncDevice
+        self.apiClient = apiClient
+        self.tokenProvider = tokenProvider
+    }
+
+    func execute() async throws -> SyncPreview {
+        guard tokenProvider.getServerURL() != nil else { throw SyncPreviewError.notConnected }
+        guard syncDevice.isSyncAPISupported else { throw SyncPreviewError.serverTooOld }
+        guard let deviceId = await syncDevice.deviceId() else {
+            throw SyncPreviewError.deviceRegistrationFailed
+        }
+
+        let localSaves = collectBatterySaves()
+        logger.info("Sync preview: reporting \(localSaves.count) battery saves as device \(deviceId)")
+
+        let response: SyncNegotiateResponse
+        do {
+            response = try await apiClient.negotiateSync(
+                SyncNegotiateRequest(deviceId: deviceId, saves: localSaves)
+            )
+        } catch {
+            logger.warning("Sync preview failed: \(error.localizedDescription)")
+            throw SyncPreviewError.negotiationFailed(error.localizedDescription)
+        }
+
+        logger.info("Sync preview: \(response.operations.count) operations "
+            + "(up=\(response.totalUpload ?? 0) down=\(response.totalDownload ?? 0) "
+            + "conflict=\(response.totalConflict ?? 0) noop=\(response.totalNoOp ?? 0))")
+
+        return SyncPreview(
+            deviceId: deviceId,
+            reportedSaveCount: localSaves.count,
+            operations: response.operations.compactMap(Self.previewOperation)
+        )
+    }
+
+    // MARK: - Private
+
+    /// Every battery save on this device, reported under the battery slot.
+    ///
+    /// The slot is what makes these saves pairable at all: the server never
+    /// pairs a save that arrives without one. Uploads still send no slot today,
+    /// so this preview shows what a sync *would* do once they do, which is the
+    /// point of looking before changing it.
+    private func collectBatterySaves() -> [ClientSaveState] {
+        let romIds = (try? saveStore.listRomIds()) ?? []
+        return romIds.compactMap { romId in
+            guard let data = try? saveStore.readBattery(romId: romId), !data.isEmpty else { return nil }
+            return ClientSaveState(
+                romId: romId,
+                fileName: "battery.sav",
+                slot: SaveSlot.battery,
+                // Attribution only; the server does not pair on it, and which
+                // engine last wrote a save is not recorded per ROM.
+                emulator: nil,
+                contentHash: Self.contentHash(data),
+                updatedAt: saveStore.batteryModifiedAt(romId: romId) ?? Date(timeIntervalSince1970: 0),
+                fileSizeBytes: data.count
+            )
+        }
+    }
+
+    /// Drops state operations: this preview reports battery saves only, so an
+    /// operation about a state came from another device and acting on it here
+    /// would misrepresent what syncing from this screen does.
+    private static func previewOperation(_ op: SyncOperationSchema) -> SyncPreviewOperation? {
+        guard let romId = op.romId else { return nil }
+        if op.fileName?.hasSuffix(".state") == true { return nil }
+
+        let direction: SyncPreviewOperation.Direction
+        switch op.action {
+        case .upload: direction = .upload
+        case .download: direction = .download
+        case .conflict: direction = .conflict
+        case .noOp: direction = .noOp
+        // A newer server planned something this build has no name for. Showing
+        // it as one of the four would misstate what syncing does, and this is a
+        // preview the user is asked to approve, so it is left out.
+        case .unknown: return nil
+        }
+
+        return SyncPreviewOperation(
+            romId: romId,
+            direction: direction,
+            serverFileName: op.fileName,
+            slot: op.slot,
+            emulator: op.emulator,
+            reason: op.reason,
+            serverUpdatedAt: op.serverUpdatedAt
+        )
+    }
+
+    /// Matches the hash the rest of the sync path sends, so the server compares
+    /// like with like.
+    private static func contentHash(_ data: Data) -> String {
+        Insecure.MD5.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -120,6 +120,7 @@ protocol PDependencyFactory {
     func makeSyncPreviewUseCase() -> PSyncPreviewUseCase
     func makeScanExternalSavesUseCase() -> PScanExternalSavesUseCase
     var externalSaveFolderStore: PExternalSaveFolderStore { get }
+    var externalEmulatorSetupStore: PExternalEmulatorSetupStore { get }
     func makeBIOSSyncUseCase() -> PBIOSSyncUseCase
     @MainActor func makeCloudSaveSyncService(romId: Int, emulator: String, batteryFileName: String) -> CloudSaveSyncService
     @MainActor func makeLibretroEmulatorViewModel(rom: Rom, core: LibretroCore) -> LibretroEmulatorViewModel
@@ -507,6 +508,7 @@ class DefaultDependencyFactory: PDependencyFactory {
     }
 
     lazy var externalSaveFolderStore: PExternalSaveFolderStore = UserDefaultsExternalSaveFolderStore()
+    lazy var externalEmulatorSetupStore: PExternalEmulatorSetupStore = UserDefaultsExternalEmulatorSetupStore()
 
     func makeScanExternalSavesUseCase() -> PScanExternalSavesUseCase {
         ScanExternalSavesUseCase(

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -118,6 +118,8 @@ protocol PDependencyFactory {
     func makeResolveExternalGameIdentifierUseCase() -> PResolveExternalGameIdentifierUseCase
     func makeEmulatorSaveStatesUseCase() -> PEmulatorSaveStatesUseCase
     func makeSyncPreviewUseCase() -> PSyncPreviewUseCase
+    func makeScanExternalSavesUseCase() -> PScanExternalSavesUseCase
+    var externalSaveFolderStore: PExternalSaveFolderStore { get }
     func makeBIOSSyncUseCase() -> PBIOSSyncUseCase
     @MainActor func makeCloudSaveSyncService(romId: Int, emulator: String, batteryFileName: String) -> CloudSaveSyncService
     @MainActor func makeLibretroEmulatorViewModel(rom: Rom, core: LibretroCore) -> LibretroEmulatorViewModel
@@ -501,6 +503,16 @@ class DefaultDependencyFactory: PDependencyFactory {
             syncDevice: syncDeviceRepository,
             apiClient: apiClient,
             tokenProvider: tokenProvider
+        )
+    }
+
+    lazy var externalSaveFolderStore: PExternalSaveFolderStore = UserDefaultsExternalSaveFolderStore()
+
+    func makeScanExternalSavesUseCase() -> PScanExternalSavesUseCase {
+        ScanExternalSavesUseCase(
+            folderStore: externalSaveFolderStore,
+            localROMs: localROMRepository,
+            handoffStore: externalEmulatorHandoffStore
         )
     }
 

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -117,6 +117,7 @@ protocol PDependencyFactory {
     func makeResolveROMFileUseCase() -> PResolveROMFileUseCase
     func makeResolveExternalGameIdentifierUseCase() -> PResolveExternalGameIdentifierUseCase
     func makeEmulatorSaveStatesUseCase() -> PEmulatorSaveStatesUseCase
+    func makeSyncPreviewUseCase() -> PSyncPreviewUseCase
     func makeBIOSSyncUseCase() -> PBIOSSyncUseCase
     @MainActor func makeCloudSaveSyncService(romId: Int, emulator: String, batteryFileName: String) -> CloudSaveSyncService
     @MainActor func makeLibretroEmulatorViewModel(rom: Rom, core: LibretroCore) -> LibretroEmulatorViewModel
@@ -492,6 +493,15 @@ class DefaultDependencyFactory: PDependencyFactory {
 
     func makeEmulatorSaveStatesUseCase() -> PEmulatorSaveStatesUseCase {
         EmulatorSaveStatesUseCase(saveStore: saveStore)
+    }
+
+    func makeSyncPreviewUseCase() -> PSyncPreviewUseCase {
+        SyncPreviewUseCase(
+            saveStore: saveStore,
+            syncDevice: syncDeviceRepository,
+            apiClient: apiClient,
+            tokenProvider: tokenProvider
+        )
     }
 
     func makeBIOSSyncUseCase() -> PBIOSSyncUseCase {

--- a/romm/romm/UI/Home/HomeView.swift
+++ b/romm/romm/UI/Home/HomeView.swift
@@ -14,6 +14,17 @@ struct HomeView: View {
             .background(Color(.systemGroupedBackground))
             .navigationTitle("Home")
             .toolbar {
+                // Its own button for now. The plan is a menu on the user name
+                // that gathers this and settings, which needs the account UI
+                // from issue #98 first.
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    NavigationLink {
+                        SyncOverviewView()
+                    } label: {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                    }
+                    .accessibilityLabel("Save Sync")
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink {
                         SettingsView()

--- a/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
+++ b/romm/romm/UI/Settings/EmulatorEngineSettingsView.swift
@@ -33,6 +33,11 @@ struct EmulatorEngineSettingsView: View {
     @State private var swapFaceButtons: Bool
     @State private var rumbleEnabled: Bool
     @State private var installedEmulators: [ExternalEmulatorID] = []
+    /// Apps the user has been through the assistant for. Only these are offered
+    /// as a Play target, so picking one can rely on it being set up.
+    @State private var configuredEmulators: [ExternalEmulatorID] = []
+    @State private var isAddingEmulator = false
+    private let setupStore: PExternalEmulatorSetupStore
     private let preference: PEmulatorEnginePreference
     private let menuShortcutPreference: PEmulatorMenuShortcutPreference
     private let faceButtonPreference: PGamepadFaceButtonPreference
@@ -59,6 +64,7 @@ struct EmulatorEngineSettingsView: View {
         self.rumblePreference = factory.rumblePreference
         self.playTargetPreference = factory.playTargetPreference
         self.externalAppLauncher = factory.externalAppLauncher
+        self.setupStore = factory.externalEmulatorSetupStore
         _menuShortcut = State(wrappedValue: factory.emulatorMenuShortcutPreference.current)
         _swapFaceButtons = State(wrappedValue: factory.gamepadFaceButtonPreference.isSwapped)
         _rumbleEnabled = State(wrappedValue: factory.rumblePreference.isEnabled)
@@ -125,6 +131,14 @@ struct EmulatorEngineSettingsView: View {
         .onChange(of: swapFaceButtons) { _, new in faceButtonPreference.isSwapped = new }
         .onChange(of: rumbleEnabled) { _, new in rumblePreference.isEnabled = new }
         .onChange(of: playChoice) { _, new in apply(new) }
+        .sheet(isPresented: $isAddingEmulator) {
+            ExternalEmulatorSetupView {
+                // The assistant makes the app it added the Play target, so this
+                // screen has to re-read both or it would show the old choice.
+                refreshInstalledEmulators()
+                playChoice = PlayChoice(engine: preference.current, target: playTargetPreference.current)
+            }
+        }
     }
 
     /// One list for where a game runs, built-in engines first, then the apps a
@@ -145,6 +159,17 @@ struct EmulatorEngineSettingsView: View {
                     Text("Play with")
                     Spacer()
                     Text(label(for: playChoice)).foregroundStyle(.secondary)
+                }
+            }
+
+            // Adding is its own row rather than more entries in the picker:
+            // an app has to be set up before it can be played to, and a picker
+            // entry would let it be chosen before any of that happened.
+            if !ExternalEmulatorID.allCases.allSatisfy(configuredEmulators.contains) {
+                Button {
+                    isAddingEmulator = true
+                } label: {
+                    Label("Add an emulator app", systemImage: "plus")
                 }
             }
         }
@@ -185,13 +210,17 @@ struct EmulatorEngineSettingsView: View {
         }
     }
 
-    /// Installed apps, plus whatever is currently selected so an uninstalled
-    /// choice does not silently disappear from the picker.
+    /// Apps that have been set up, plus whatever is currently selected so a
+    /// choice does not silently disappear from the picker after an uninstall.
+    ///
+    /// Being installed is no longer enough to appear here: an app reaches this
+    /// list by going through the assistant, which is what makes it safe to
+    /// assume the user knows how a game gets there.
     private var pickableEmulators: [ExternalEmulatorID] {
-        guard case .external(let selected) = playChoice, !installedEmulators.contains(selected) else {
-            return installedEmulators
+        guard case .external(let selected) = playChoice, !configuredEmulators.contains(selected) else {
+            return configuredEmulators
         }
-        return installedEmulators + [selected]
+        return configuredEmulators + [selected]
     }
 
     /// Every app Play can hand a ROM to, for the "nothing installed yet" hint.
@@ -203,6 +232,7 @@ struct EmulatorEngineSettingsView: View {
 
     private func refreshInstalledEmulators() {
         installedEmulators = ExternalEmulatorID.allCases.filter { externalAppLauncher.isInstalled($0.emulator) }
+        configuredEmulators = setupStore.configuredEmulators()
     }
 
     #if DEBUG

--- a/romm/romm/UI/Settings/ExternalEmulatorSetup/ExternalEmulatorSetupView.swift
+++ b/romm/romm/UI/Settings/ExternalEmulatorSetup/ExternalEmulatorSetupView.swift
@@ -1,0 +1,298 @@
+import SwiftUI
+
+/// Walks the user through adding an emulator app: install it, understand how a
+/// game gets there, point at its saves, then hand one over for real.
+///
+/// It exists because picking an app used to be a one-tap setting that left three
+/// things unsaid. The worst of them was Manic, which cannot take a game from the
+/// share sheet at all, so Play looked broken until you knew to paste.
+struct ExternalEmulatorSetupView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
+
+    @State private var viewModel = ExternalEmulatorSetupViewModel()
+    @State private var externalPlay = ExternalPlayCoordinator()
+    @State private var isPickingFolder = false
+
+    /// Called when an app was added, so the settings list can refresh.
+    let onFinished: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch viewModel.stage {
+                case .choosingApp: appChoiceList
+                case .step(let step): stepContent(step)
+                case .finished: finishedContent
+                }
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .fileImporter(
+                isPresented: $isPickingFolder,
+                allowedContentTypes: [.folder]
+            ) { result in
+                if case .success(let url) = result { viewModel.grantFolder(url) }
+            }
+            .externalPlayHandoff(externalPlay)
+        }
+        // Coming back from the App Store is the only way the install step ends,
+        // and nothing tells us it happened, so it is re-checked on return.
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active { viewModel.refreshInstallState() }
+        }
+    }
+
+    private var navigationTitle: String {
+        guard let emulator = viewModel.emulator else { return String(localized: "Add Emulator") }
+        return emulator.emulator.displayName
+    }
+
+    // MARK: - Choosing
+
+    private var appChoiceList: some View {
+        List {
+            Section {
+                ForEach(viewModel.addableEmulators, id: \.self) { emulator in
+                    Button {
+                        viewModel.choose(emulator)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "gamecontroller")
+                                .foregroundStyle(Color.accentColor)
+                                .frame(width: 24)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(emulator.emulator.displayName)
+                                    .foregroundStyle(Color.primary)
+                                if !viewModel.isInstalled(emulator) {
+                                    Text("Not installed")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                }
+            } header: {
+                Text("Which app")
+            } footer: {
+                Text("Games are handed to the app you pick. Its saves can be synced back to RomM.")
+            }
+
+            if viewModel.addableEmulators.isEmpty {
+                Section {
+                    Text("Every supported app has already been added.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Steps
+
+    @ViewBuilder
+    private func stepContent(_ step: ExternalEmulatorSetupStep) -> some View {
+        VStack(spacing: 0) {
+            List {
+                switch step {
+                case .install: installStep
+                case .handoff: handoffStep
+                case .saveFolder: saveFolderStep
+                case .testRun: testRunStep
+                }
+            }
+            stepFooter(step)
+        }
+    }
+
+    private var installStep: some View {
+        Section {
+            explanation(
+                icon: "arrow.down.app",
+                text: String(localized: "\(navigationTitle) is not on this device yet. Install it, then come back here.")
+            )
+            Button("Open the App Store") { viewModel.openAppStore() }
+        } header: {
+            Text(ExternalEmulatorSetupStep.install.title)
+        } footer: {
+            Text("This step finishes by itself once the app is installed.")
+        }
+    }
+
+    private var handoffStep: some View {
+        Section {
+            explanation(
+                icon: "square.and.arrow.up",
+                text: viewModel.emulator?.emulator.handoffExplanation ?? ""
+            )
+        } header: {
+            Text(ExternalEmulatorSetupStep.handoff.title)
+        }
+    }
+
+    private var saveFolderStep: some View {
+        Section {
+            explanation(
+                icon: "folder",
+                text: String(localized: "Pick this app's folder in Files so its saves can be read. Nothing is written to it.")
+            )
+            Button("Choose Folder…") { isPickingFolder = true }
+            if let scan = viewModel.folderScan {
+                scanResult(scan)
+            }
+        } header: {
+            Text(ExternalEmulatorSetupStep.saveFolder.title)
+        } footer: {
+            Text("You can do this later from the sync screen.")
+        }
+    }
+
+    private func scanResult(_ scan: ExternalSaveScan) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: scan.matched.isEmpty ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                .foregroundStyle(scan.matched.isEmpty ? Color.orange : Color.green)
+            if scan.matched.isEmpty {
+                // Saying which of the two went wrong, because they need
+                // opposite fixes: a wrong folder versus saves for games that
+                // are not on this device.
+                Text(scan.isEmpty
+                     ? String(localized: "No saves in that folder. It may be the wrong one.")
+                     : String(localized: "\(scan.unmatchedFileNames.count) saves found, but none for games you have here."))
+            } else {
+                Text("Found \(scan.matched.count) saves for games you have.")
+            }
+        }
+        .font(.callout)
+    }
+
+    private var testRunStep: some View {
+        Section {
+            explanation(
+                icon: "play.circle",
+                text: String(localized: "Hand a game over once to see it work. Nothing is changed on the server.")
+            )
+            if let result = viewModel.testResult {
+                testResultRow(result)
+            }
+            if viewModel.testableROMs.isEmpty {
+                Text("Download a game first to try this.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(viewModel.testableROMs.prefix(8)) { rom in
+                    Button(rom.name) { testHandoff(rom) }
+                }
+            }
+        } header: {
+            Text(ExternalEmulatorSetupStep.testRun.title)
+        }
+    }
+
+    private func testResultRow(_ result: ExternalEmulatorSetupViewModel.TestResult) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            switch result {
+            case .handedOver(let name):
+                Image(systemName: "checkmark.circle.fill").foregroundStyle(Color.green)
+                Text("\(name) was handed over.")
+            case .failed(let message):
+                Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(Color.orange)
+                Text(message)
+            }
+        }
+        .font(.callout)
+    }
+
+    private func testHandoff(_ rom: DownloadedROM) {
+        Task {
+            // The target is not the saved one yet, since setup has not finished,
+            // so the coordinator is pointed at the app being set up.
+            guard let emulator = viewModel.emulator else { return }
+            externalPlay.overrideTarget(.external(emulator))
+            let handled = await externalPlay.play(romId: rom.id)
+            if let error = externalPlay.errorMessage {
+                viewModel.recordTestResult(.failed(error))
+                externalPlay.errorMessage = nil
+            } else if handled {
+                viewModel.recordTestResult(.handedOver(romName: rom.name))
+            }
+        }
+    }
+
+    // MARK: - Finishing
+
+    private var finishedContent: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 52))
+                .foregroundStyle(Color.green)
+            Text("\(navigationTitle) is ready")
+                .font(.title3.weight(.semibold))
+            Text("Play now opens games there.")
+                .foregroundStyle(.secondary)
+            Button("Done") {
+                onFinished()
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.top, 8)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Shared pieces
+
+    private func explanation(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 24)
+            Text(text)
+        }
+    }
+
+    private func stepFooter(_ step: ExternalEmulatorSetupStep) -> some View {
+        HStack(spacing: 12) {
+            // Where the user is, because four steps without a count feel
+            // open-ended, and the install step can drop out so the total is
+            // not something they can assume.
+            if let position = stepPosition(step) {
+                Text("Step \(position.current) of \(position.total)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Spacer()
+            if step.isSkippable {
+                Button("Skip") { viewModel.skipCurrentStep() }
+            }
+            Button(isLastStep(step) ? "Finish" : "Continue") { viewModel.advance() }
+                .buttonStyle(.borderedProminent)
+                .disabled(step == .install && !isInstalledNow)
+        }
+        .padding()
+        .background(.bar)
+    }
+
+    private func stepPosition(_ step: ExternalEmulatorSetupStep) -> (current: Int, total: Int)? {
+        guard let steps = viewModel.plan?.steps, let index = steps.firstIndex(of: step) else { return nil }
+        return (index + 1, steps.count)
+    }
+
+    private var isInstalledNow: Bool {
+        guard let emulator = viewModel.emulator else { return false }
+        return viewModel.isInstalled(emulator)
+    }
+
+    private func isLastStep(_ step: ExternalEmulatorSetupStep) -> Bool {
+        viewModel.plan?.steps.last == step
+    }
+}

--- a/romm/romm/UI/Settings/ExternalEmulatorSetup/ExternalEmulatorSetupViewModel.swift
+++ b/romm/romm/UI/Settings/ExternalEmulatorSetup/ExternalEmulatorSetupViewModel.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+@Observable
+@MainActor
+final class ExternalEmulatorSetupViewModel {
+
+    /// Where the assistant currently is.
+    enum Stage: Equatable {
+        /// Nothing picked yet, the list of apps is showing.
+        case choosingApp
+        /// Working through the steps for the picked app.
+        case step(ExternalEmulatorSetupStep)
+        case finished
+    }
+
+    private(set) var stage: Stage = .choosingApp
+    private(set) var emulator: ExternalEmulatorID?
+    private(set) var plan: ExternalEmulatorSetupPlan?
+    private(set) var completedSteps: Set<ExternalEmulatorSetupStep> = []
+
+    /// What the folder step found, so the user gets an answer rather than a
+    /// silent dismissal.
+    private(set) var folderScan: ExternalSaveScan?
+    /// ROMs offered for the test run.
+    private(set) var testableROMs: [DownloadedROM] = []
+    private(set) var testResult: TestResult?
+
+    var errorMessage: String?
+
+    enum TestResult: Equatable {
+        case handedOver(romName: String)
+        case failed(String)
+    }
+
+    private let launcher: PExternalAppLauncher
+    private let folderStore: PExternalSaveFolderStore
+    private let setupStore: PExternalEmulatorSetupStore
+    private let scanUseCase: PScanExternalSavesUseCase
+    private let localROMs: PLocalROMRepository
+    private let playTargetPreference: PPlayTargetPreference
+
+    init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
+        self.launcher = factory.externalAppLauncher
+        self.folderStore = factory.externalSaveFolderStore
+        self.setupStore = factory.externalEmulatorSetupStore
+        self.scanUseCase = factory.makeScanExternalSavesUseCase()
+        self.localROMs = factory.localROMRepository
+        self.playTargetPreference = factory.playTargetPreference
+    }
+
+    /// Apps that can still be added, so an already configured one is not offered
+    /// twice.
+    var addableEmulators: [ExternalEmulatorID] {
+        ExternalEmulatorID.allCases.filter { !setupStore.isConfigured($0) }
+    }
+
+    func isInstalled(_ emulator: ExternalEmulatorID) -> Bool {
+        launcher.isInstalled(emulator.emulator)
+    }
+
+    // MARK: - Flow
+
+    func choose(_ emulator: ExternalEmulatorID) {
+        self.emulator = emulator
+        let plan = ExternalEmulatorSetupPlan(
+            emulator: emulator,
+            isInstalled: isInstalled(emulator),
+            hasSaveFolder: folderStore.grantedFolder(for: emulator) != nil
+        )
+        self.plan = plan
+        completedSteps = []
+        stage = plan.steps.first.map { .step($0) } ?? .finished
+    }
+
+    /// Re-checks installation, for coming back from the App Store.
+    func refreshInstallState() {
+        guard let emulator, case .step(.install) = stage, isInstalled(emulator) else { return }
+        advance()
+    }
+
+    func advance() {
+        guard let plan, case .step(let current) = stage else { return }
+        completedSteps.insert(current)
+        guard let index = plan.steps.firstIndex(of: current),
+              plan.steps.indices.contains(index + 1) else {
+            finish()
+            return
+        }
+        stage = .step(plan.steps[index + 1])
+        if case .testRun = plan.steps[index + 1] { loadTestableROMs() }
+    }
+
+    func skipCurrentStep() {
+        guard case .step(let current) = stage, current.isSkippable else { return }
+        advance()
+    }
+
+    /// Marks the app as set up and makes it the Play target, which is what the
+    /// user came here to do.
+    private func finish() {
+        if let emulator {
+            setupStore.markConfigured(emulator)
+            playTargetPreference.current = .external(emulator)
+        }
+        stage = .finished
+    }
+
+    // MARK: - Steps
+
+    func openAppStore() {
+        // Nothing here can install an app; this only gets the user to where they
+        // can, and `refreshInstallState` picks it up when they come back.
+        guard let emulator, let url = emulator.emulator.probeURL else { return }
+        Task { _ = await launcher.open(emulator.emulator) }
+        _ = url
+    }
+
+    func grantFolder(_ url: URL) {
+        guard let emulator else { return }
+        do {
+            try folderStore.remember(folderURL: url, for: emulator)
+            folderScan = try? scanUseCase.execute(for: emulator)
+        } catch {
+            errorMessage = String(
+                localized: "Could not keep access to that folder: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func loadTestableROMs() {
+        // Only downloaded ROMs can be handed over, and the list is capped
+        // because this is a confidence check, not a library browser.
+        testableROMs = Array(((try? localROMs.getAllDownloadedROMs()) ?? []).prefix(30))
+    }
+
+    /// Records how the test run went. The handoff itself is driven by the shared
+    /// coordinator, which owns the presentation it needs.
+    func recordTestResult(_ result: TestResult) {
+        testResult = result
+    }
+}

--- a/romm/romm/UI/Shared/ExternalPlay/ExternalPlayCoordinator.swift
+++ b/romm/romm/UI/Shared/ExternalPlay/ExternalPlayCoordinator.swift
@@ -77,6 +77,15 @@ final class ExternalPlayCoordinator {
         playTarget = playTargetPreference.current
     }
 
+    /// Points this coordinator at a target without changing the user's setting.
+    ///
+    /// For the setup assistant's test run: it hands a ROM to the app being set
+    /// up, which is deliberately not the saved target yet, since the user has
+    /// not finished deciding.
+    func overrideTarget(_ target: PlayTarget) {
+        playTarget = target
+    }
+
     /// Routes a Play tap to the configured external emulator.
     ///
     /// - Returns: false when the built-in emulator should take over instead, so a

--- a/romm/romm/UI/Sync/SyncOverviewView.swift
+++ b/romm/romm/UI/Sync/SyncOverviewView.swift
@@ -7,7 +7,20 @@ import SwiftUI
 /// of games cannot show. Only two sources exist so far, this device and the
 /// server; external emulator apps are meant to join them as further rows.
 struct SyncOverviewView: View {
-    @State private var viewModel = SyncOverviewViewModel()
+    @State private var viewModel: SyncOverviewViewModel
+
+    init() {
+        _viewModel = State(initialValue: SyncOverviewViewModel())
+    }
+
+    /// Takes a view model that is already in the state to show, for previews.
+    ///
+    /// Separate from `init()` rather than a defaulted parameter: a default
+    /// argument is evaluated in a nonisolated context, which the main-actor
+    /// view model cannot be built from.
+    init(viewModel: SyncOverviewViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
 
     var body: some View {
         Form {
@@ -133,11 +146,10 @@ struct SyncOverviewView: View {
             Image(systemName: direction.icon)
                 .foregroundStyle(direction.tint)
                 .frame(width: 24)
+            // The count is in the label already; repeating it on the right made
+            // the row read "Upload 1 save … 1".
             Text(direction.summary(count: count))
             Spacer()
-            Text("\(count)")
-                .foregroundStyle(.secondary)
-                .monospacedDigit()
         }
     }
 
@@ -173,6 +185,92 @@ struct SyncOverviewView: View {
                     .foregroundStyle(.secondary)
             }
         }
+    }
+}
+
+// MARK: - Previews
+
+// Each of these needs a server in a particular state to reach for real, which
+// is why the screen is otherwise only ever seen empty or broken.
+
+private func previewOperation(
+    _ direction: SyncPreviewOperation.Direction,
+    romId: Int,
+    reason: String
+) -> SyncPreviewOperation {
+    SyncPreviewOperation(
+        romId: romId,
+        direction: direction,
+        serverFileName: "Game [2026-09-04_22-01-15].sav",
+        slot: SaveSlot.battery,
+        emulator: "mgba",
+        reason: reason,
+        serverUpdatedAt: Date(timeIntervalSince1970: 1_788_000_000)
+    )
+}
+
+private let previewNames = [
+    1: "The Legend of Zelda: The Minish Cap",
+    2: "Pokémon Emerald",
+    3: "Metroid Fusion",
+    4: "Golden Sun"
+]
+
+#Preview("Changes pending") {
+    NavigationStack {
+        SyncOverviewView(viewModel: SyncOverviewViewModel(
+            showing: .loaded(SyncPreview(
+                deviceId: "75018cac-3f2e-4a91-b7d2-19c4e8f0a1bb",
+                reportedSaveCount: 4,
+                operations: [
+                    previewOperation(.upload, romId: 1, reason: "Save exists on client but not on server"),
+                    previewOperation(.download, romId: 2, reason: "Server save is newer (no sync history)"),
+                    previewOperation(.conflict, romId: 3, reason: "Both changed since the last sync")
+                ]
+            )),
+            romNames: previewNames
+        ))
+    }
+}
+
+#Preview("Up to date") {
+    NavigationStack {
+        SyncOverviewView(viewModel: SyncOverviewViewModel(
+            showing: .loaded(SyncPreview(
+                deviceId: "75018cac-3f2e-4a91-b7d2-19c4e8f0a1bb",
+                reportedSaveCount: 4,
+                operations: []
+            )),
+            romNames: previewNames
+        ))
+    }
+}
+
+/// The row a user is least likely to recognise: a save pushed by another
+/// device, for a ROM this one has never downloaded.
+#Preview("Unknown ROM") {
+    NavigationStack {
+        SyncOverviewView(viewModel: SyncOverviewViewModel(
+            showing: .loaded(SyncPreview(
+                deviceId: "75018cac-3f2e-4a91-b7d2-19c4e8f0a1bb",
+                reportedSaveCount: 0,
+                operations: [
+                    previewOperation(.download, romId: 4711, reason: "Save exists on server but not on client")
+                ]
+            ))
+        ))
+    }
+}
+
+#Preview("Server too old") {
+    NavigationStack {
+        SyncOverviewView(viewModel: SyncOverviewViewModel(showing: .failed(.serverTooOld)))
+    }
+}
+
+#Preview("Loading") {
+    NavigationStack {
+        SyncOverviewView(viewModel: SyncOverviewViewModel(showing: .loading))
     }
 }
 

--- a/romm/romm/UI/Sync/SyncOverviewView.swift
+++ b/romm/romm/UI/Sync/SyncOverviewView.swift
@@ -22,20 +22,55 @@ struct SyncOverviewView: View {
         _viewModel = State(initialValue: viewModel)
     }
 
+    /// Which app the folder picker was opened for. The picker reports only the
+    /// URL, so the app has to be remembered across it.
+    @State private var pickingFolderFor: ExternalEmulatorID?
+
     var body: some View {
         Form {
+            // The sources come first and stay put whatever the server says: a
+            // granted folder is on this device and is readable regardless, so
+            // hiding it behind a failed request would have it the wrong way
+            // round.
+            sourcesSection
+            externalAppsSection
+
             switch viewModel.state {
             case .idle, .loading:
                 loadingSection
             case .failed(let error):
                 failureSection(error)
             case .loaded(let preview):
-                sourcesSection(preview)
                 plannedSection(preview)
                 if !preview.isUpToDate {
                     operationsSection(preview)
                 }
             }
+        }
+        .fileImporter(
+            isPresented: Binding(
+                get: { pickingFolderFor != nil },
+                set: { if !$0 { pickingFolderFor = nil } }
+            ),
+            allowedContentTypes: [.folder]
+        ) { result in
+            guard let emulator = pickingFolderFor else { return }
+            pickingFolderFor = nil
+            if case .success(let url) = result {
+                viewModel.grantFolder(url, for: emulator)
+            }
+        }
+        .alert(
+            "Folder",
+            isPresented: Binding(
+                get: { viewModel.folderError != nil },
+                set: { if !$0 { viewModel.folderError = nil } }
+            ),
+            presenting: viewModel.folderError
+        ) { _ in
+            Button("OK", role: .cancel) { viewModel.folderError = nil }
+        } message: { message in
+            Text(message)
         }
         .navigationTitle("Save Sync")
         .navigationBarTitleDisplayMode(.inline)
@@ -80,25 +115,111 @@ struct SyncOverviewView: View {
         }
     }
 
-    private func sourcesSection(_ preview: SyncPreview) -> some View {
+    private var sourcesSection: some View {
         Section {
             sourceRow(
                 icon: "iphone",
                 title: String(localized: "This Device"),
-                detail: preview.reportedSaveCount == 1
-                    ? String(localized: "1 battery save")
-                    : String(localized: "\(preview.reportedSaveCount) battery saves")
+                detail: loadedPreview.map { preview in
+                    preview.reportedSaveCount == 1
+                        ? String(localized: "1 battery save")
+                        : String(localized: "\(preview.reportedSaveCount) battery saves")
+                } ?? "…"
             )
             sourceRow(
                 icon: "server.rack",
                 title: String(localized: "RomM Server"),
-                detail: String(localized: "Connected")
+                detail: serverStatus
             )
         } header: {
             Text("Sources")
         } footer: {
-            Text("Registered as device \(preview.deviceId).")
-                .font(.caption2)
+            if let deviceId = loadedPreview?.deviceId {
+                Text("Registered as device \(deviceId).")
+                    .font(.caption2)
+            }
+        }
+    }
+
+    /// One row per emulator app, whether or not a folder was granted, so the
+    /// ones that could be connected are discoverable rather than hidden behind
+    /// having already connected them.
+    private var externalAppsSection: some View {
+        Section {
+            ForEach(viewModel.externalSources, id: \.self) { emulator in
+                externalAppRow(emulator)
+            }
+        } header: {
+            Text("Emulator Apps")
+        } footer: {
+            Text("Saves made in these apps are read from a folder you pick in Files. "
+                + "Nothing is written to them.")
+        }
+    }
+
+    private func externalAppRow(_ emulator: ExternalEmulatorID) -> some View {
+        let scan = viewModel.externalScans[emulator]
+        return HStack(spacing: 12) {
+            Image(systemName: "gamecontroller")
+                .foregroundStyle(scan == nil ? Color.secondary : Color.accentColor)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(emulator.emulator.displayName)
+                if let scan {
+                    Text(scanSummary(scan))
+                        .font(.caption)
+                        .foregroundStyle(scan.matched.isEmpty ? Color.orange : Color.secondary)
+                }
+            }
+            Spacer()
+            if scan == nil {
+                Button("Choose Folder…") { pickingFolderFor = emulator }
+                    .font(.callout)
+            } else {
+                Menu {
+                    Button("Choose a Different Folder…") { pickingFolderFor = emulator }
+                    Button("Disconnect", role: .destructive) {
+                        viewModel.revokeFolder(for: emulator)
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
+    }
+
+    /// Says what was found, and says it differently when nothing matched.
+    ///
+    /// "Found 12 files but matched none" and "found nothing at all" call for
+    /// different fixes, the first pointing at the matching and the second at the
+    /// folder, so they must not read the same.
+    private func scanSummary(_ scan: ExternalSaveScan) -> String {
+        if scan.isStale {
+            return String(localized: "Folder moved, pick it again")
+        }
+        if scan.isEmpty {
+            return String(localized: "No saves found in this folder")
+        }
+        if scan.matched.isEmpty {
+            return String(localized: "\(scan.unmatchedFileNames.count) saves found, none for games you have")
+        }
+        let found = scan.matched.count == 1
+            ? String(localized: "1 save")
+            : String(localized: "\(scan.matched.count) saves")
+        guard !scan.unmatchedFileNames.isEmpty else { return found }
+        return String(localized: "\(found), \(scan.unmatchedFileNames.count) unrecognised")
+    }
+
+    private var loadedPreview: SyncPreview? {
+        if case .loaded(let preview) = viewModel.state { return preview }
+        return nil
+    }
+
+    private var serverStatus: String {
+        switch viewModel.state {
+        case .loaded: return String(localized: "Connected")
+        case .failed: return String(localized: "Unavailable")
+        case .idle, .loading: return "…"
         }
     }
 
@@ -124,8 +245,14 @@ struct SyncOverviewView: View {
                     Text("Everything is up to date.")
                 }
             } else {
-                countRow(.upload, count: preview.uploads.count)
-                countRow(.download, count: preview.downloads.count)
+                // Only directions that would actually happen. A standing
+                // "Download 0 saves" reads as a thing the sync does.
+                if !preview.uploads.isEmpty {
+                    countRow(.upload, count: preview.uploads.count)
+                }
+                if !preview.downloads.isEmpty {
+                    countRow(.download, count: preview.downloads.count)
+                }
                 if !preview.conflicts.isEmpty {
                     countRow(.conflict, count: preview.conflicts.count)
                 }

--- a/romm/romm/UI/Sync/SyncOverviewView.swift
+++ b/romm/romm/UI/Sync/SyncOverviewView.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+/// Shows what syncing saves would do, without doing any of it.
+///
+/// Grouped by source rather than by game, because the question this screen
+/// answers is "where do my saves live and do those places agree", which a list
+/// of games cannot show. Only two sources exist so far, this device and the
+/// server; external emulator apps are meant to join them as further rows.
+struct SyncOverviewView: View {
+    @State private var viewModel = SyncOverviewViewModel()
+
+    var body: some View {
+        Form {
+            switch viewModel.state {
+            case .idle, .loading:
+                loadingSection
+            case .failed(let error):
+                failureSection(error)
+            case .loaded(let preview):
+                sourcesSection(preview)
+                plannedSection(preview)
+                if !preview.isUpToDate {
+                    operationsSection(preview)
+                }
+            }
+        }
+        .navigationTitle("Save Sync")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    Task { await viewModel.load() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .disabled(viewModel.isLoading)
+            }
+        }
+        .task {
+            if case .idle = viewModel.state {
+                await viewModel.load()
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var loadingSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                ProgressView()
+                Text("Asking the server what would change…")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func failureSection(_ error: SyncPreviewError) -> some View {
+        Section {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text(error.localizedDescription)
+            }
+        } header: {
+            Text("Not Available")
+        }
+    }
+
+    private func sourcesSection(_ preview: SyncPreview) -> some View {
+        Section {
+            sourceRow(
+                icon: "iphone",
+                title: String(localized: "This Device"),
+                detail: preview.reportedSaveCount == 1
+                    ? String(localized: "1 battery save")
+                    : String(localized: "\(preview.reportedSaveCount) battery saves")
+            )
+            sourceRow(
+                icon: "server.rack",
+                title: String(localized: "RomM Server"),
+                detail: String(localized: "Connected")
+            )
+        } header: {
+            Text("Sources")
+        } footer: {
+            Text("Registered as device \(preview.deviceId).")
+                .font(.caption2)
+        }
+    }
+
+    private func sourceRow(icon: String, title: String, detail: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(.tint)
+                .frame(width: 24)
+            Text(title)
+            Spacer()
+            Text(detail)
+                .foregroundStyle(.secondary)
+                .font(.callout)
+        }
+    }
+
+    private func plannedSection(_ preview: SyncPreview) -> some View {
+        Section {
+            if preview.isUpToDate {
+                HStack(spacing: 12) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text("Everything is up to date.")
+                }
+            } else {
+                countRow(.upload, count: preview.uploads.count)
+                countRow(.download, count: preview.downloads.count)
+                if !preview.conflicts.isEmpty {
+                    countRow(.conflict, count: preview.conflicts.count)
+                }
+            }
+        } header: {
+            Text("A Sync Would")
+        } footer: {
+            // Said plainly because the screen otherwise reads like it is syncing,
+            // and because uploads still send no slot, so this is a preview of a
+            // change that has not been made yet.
+            Text("Nothing has been changed. This is what a sync would do once "
+                + "saves are uploaded under a slot.")
+        }
+    }
+
+    private func countRow(_ direction: SyncPreviewOperation.Direction, count: Int) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: direction.icon)
+                .foregroundStyle(direction.tint)
+                .frame(width: 24)
+            Text(direction.summary(count: count))
+            Spacer()
+            Text("\(count)")
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    private func operationsSection(_ preview: SyncPreview) -> some View {
+        Section {
+            // Conflicts first: they are the only rows that cannot be resolved by
+            // letting the sync run, so they must not be buried under the rest.
+            ForEach(preview.conflicts + preview.uploads + preview.downloads) { operation in
+                operationRow(operation)
+            }
+        } header: {
+            Text("Changes")
+        }
+    }
+
+    private func operationRow(_ operation: SyncPreviewOperation) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: operation.direction.icon)
+                .foregroundStyle(operation.direction.tint)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(viewModel.displayName(forRom: operation.romId))
+                if let reason = operation.reason {
+                    Text(reason)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            if let updatedAt = operation.serverUpdatedAt {
+                Text(updatedAt, style: .date)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private extension SyncPreviewOperation.Direction {
+    var icon: String {
+        switch self {
+        case .upload: return "arrow.up.circle.fill"
+        case .download: return "arrow.down.circle.fill"
+        case .conflict: return "exclamationmark.triangle.fill"
+        case .noOp: return "equal.circle.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .upload: return .blue
+        case .download: return .green
+        case .conflict: return .orange
+        case .noOp: return .secondary
+        }
+    }
+
+    func summary(count: Int) -> String {
+        switch self {
+        case .upload:
+            return count == 1
+                ? String(localized: "Upload 1 save")
+                : String(localized: "Upload \(count) saves")
+        case .download:
+            return count == 1
+                ? String(localized: "Download 1 save")
+                : String(localized: "Download \(count) saves")
+        case .conflict:
+            return count == 1
+                ? String(localized: "1 conflict to resolve")
+                : String(localized: "\(count) conflicts to resolve")
+        case .noOp:
+            return String(localized: "Already in sync")
+        }
+    }
+}

--- a/romm/romm/UI/Sync/SyncOverviewView.swift
+++ b/romm/romm/UI/Sync/SyncOverviewView.swift
@@ -180,9 +180,17 @@ struct SyncOverviewView: View {
             }
             Spacer()
             if let updatedAt = operation.serverUpdatedAt {
-                Text(updatedAt, style: .date)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                // Over two lines, and with the time: which of two saves is
+                // newer is the whole question here, and saves synced on the
+                // same day are indistinguishable by date alone. One line
+                // carrying both would crowd out the game's name.
+                VStack(alignment: .trailing, spacing: 1) {
+                    Text(updatedAt, format: .dateTime.day().month(.abbreviated).year())
+                    Text(updatedAt, format: .dateTime.hour().minute())
+                }
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .fixedSize()
             }
         }
     }

--- a/romm/romm/UI/Sync/SyncOverviewViewModel.swift
+++ b/romm/romm/UI/Sync/SyncOverviewViewModel.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+@Observable
+@MainActor
+final class SyncOverviewViewModel {
+
+    enum State {
+        case idle
+        case loading
+        case loaded(SyncPreview)
+        case failed(SyncPreviewError)
+    }
+
+    private(set) var state: State = .idle
+
+    /// Names for the ROMs an operation refers to, resolved from what this device
+    /// has downloaded. A plan that reads "ROM 4711" tells the user nothing, and
+    /// asking the server for each name would put a round trip per row between
+    /// the tap and the answer.
+    private(set) var romNames: [Int: String] = [:]
+
+    private let previewUseCase: PSyncPreviewUseCase
+    private let getDownloadedROM: PGetDownloadedROMUseCase
+
+    init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
+        self.previewUseCase = factory.makeSyncPreviewUseCase()
+        self.getDownloadedROM = factory.makeGetDownloadedROMUseCase()
+    }
+
+    var isLoading: Bool {
+        if case .loading = state { return true }
+        return false
+    }
+
+    func load() async {
+        state = .loading
+        do {
+            let preview = try await previewUseCase.execute()
+            romNames = resolveNames(for: preview)
+            state = .loaded(preview)
+        } catch let error as SyncPreviewError {
+            state = .failed(error)
+        } catch {
+            state = .failed(.negotiationFailed(error.localizedDescription))
+        }
+    }
+
+    /// The name to show for a ROM, falling back to its id when this device has
+    /// never downloaded it. That happens for a save another device pushed, which
+    /// is exactly the row a user is least likely to recognise, so the id is
+    /// spelled out rather than left blank.
+    func displayName(forRom romId: Int) -> String {
+        romNames[romId] ?? String(localized: "ROM \(romId)")
+    }
+
+    private func resolveNames(for preview: SyncPreview) -> [Int: String] {
+        let romIds = Set(preview.operations.map { $0.romId })
+        return romIds.reduce(into: [Int: String]()) { names, romId in
+            if let resolved = try? getDownloadedROM.execute(romId: romId) {
+                names[romId] = resolved.rom.name
+            }
+        }
+    }
+}

--- a/romm/romm/UI/Sync/SyncOverviewViewModel.swift
+++ b/romm/romm/UI/Sync/SyncOverviewViewModel.swift
@@ -27,6 +27,22 @@ final class SyncOverviewViewModel {
         self.getDownloadedROM = factory.makeGetDownloadedROMUseCase()
     }
 
+    /// Starts in a given state, for previews.
+    ///
+    /// Every state this screen can show needs a server that is in that state,
+    /// which is the one thing a preview cannot arrange. Loading is skipped
+    /// because it only runs from `.idle`.
+    init(
+        showing state: State,
+        romNames: [Int: String] = [:],
+        factory: PDependencyFactory = DefaultDependencyFactory.shared
+    ) {
+        self.previewUseCase = factory.makeSyncPreviewUseCase()
+        self.getDownloadedROM = factory.makeGetDownloadedROMUseCase()
+        self.state = state
+        self.romNames = romNames
+    }
+
     var isLoading: Bool {
         if case .loading = state { return true }
         return false
@@ -50,7 +66,9 @@ final class SyncOverviewViewModel {
     /// is exactly the row a user is least likely to recognise, so the id is
     /// spelled out rather than left blank.
     func displayName(forRom romId: Int) -> String {
-        romNames[romId] ?? String(localized: "ROM \(romId)")
+        // The id goes in as text: interpolating the Int formats it for the
+        // locale, which turned ROM 4711 into "ROM 4.711" in German.
+        romNames[romId] ?? String(localized: "ROM \(String(romId))")
     }
 
     private func resolveNames(for preview: SyncPreview) -> [Int: String] {

--- a/romm/romm/UI/Sync/SyncOverviewViewModel.swift
+++ b/romm/romm/UI/Sync/SyncOverviewViewModel.swift
@@ -19,12 +19,26 @@ final class SyncOverviewViewModel {
     /// the tap and the answer.
     private(set) var romNames: [Int: String] = [:]
 
+    /// What was found in each external app's folder, keyed by app.
+    ///
+    /// Kept apart from `state`, which is about the server: a granted folder is
+    /// readable whether or not the server answers, and hiding what is on the
+    /// device behind a failed request would be the wrong way round.
+    private(set) var externalScans: [ExternalEmulatorID: ExternalSaveScan] = [:]
+
+    /// Set when picking a folder failed, e.g. the grant could not be stored.
+    var folderError: String?
+
     private let previewUseCase: PSyncPreviewUseCase
     private let getDownloadedROM: PGetDownloadedROMUseCase
+    private let scanExternalSaves: PScanExternalSavesUseCase
+    private let folderStore: PExternalSaveFolderStore
 
     init(factory: PDependencyFactory = DefaultDependencyFactory.shared) {
         self.previewUseCase = factory.makeSyncPreviewUseCase()
         self.getDownloadedROM = factory.makeGetDownloadedROMUseCase()
+        self.scanExternalSaves = factory.makeScanExternalSavesUseCase()
+        self.folderStore = factory.externalSaveFolderStore
     }
 
     /// Starts in a given state, for previews.
@@ -35,12 +49,24 @@ final class SyncOverviewViewModel {
     init(
         showing state: State,
         romNames: [Int: String] = [:],
+        externalScans: [ExternalEmulatorID: ExternalSaveScan] = [:],
         factory: PDependencyFactory = DefaultDependencyFactory.shared
     ) {
         self.previewUseCase = factory.makeSyncPreviewUseCase()
         self.getDownloadedROM = factory.makeGetDownloadedROMUseCase()
+        self.scanExternalSaves = factory.makeScanExternalSavesUseCase()
+        self.folderStore = factory.externalSaveFolderStore
         self.state = state
         self.romNames = romNames
+        self.externalScans = externalScans
+    }
+
+    /// The apps that could be read from, whether or not a folder was granted yet.
+    ///
+    /// An app with no described layout is left out entirely rather than shown as
+    /// unconfigured: there would be nothing the user could do about it.
+    var externalSources: [ExternalEmulatorID] {
+        ExternalEmulatorID.allCases.filter { $0.emulator.saveLayout != nil }
     }
 
     var isLoading: Bool {
@@ -49,6 +75,10 @@ final class SyncOverviewViewModel {
     }
 
     func load() async {
+        // The folders are read first and on their own: they are local, they are
+        // quick, and they stay meaningful when the request below fails.
+        rescanExternalFolders()
+
         state = .loading
         do {
             let preview = try await previewUseCase.execute()
@@ -59,6 +89,31 @@ final class SyncOverviewViewModel {
         } catch {
             state = .failed(.negotiationFailed(error.localizedDescription))
         }
+    }
+
+    /// Stores the grant for a folder the user just picked and reads it at once,
+    /// so picking the wrong one is visible immediately rather than at the next
+    /// sync.
+    func grantFolder(_ url: URL, for emulator: ExternalEmulatorID) {
+        do {
+            try folderStore.remember(folderURL: url, for: emulator)
+            rescanExternalFolders()
+        } catch {
+            folderError = String(
+                localized: "Could not keep access to that folder: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func revokeFolder(for emulator: ExternalEmulatorID) {
+        folderStore.forget(emulator)
+        externalScans[emulator] = nil
+    }
+
+    func rescanExternalFolders() {
+        externalScans = Dictionary(
+            uniqueKeysWithValues: scanExternalSaves.executeForAllGranted().map { ($0.emulator, $0) }
+        )
     }
 
     /// The name to show for a ROM, falling back to its id when this device has

--- a/romm/rommTests/ExternalEmulatorSetupTests.swift
+++ b/romm/rommTests/ExternalEmulatorSetupTests.swift
@@ -1,0 +1,139 @@
+import Testing
+import Foundation
+@testable import romm
+
+struct ExternalEmulatorSetupPlanTests {
+
+    /// An app already on the device should not be told to install it.
+    @Test func skipsInstallForAnInstalledApp() {
+        let plan = ExternalEmulatorSetupPlan(emulator: .delta, isInstalled: true, hasSaveFolder: false)
+        #expect(!plan.steps.contains(.install))
+        #expect(plan.steps.first == .handoff)
+    }
+
+    @Test func startsWithInstallWhenTheAppIsMissing() {
+        let plan = ExternalEmulatorSetupPlan(emulator: .delta, isInstalled: false, hasSaveFolder: false)
+        #expect(plan.steps.first == .install)
+    }
+
+    /// The handoff is the step that stops Manic from looking broken, so it is
+    /// never skipped over regardless of what else is already true.
+    @Test(arguments: [true, false])
+    func alwaysExplainsTheHandoff(isInstalled: Bool) {
+        let plan = ExternalEmulatorSetupPlan(
+            emulator: .manicEmu, isInstalled: isInstalled, hasSaveFolder: true
+        )
+        #expect(plan.steps.contains(.handoff))
+    }
+
+    /// Asking again for a folder that was already granted would be busywork.
+    @Test func skipsTheFolderStepWhenOneIsAlreadyGranted() {
+        let plan = ExternalEmulatorSetupPlan(emulator: .retroarch, isInstalled: true, hasSaveFolder: true)
+        #expect(!plan.steps.contains(.saveFolder))
+    }
+
+    @Test func asksForAFolderWhenNoneIsGranted() {
+        let plan = ExternalEmulatorSetupPlan(emulator: .retroarch, isInstalled: true, hasSaveFolder: false)
+        #expect(plan.steps.contains(.saveFolder))
+    }
+
+    /// The test run comes last: it is the confirmation, so everything else has
+    /// to be in place before it can mean anything.
+    @Test func endsWithTheTestRun() {
+        let plan = ExternalEmulatorSetupPlan(emulator: .delta, isInstalled: false, hasSaveFolder: false)
+        #expect(plan.steps.last == .testRun)
+    }
+
+    /// Only the steps that ask for something offer a way past them. Reading is
+    /// not one: a Skip beside Continue on the handoff step would be a second
+    /// button doing the same thing.
+    @Test func onlyStepsThatAskForSomethingCanBeSkipped() {
+        #expect(!ExternalEmulatorSetupStep.install.isSkippable)
+        #expect(!ExternalEmulatorSetupStep.handoff.isSkippable)
+        #expect(ExternalEmulatorSetupStep.saveFolder.isSkippable)
+        #expect(ExternalEmulatorSetupStep.testRun.isSkippable)
+    }
+
+    /// Every supported app describes where its saves are, so all of them reach
+    /// the folder step. This fails the day one is added that does not.
+    @Test(arguments: ExternalEmulatorID.allCases)
+    func everySupportedAppCanBeSetUp(id: ExternalEmulatorID) {
+        let plan = ExternalEmulatorSetupPlan(emulator: id, isInstalled: false, hasSaveFolder: false)
+        #expect(plan.steps == [.install, .handoff, .saveFolder, .testRun])
+    }
+}
+
+struct ExternalEmulatorHandoffExplanationTests {
+
+    /// Manic's whole reason for the assistant: it ignores the share sheet, so
+    /// without being told the user taps Play and nothing appears to happen.
+    @Test func manicSaysToPaste() {
+        let text = ManicEmuExternalEmulator().handoffExplanation
+        #expect(text.localizedCaseInsensitiveContains("paste"))
+        #expect(text.localizedCaseInsensitiveContains("clipboard"))
+    }
+
+    /// The apps that do take a document describe the share sheet instead, and
+    /// must not tell the user to paste anything.
+    @Test(arguments: [ExternalEmulatorID.delta, .retroarch])
+    func shareSheetAppsDoNotMentionPasting(id: ExternalEmulatorID) {
+        let text = id.emulator.handoffExplanation
+        #expect(text.localizedCaseInsensitiveContains("share sheet"))
+        #expect(!text.localizedCaseInsensitiveContains("paste"))
+    }
+
+    @Test(arguments: ExternalEmulatorID.allCases)
+    func everyAppNamesItself(id: ExternalEmulatorID) {
+        #expect(id.emulator.handoffExplanation.contains(id.emulator.displayName))
+    }
+}
+
+struct ExternalEmulatorSetupStoreTests {
+
+    private func makeStore() -> UserDefaultsExternalEmulatorSetupStore {
+        let defaults = UserDefaults(suiteName: "setup-tests-\(UUID().uuidString)")!
+        return UserDefaultsExternalEmulatorSetupStore(userDefaults: defaults)
+    }
+
+    @Test func remembersWhatWasConfigured() {
+        let store = makeStore()
+        #expect(!store.isConfigured(.delta))
+        store.markConfigured(.delta)
+        #expect(store.isConfigured(.delta))
+        #expect(store.configuredEmulators() == [.delta])
+    }
+
+    /// The settings list is built from this, and a list that reorders itself
+    /// between launches would move rows under the user's finger.
+    @Test func keepsTheOrderTheyWereAddedIn() {
+        let store = makeStore()
+        store.markConfigured(.manicEmu)
+        store.markConfigured(.delta)
+        #expect(store.configuredEmulators() == [.manicEmu, .delta])
+    }
+
+    @Test func addingTwiceDoesNotDuplicate() {
+        let store = makeStore()
+        store.markConfigured(.delta)
+        store.markConfigured(.delta)
+        #expect(store.configuredEmulators() == [.delta])
+    }
+
+    @Test func forgettingRemovesIt() {
+        let store = makeStore()
+        store.markConfigured(.delta)
+        store.forget(.delta)
+        #expect(store.configuredEmulators().isEmpty)
+    }
+
+    /// A build that no longer knows an app must not erase a setup that a build
+    /// which does know it would still use.
+    @Test func ignoresUnknownStoredValuesWithoutDroppingThem() {
+        let defaults = UserDefaults(suiteName: "setup-tests-\(UUID().uuidString)")!
+        defaults.set(["delta", "some-future-emulator"], forKey: "externalEmulator.configured")
+        let store = UserDefaultsExternalEmulatorSetupStore(userDefaults: defaults)
+
+        #expect(store.configuredEmulators() == [.delta])
+        #expect(defaults.stringArray(forKey: "externalEmulator.configured")?.count == 2)
+    }
+}

--- a/romm/rommTests/ExternalSaveLayoutTests.swift
+++ b/romm/rommTests/ExternalSaveLayoutTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import Foundation
+@testable import romm
+
+/// The file names in here are the ones reported in issue #144, from a real
+/// device. They are the contract: if a layout stops recognising them, saves made
+/// in that app stop being found and the sync silently has nothing to offer.
+struct ExternalSaveLayoutTests {
+
+    // MARK: - RetroArch
+
+    /// `…/RetroArch/saves/<core>/ROMNAME.srm`
+    @Test func retroArchRecognisesItsOwnSaveNames() {
+        let layout = RetroArchExternalEmulator().saveLayout!
+        #expect(layout.isBatterySave(fileName: "Chrono Trigger.srm", matching: "Chrono Trigger"))
+        #expect(layout.isBatterySave(fileName: "Chrono Trigger.sav", matching: "Chrono Trigger"))
+    }
+
+    /// A save is named after the ROM file's base name, so a ROM keeps matching
+    /// after its extension is stripped.
+    @Test func retroArchMatchesOnTheRomBaseName() {
+        let layout = RetroArchExternalEmulator().saveLayout!
+        #expect(layout.naming == .romBaseName)
+        #expect(!layout.isBatterySave(fileName: "Chrono Trigger.srm", matching: "Chrono Trigger.sfc"))
+    }
+
+    // MARK: - Manic EMU
+
+    /// `…/3DS/sdmc/saves/<system>/ROMNAME.sav` for gb/gba/gbc/nds.
+    @Test func manicRecognisesTheSystemFolderNaming() {
+        let layout = ManicEmuExternalEmulator().saveLayout!
+        #expect(layout.isBatterySave(fileName: "Pokemon Emerald.sav", matching: "Pokemon Emerald"))
+    }
+
+    /// `…/3DS/sdmc/saves/Mupen64Plus-Next/ROMNAME.srm` for n64: the same app
+    /// writes the libretro extension through that core, so both have to count.
+    @Test func manicRecognisesTheN64CoreExtension() {
+        let layout = ManicEmuExternalEmulator().saveLayout!
+        #expect(layout.isBatterySave(fileName: "Mario 64.srm", matching: "Mario 64"))
+    }
+
+    /// The hint stops above the per-system directory, because that level is not
+    /// one fixed value: it is the system for most cores and the core name for n64.
+    @Test func manicHintsAtTheSharedSavesFolderOnly() {
+        let layout = ManicEmuExternalEmulator().saveLayout!
+        #expect(layout.searchHints == ["3DS/sdmc/saves"])
+    }
+
+    // MARK: - Delta
+
+    /// Delta names a save after the SHA-1 it addresses the game by, so the key is
+    /// the resolved identifier rather than any file name.
+    @Test func deltaMatchesOnTheGameIdentifier() {
+        let layout = DeltaExternalEmulator().saveLayout!
+        let sha1 = "4f2b8c1d9e0a7b6c5d4e3f2a1b0c9d8e7f6a5b4c"
+        #expect(layout.naming == .gameIdentifier)
+        #expect(layout.isBatterySave(fileName: "\(sha1).sav", matching: sha1))
+    }
+
+    /// Delta keeps the ROM and its artwork under the same name as the save, so
+    /// matching the name alone would offer to upload a ROM as if it were a save.
+    @Test func deltaIgnoresTheRomAndArtworkBesideTheSave() {
+        let layout = DeltaExternalEmulator().saveLayout!
+        let sha1 = "4f2b8c1d9e0a7b6c5d4e3f2a1b0c9d8e7f6a5b4c"
+        #expect(!layout.isBatterySave(fileName: "\(sha1).gba", matching: sha1))
+        #expect(!layout.isBatterySave(fileName: "\(sha1).png", matching: sha1))
+    }
+
+    // MARK: - Shared behaviour
+
+    /// Case folding differs across the file providers these folders come from,
+    /// so a save must not be missed over it.
+    @Test func matchingIgnoresCase() {
+        let layout = RetroArchExternalEmulator().saveLayout!
+        #expect(layout.isBatterySave(fileName: "ZELDA.SRM", matching: "Zelda"))
+    }
+
+    /// Names are truncated at the last dot, so a ROM whose name contains one
+    /// still resolves.
+    @Test func matchesNamesContainingDots() {
+        let layout = RetroArchExternalEmulator().saveLayout!
+        #expect(layout.isBatterySave(fileName: "Sonic 3.knuckles.srm", matching: "Sonic 3.knuckles"))
+    }
+
+    /// A save state is not a battery save, and the two sit in neighbouring
+    /// folders in every one of these apps.
+    @Test func rejectsSaveStates() {
+        let retroarch = RetroArchExternalEmulator().saveLayout!
+        #expect(!retroarch.isBatterySave(fileName: "Zelda.state", matching: "Zelda"))
+        #expect(!retroarch.isBatterySave(fileName: "Zelda.state1", matching: "Zelda"))
+    }
+
+    /// An app that has not described where it writes is not searched at all,
+    /// rather than searched with a guess.
+    @Test func anUndescribedAppHasNoLayout() {
+        #expect(RetroArchExternalEmulator().saveLayout != nil)
+        #expect(DeltaExternalEmulator().saveLayout != nil)
+        #expect(ManicEmuExternalEmulator().saveLayout != nil)
+    }
+
+    /// Every layout has to bound its own search: these folders can sit next to a
+    /// whole ROM collection.
+    @Test(arguments: ExternalEmulatorID.allCases)
+    func everyLayoutBoundsItsSearch(id: ExternalEmulatorID) throws {
+        let layout = try #require(id.emulator.saveLayout)
+        #expect(layout.maxSearchDepth > 0)
+        #expect(layout.maxSearchDepth <= 4)
+        #expect(!layout.batteryExtensions.isEmpty)
+    }
+}

--- a/romm/rommTests/LocalSaveStoreTests.swift
+++ b/romm/rommTests/LocalSaveStoreTests.swift
@@ -23,6 +23,32 @@ struct LocalSaveStoreRepositoryTests {
         #expect(try store.readBattery(romId: 99) == nil)
     }
 
+    /// Sync negotiation reports the whole library in one request, so the store
+    /// has to be able to name every ROM it holds something for.
+    @Test func listsEveryRomItHoldsSomethingFor() throws {
+        let (store, _) = makeStore()
+        try store.writeBattery(romId: 42, data: Data([0xCA]))
+        try store.writeState(romId: 7, slot: 0, data: Data([0x01]))
+        #expect(try store.listRomIds() == [7, 42])
+    }
+
+    @Test func listsNothingForAnEmptyStore() throws {
+        let (store, _) = makeStore()
+        #expect(try store.listRomIds().isEmpty)
+    }
+
+    /// The root is shared with whatever else may end up there, and a stray
+    /// directory must not become a ROM id.
+    @Test func skipsDirectoriesThatAreNotRomIds() throws {
+        let (store, root) = makeStore()
+        try store.writeBattery(romId: 3, data: Data([0xCA]))
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("not-a-rom", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        #expect(try store.listRomIds() == [3])
+    }
+
     @Test func stateRoundtripAndList() throws {
         let (store, _) = makeStore()
         try store.writeState(romId: 1, slot: 1, data: Data([0x01]))

--- a/romm/rommTests/ScanExternalSavesUseCaseTests.swift
+++ b/romm/rommTests/ScanExternalSavesUseCaseTests.swift
@@ -1,0 +1,247 @@
+import Testing
+import Foundation
+@testable import romm
+
+/// Hands out a folder in the temporary directory. Nothing here is security
+/// scoped, which is the one part of the real thing a test cannot stand in for.
+private final class FakeFolderStore: PExternalSaveFolderStore, @unchecked Sendable {
+    var folders: [ExternalEmulatorID: URL] = [:]
+    var stale: Set<ExternalEmulatorID> = []
+
+    func remember(folderURL: URL, for emulator: ExternalEmulatorID) throws {
+        folders[emulator] = folderURL
+    }
+
+    func grantedFolder(for emulator: ExternalEmulatorID) -> ExternalSaveFolderGrant? {
+        guard let url = folders[emulator] else { return nil }
+        return ExternalSaveFolderGrant(url: url, isStale: stale.contains(emulator), scoped: false)
+    }
+
+    func forget(_ emulator: ExternalEmulatorID) { folders[emulator] = nil }
+    func grantedEmulators() -> [ExternalEmulatorID] { Array(folders.keys) }
+}
+
+private final class FakeLocalROMs: PLocalROMRepository, @unchecked Sendable {
+    var roms: [DownloadedROM] = []
+
+    var romsBaseURL: URL { FileManager.default.temporaryDirectory }
+
+    func getAllDownloadedROMs() throws -> [DownloadedROM] { roms }
+    func getDownloadedROMsByPlatform() throws -> [String: [DownloadedROM]] { [:] }
+    func getDownloadedROM(byId id: Int) throws -> DownloadedROM? { roms.first { $0.id == id } }
+    func saveDownloadedROM(_ rom: DownloadedROM) throws {}
+    func deleteDownloadedROM(_ rom: DownloadedROM) throws {}
+    func getTotalDownloadedSize() throws -> Int64 { 0 }
+    func getDownloadedROMsCount() throws -> Int { roms.count }
+}
+
+private final class FakeHandoffStore: PExternalEmulatorHandoffStore, @unchecked Sendable {
+    var identifiers: [Int: String] = [:]
+
+    func hasHandedOff(romId: Int, to target: ExternalEmulatorID) -> Bool { false }
+    func markHandedOff(romId: Int, to target: ExternalEmulatorID) {}
+    func forget(romId: Int) {}
+    func cachedGameIdentifier(romId: Int, kind: ExternalGameIdentifierKind) -> String? {
+        identifiers[romId]
+    }
+    func cacheGameIdentifier(_ identifier: String, romId: Int, kind: ExternalGameIdentifierKind) {}
+}
+
+struct ScanExternalSavesUseCaseTests {
+
+    private func makeRoot() -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScanExternalSaves-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func write(_ path: String, in root: URL, bytes: Int = 32) {
+        let url = root.appendingPathComponent(path)
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? Data(repeating: 0xAB, count: bytes).write(to: url)
+    }
+
+    private func rom(id: Int, fileName: String) -> DownloadedROM {
+        DownloadedROM(
+            id: id, name: fileName, platformName: "GBA", platformSlug: "gba",
+            downloadedAt: Date(), totalSizeBytes: 1024, localDirectory: "gba/\(id)",
+            files: [DownloadedROMFile(fileName: fileName, fileSizeBytes: 1024)],
+            urlCover: nil
+        )
+    }
+
+    private func makeUseCase(
+        root: URL,
+        emulator: ExternalEmulatorID,
+        roms: [DownloadedROM],
+        identifiers: [Int: String] = [:]
+    ) -> (ScanExternalSavesUseCase, FakeFolderStore) {
+        let folders = FakeFolderStore()
+        folders.folders[emulator] = root
+        let localROMs = FakeLocalROMs()
+        localROMs.roms = roms
+        let handoff = FakeHandoffStore()
+        handoff.identifiers = identifiers
+        return (
+            ScanExternalSavesUseCase(folderStore: folders, localROMs: localROMs, handoffStore: handoff),
+            folders
+        )
+    }
+
+    // MARK: - Finding saves where the apps actually put them
+
+    /// The RetroArch path from issue #144, core directory and all.
+    @Test func findsRetroArchSavesUnderTheCoreFolder() throws {
+        let root = makeRoot()
+        write("RetroArch/saves/mgba/Chrono Trigger.srm", in: root)
+        let (useCase, _) = makeUseCase(
+            root: root, emulator: .retroarch, roms: [rom(id: 7, fileName: "Chrono Trigger.sfc")]
+        )
+
+        let scan = try #require(try useCase.execute(for: .retroarch))
+
+        #expect(scan.matched.map(\.romId) == [7])
+        #expect(scan.unmatchedFileNames.isEmpty)
+    }
+
+    /// The Manic path from issue #144, where the level below `saves` is the
+    /// system for most cores and the core name for n64.
+    @Test func findsManicSavesUnderBothSystemAndCoreFolders() throws {
+        let root = makeRoot()
+        write("3DS/sdmc/saves/gba/Pokemon Emerald.sav", in: root)
+        write("3DS/sdmc/saves/Mupen64Plus-Next/Mario 64.srm", in: root)
+        let (useCase, _) = makeUseCase(
+            root: root, emulator: .manicEmu,
+            roms: [rom(id: 1, fileName: "Pokemon Emerald.gba"), rom(id: 2, fileName: "Mario 64.z64")]
+        )
+
+        let scan = try #require(try useCase.execute(for: .manicEmu))
+
+        #expect(Set(scan.matched.map(\.romId)) == [1, 2])
+    }
+
+    /// Delta names a save after the SHA-1 the deep link resolves, so a scan can
+    /// only match ROMs whose identifier is already known.
+    @Test func matchesDeltaSavesByCachedIdentifier() throws {
+        let root = makeRoot()
+        let sha1 = "4f2b8c1d9e0a7b6c5d4e3f2a1b0c9d8e7f6a5b4c"
+        write("Database/\(sha1).sav", in: root)
+        let (useCase, _) = makeUseCase(
+            root: root, emulator: .delta,
+            roms: [rom(id: 3, fileName: "Zelda.gba")],
+            identifiers: [3: sha1]
+        )
+
+        let scan = try #require(try useCase.execute(for: .delta))
+
+        #expect(scan.matched.map(\.romId) == [3])
+    }
+
+    /// Without a cached identifier there is nothing to match against, and the
+    /// file has to be reported as unmatched rather than silently dropped.
+    @Test func reportsDeltaSavesWithoutACachedIdentifier() throws {
+        let root = makeRoot()
+        write("Database/deadbeef00112233445566778899aabbccddeeff.sav", in: root)
+        let (useCase, _) = makeUseCase(
+            root: root, emulator: .delta, roms: [rom(id: 3, fileName: "Zelda.gba")]
+        )
+
+        let scan = try #require(try useCase.execute(for: .delta))
+
+        #expect(scan.matched.isEmpty)
+        #expect(scan.unmatchedFileNames.count == 1)
+    }
+
+    // MARK: - When the hints are wrong
+
+    /// The whole reason the paths are hints: an app that moved its files must
+    /// still be found, or the feature fails silently.
+    @Test func fallsBackToWalkingTheFolderWhenNoHintMatches() throws {
+        let root = makeRoot()
+        write("SomewhereElse/Chrono Trigger.srm", in: root)
+        let (useCase, _) = makeUseCase(
+            root: root, emulator: .retroarch, roms: [rom(id: 7, fileName: "Chrono Trigger.sfc")]
+        )
+
+        let scan = try #require(try useCase.execute(for: .retroarch))
+
+        #expect(scan.matched.map(\.romId) == [7])
+    }
+
+    /// A folder deeper than the layout allows is not descended into, so a scan
+    /// cannot wander through an entire ROM collection.
+    @Test func doesNotDescendPastTheDepthLimit() throws {
+        let root = makeRoot()
+        write("a/b/c/d/e/Chrono Trigger.srm", in: root)
+        let (useCase, _) = makeUseCase(
+            root: root, emulator: .retroarch, roms: [rom(id: 7, fileName: "Chrono Trigger.sfc")]
+        )
+
+        let scan = try #require(try useCase.execute(for: .retroarch))
+
+        #expect(scan.matched.isEmpty)
+    }
+
+    // MARK: - What is not a save
+
+    @Test func ignoresRomsAndArtworkBesideTheSave() throws {
+        let root = makeRoot()
+        let sha1 = "4f2b8c1d9e0a7b6c5d4e3f2a1b0c9d8e7f6a5b4c"
+        write("Database/\(sha1).sav", in: root)
+        write("Database/\(sha1).gba", in: root)
+        write("Database/\(sha1).png", in: root)
+        let (useCase, _) = makeUseCase(
+            root: root, emulator: .delta,
+            roms: [rom(id: 3, fileName: "Zelda.gba")], identifiers: [3: sha1]
+        )
+
+        let scan = try #require(try useCase.execute(for: .delta))
+
+        #expect(scan.matched.count == 1)
+        #expect(scan.matched.first?.fileName == "\(sha1).sav")
+        #expect(scan.unmatchedFileNames.isEmpty)
+    }
+
+    /// An empty file is not a save. Offering to upload one over a real save on
+    /// the server would lose a game.
+    @Test func ignoresEmptySaveFiles() throws {
+        let root = makeRoot()
+        write("RetroArch/saves/mgba/Chrono Trigger.srm", in: root, bytes: 0)
+        let (useCase, _) = makeUseCase(
+            root: root, emulator: .retroarch, roms: [rom(id: 7, fileName: "Chrono Trigger.sfc")]
+        )
+
+        let scan = try #require(try useCase.execute(for: .retroarch))
+
+        #expect(scan.matched.isEmpty)
+    }
+
+    // MARK: - No grant
+
+    @Test func returnsNothingWithoutAGrantedFolder() throws {
+        let useCase = ScanExternalSavesUseCase(
+            folderStore: FakeFolderStore(), localROMs: FakeLocalROMs(), handoffStore: FakeHandoffStore()
+        )
+
+        #expect(try useCase.execute(for: .retroarch) == nil)
+    }
+
+    /// A bookmark that resolved but whose folder moved still scans; the staleness
+    /// is passed on so the screen can say so.
+    @Test func reportsAStaleGrant() throws {
+        let root = makeRoot()
+        write("RetroArch/saves/mgba/Chrono Trigger.srm", in: root)
+        let (useCase, folders) = makeUseCase(
+            root: root, emulator: .retroarch, roms: [rom(id: 7, fileName: "Chrono Trigger.sfc")]
+        )
+        folders.stale.insert(.retroarch)
+
+        let scan = try #require(try useCase.execute(for: .retroarch))
+
+        #expect(scan.isStale)
+        #expect(scan.matched.count == 1)
+    }
+}

--- a/romm/rommTests/StubRommAPIClient.swift
+++ b/romm/rommTests/StubRommAPIClient.swift
@@ -1,0 +1,63 @@
+import Foundation
+@testable import romm
+
+/// A `PRommAPIClient` whose every call fails until a subclass overrides it.
+///
+/// The protocol has fifty-odd requirements while a given test needs one or two,
+/// so without this each test file carries forty-nine stubs of its own before it
+/// can say anything. Failing loudly rather than returning an empty value is
+/// deliberate: a test that reaches an unstubbed call is testing a path it did
+/// not mean to, and a plausible-looking default would hide that.
+class StubRommAPIClient: PRommAPIClient {
+    func makeRequest<T: Codable>(path: String, method: HTTPMethod, body: Data?, responseType: T.Type) async throws -> T { fatalError("makeRequest not stubbed") }
+    func makeRequest(path: String, method: HTTPMethod, body: Data?) async throws -> Data { fatalError("makeRequest not stubbed") }
+    func downloadFile(path: String, progressHandler: ((Int64, Int64) -> Void)?) async throws -> URL { fatalError("downloadFile not stubbed") }
+    func multipartRequest(path: String, method: HTTPMethod, boundary: String, formData: Data, additionalHeaders: [String: String]?) async throws -> Data { fatalError("multipartRequest not stubbed") }
+    func get<T: Codable>(_ path: String, responseType: T.Type) async throws -> T { fatalError("get not stubbed") }
+    func get(_ path: String) async throws -> Data { fatalError("get not stubbed") }
+    func getBinary(_ path: String) async throws -> Data { fatalError("getBinary not stubbed") }
+    func post<RequestBody: Codable, ResponseType: Codable>(_ path: String, body: RequestBody, responseType: ResponseType.Type) async throws -> ResponseType { fatalError("post not stubbed") }
+    func post(_ path: String, body: Data?) async throws -> Data { fatalError("post not stubbed") }
+    func put<RequestBody: Codable, ResponseType: Codable>(_ path: String, body: RequestBody, responseType: ResponseType.Type) async throws -> ResponseType { fatalError("put not stubbed") }
+    func put<RequestBody: Codable>(_ path: String, body: RequestBody) async throws -> Data { fatalError("put not stubbed") }
+    func put(_ path: String, body: Data?) async throws -> Data { fatalError("put not stubbed") }
+    func delete(_ path: String) async throws -> Data { fatalError("delete not stubbed") }
+    func getRomManual(romId: Int) async throws -> Manual? { fatalError("getRomManual not stubbed") }
+    func getManualPDFData(manualURL: String) async throws -> Data { fatalError("getManualPDFData not stubbed") }
+    func getRomDetails(id: Int) async throws -> DetailedRomSchema { fatalError("getRomDetails not stubbed") }
+    func getRoms( searchTerm: String?, platformId: Int?, limit: Int ) async throws -> CustomLimitOffsetPageSimpleRomSchema { fatalError("getRoms not stubbed") }
+    func getRomsWithFilters( searchTerm: String?, platformId: Int?, collectionId: Int?, limit: Int, offset: Int?, withCharIndex: Bool?, orderBy: String?, orderDir: String?, filters: RomFilters ) async throws -> CustomLimitOffsetPageSimpleRomSchema { fatalError("getRomsWithFilters not stubbed") }
+    func searchRomsWithOpenAPI(query: String) async throws -> CustomLimitOffsetPageSimpleRomSchema { fatalError("searchRomsWithOpenAPI not stubbed") }
+    func getCollections(limit: Int?, offset: Int?) async throws -> [CollectionSchema] { fatalError("getCollections not stubbed") }
+    func getCollection(id: Int) async throws -> CollectionSchema { fatalError("getCollection not stubbed") }
+    func getVirtualCollections(type: String, limit: Int?) async throws -> [VirtualCollectionSchema] { fatalError("getVirtualCollections not stubbed") }
+    func getVirtualCollection(id: String) async throws -> VirtualCollectionSchema { fatalError("getVirtualCollection not stubbed") }
+    func createCollection(name: String, description: String, isPublic: Bool, isFavorite: Bool, artwork: URL?) async throws -> CollectionSchema { fatalError("createCollection not stubbed") }
+    func updateCollection(id: Int, name: String, description: String, isPublic: Bool, romIds: [Int]?, artwork: URL?) async throws -> CollectionSchema { fatalError("updateCollection not stubbed") }
+    func deleteCollection(id: Int) async throws -> String { fatalError("deleteCollection not stubbed") }
+    func addRomsToCollection(id: Int, romIds: [Int]) async throws -> CollectionSchema { fatalError("addRomsToCollection not stubbed") }
+    func removeRomsFromCollection(id: Int, romIds: [Int]) async throws -> CollectionSchema { fatalError("removeRomsFromCollection not stubbed") }
+    func getCurrentUser() async throws -> UserSchema { fatalError("getCurrentUser not stubbed") }
+    func updateRetroAchievementsUsername(userId: Int, username: String) async throws -> UserSchema { fatalError("updateRetroAchievementsUsername not stubbed") }
+    func getPlatforms() async throws -> [PlatformSchema] { fatalError("getPlatforms not stubbed") }
+    func addPlatform(name: String, slug: String) async throws -> PlatformSchema { fatalError("addPlatform not stubbed") }
+    func deletePlatform(id: Int) async throws -> String { fatalError("deletePlatform not stubbed") }
+    func getPlatformFirmware(platformId: Int) async throws -> [FirmwareSchema] { fatalError("getPlatformFirmware not stubbed") }
+    func downloadFirmwareContent(id: Int, fileName: String) async throws -> Data { fatalError("downloadFirmwareContent not stubbed") }
+    func getHeartbeat() async throws -> HeartbeatResponse { fatalError("getHeartbeat not stubbed") }
+    func getHeartbeat(from serverURL: String) async throws -> HeartbeatResponse { fatalError("getHeartbeat not stubbed") }
+    func updateRomLastPlayed(id: Int) async throws -> RomUserSchema { fatalError("updateRomLastPlayed not stubbed") }
+    func getStats() async throws -> StatsReturn { fatalError("getStats not stubbed") }
+    func getSaves(romId: Int) async throws -> [SaveSchema] { fatalError("getSaves not stubbed") }
+    func getStates(romId: Int) async throws -> [StateSchema] { fatalError("getStates not stubbed") }
+    func uploadSave(romId: Int, emulator: String?, slot: String?, deviceId: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema { fatalError("uploadSave not stubbed") }
+    func updateSave(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> SaveSchema { fatalError("updateSave not stubbed") }
+    func downloadSave(id: Int, deviceId: String?) async throws -> Data { fatalError("downloadSave not stubbed") }
+    func deleteSaves(ids: [Int]) async throws { fatalError("deleteSaves not stubbed") }
+    func uploadState(romId: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema { fatalError("uploadState not stubbed") }
+    func updateState(id: Int, emulator: String?, fileName: String, fileData: Data, screenshotData: Data?) async throws -> StateSchema { fatalError("updateState not stubbed") }
+    func downloadState(id: Int) async throws -> Data { fatalError("downloadState not stubbed") }
+    func deleteStates(ids: [Int]) async throws { fatalError("deleteStates not stubbed") }
+    func registerDevice(_ body: DeviceRegisterRequest) async throws -> DeviceSchema { fatalError("registerDevice not stubbed") }
+    func negotiateSync(_ body: SyncNegotiateRequest) async throws -> SyncNegotiateResponse { fatalError("negotiateSync not stubbed") }
+}

--- a/romm/rommTests/Support/MockDependencyFactory.swift
+++ b/romm/rommTests/Support/MockDependencyFactory.swift
@@ -454,6 +454,7 @@ class MockDependencyFactory: PDependencyFactory {
     }
 
     lazy var externalSaveFolderStore: PExternalSaveFolderStore = UserDefaultsExternalSaveFolderStore()
+    lazy var externalEmulatorSetupStore: PExternalEmulatorSetupStore = UserDefaultsExternalEmulatorSetupStore()
 
     func makeScanExternalSavesUseCase() -> PScanExternalSavesUseCase {
         ScanExternalSavesUseCase(

--- a/romm/rommTests/Support/MockDependencyFactory.swift
+++ b/romm/rommTests/Support/MockDependencyFactory.swift
@@ -453,6 +453,16 @@ class MockDependencyFactory: PDependencyFactory {
         )
     }
 
+    lazy var externalSaveFolderStore: PExternalSaveFolderStore = UserDefaultsExternalSaveFolderStore()
+
+    func makeScanExternalSavesUseCase() -> PScanExternalSavesUseCase {
+        ScanExternalSavesUseCase(
+            folderStore: externalSaveFolderStore,
+            localROMs: localROMRepository,
+            handoffStore: externalEmulatorHandoffStore
+        )
+    }
+
     func makeBIOSSyncUseCase() -> PBIOSSyncUseCase {
         BIOSSyncUseCase(apiClient: apiClient, fileSystem: fileSystemService)
     }

--- a/romm/rommTests/Support/MockDependencyFactory.swift
+++ b/romm/rommTests/Support/MockDependencyFactory.swift
@@ -444,6 +444,15 @@ class MockDependencyFactory: PDependencyFactory {
         EmulatorSaveStatesUseCase(saveStore: saveStore)
     }
 
+    func makeSyncPreviewUseCase() -> PSyncPreviewUseCase {
+        SyncPreviewUseCase(
+            saveStore: saveStore,
+            syncDevice: syncDeviceRepository,
+            apiClient: apiClient,
+            tokenProvider: tokenProvider
+        )
+    }
+
     func makeBIOSSyncUseCase() -> PBIOSSyncUseCase {
         BIOSSyncUseCase(apiClient: apiClient, fileSystem: fileSystemService)
     }

--- a/romm/rommTests/SyncPreviewUseCaseTests.swift
+++ b/romm/rommTests/SyncPreviewUseCaseTests.swift
@@ -1,0 +1,239 @@
+import Testing
+import Foundation
+@testable import romm
+
+/// Answers negotiation with a canned plan and records what was reported.
+private final class FakeNegotiateClient: StubRommAPIClient, @unchecked Sendable {
+    var operations: [SyncOperationSchema] = []
+    var errorToThrow: Error?
+    private(set) var reportedSaves: [ClientSaveState] = []
+    private(set) var reportedDeviceId: String?
+
+    override func negotiateSync(_ body: SyncNegotiateRequest) async throws -> SyncNegotiateResponse {
+        if let errorToThrow { throw errorToThrow }
+        reportedSaves = body.saves
+        reportedDeviceId = body.deviceId
+        return Self.response(operations)
+    }
+
+    /// Builds a response through the decoder, since the schemas only have
+    /// decoding initialisers.
+    private static func response(_ operations: [SyncOperationSchema]) -> SyncNegotiateResponse {
+        let payload: [String: Any] = [
+            "session_id": 1,
+            "operations": operations.map(Self.operationJSON),
+            "total_upload": operations.filter { $0.action == .upload }.count,
+            "total_download": operations.filter { $0.action == .download }.count,
+            "total_conflict": operations.filter { $0.action == .conflict }.count,
+            "total_no_op": operations.filter { $0.action == .noOp }.count
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: payload)
+        return try! JSONDecoder().decode(SyncNegotiateResponse.self, from: data)
+    }
+
+    private static func operationJSON(_ op: SyncOperationSchema) -> [String: Any] {
+        var json: [String: Any] = ["action": op.action.rawValue]
+        if let romId = op.romId { json["rom_id"] = romId }
+        if let fileName = op.fileName { json["file_name"] = fileName }
+        if let slot = op.slot { json["slot"] = slot }
+        if let reason = op.reason { json["reason"] = reason }
+        return json
+    }
+}
+
+private final class FakeSyncDevice: PSyncDeviceRepository, @unchecked Sendable {
+    var isSyncAPISupported: Bool = true
+    var idToReturn: String? = "device-1"
+    func deviceId() async -> String? { idToReturn }
+}
+
+private final class FakeTokenProvider: PTokenProvider, @unchecked Sendable {
+    var serverURL: String? = "https://example.org"
+
+    func getServerURL() -> String? { serverURL }
+    func getAuthToken() -> String? { "token" }
+    func getUsername() -> String? { "tester" }
+    func getPassword() -> String? { nil }
+    func isConfigured() -> Bool { serverURL != nil }
+    func getAuthMethod() -> AuthMethod { .classic }
+    func getClientToken() -> String? { nil }
+    func getClientTokenInfo() -> ClientTokenInfo? { nil }
+    func hasScope(_ scope: String) -> Bool { true }
+    var availableScopes: [String]? { nil }
+}
+
+struct SyncPreviewUseCaseTests {
+
+    private func makeStore() -> LocalSaveStoreRepository {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SyncPreviewUseCaseTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        return LocalSaveStoreRepository(rootDirectory: tmp)
+    }
+
+    private func makeUseCase(
+        store: LocalSaveStoreRepository,
+        client: FakeNegotiateClient = FakeNegotiateClient(),
+        device: FakeSyncDevice = FakeSyncDevice(),
+        token: FakeTokenProvider = FakeTokenProvider()
+    ) -> SyncPreviewUseCase {
+        SyncPreviewUseCase(saveStore: store, syncDevice: device, apiClient: client, tokenProvider: token)
+    }
+
+    private func operation(
+        _ action: SyncAction,
+        romId: Int? = 1,
+        fileName: String? = "battery.sav",
+        slot: String? = SaveSlot.battery,
+        reason: String? = nil
+    ) -> SyncOperationSchema {
+        var json: [String: Any] = ["action": action.rawValue]
+        if let romId { json["rom_id"] = romId }
+        if let fileName { json["file_name"] = fileName }
+        if let slot { json["slot"] = slot }
+        if let reason { json["reason"] = reason }
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(SyncOperationSchema.self, from: data)
+    }
+
+    // MARK: - What gets reported
+
+    /// The slot is the whole point: the server never pairs a save that arrives
+    /// without one, so a preview that omitted it would report every save as
+    /// absent and plan an upload for all of them.
+    @Test func reportsBatterySavesUnderTheBatterySlot() async throws {
+        let store = makeStore()
+        try store.writeBattery(romId: 7, data: Data([0xCA, 0xFE]))
+        let client = FakeNegotiateClient()
+
+        _ = try await makeUseCase(store: store, client: client).execute()
+
+        #expect(client.reportedSaves.count == 1)
+        #expect(client.reportedSaves.first?.slot == SaveSlot.battery)
+        #expect(client.reportedSaves.first?.romId == 7)
+        #expect(client.reportedDeviceId == "device-1")
+    }
+
+    /// An empty battery file is not a save; reporting it would have the server
+    /// plan an upload of nothing over a real save.
+    @Test func skipsEmptyBatteryFiles() async throws {
+        let store = makeStore()
+        try store.writeBattery(romId: 7, data: Data())
+        let client = FakeNegotiateClient()
+
+        _ = try await makeUseCase(store: store, client: client).execute()
+
+        #expect(client.reportedSaves.isEmpty)
+    }
+
+    // MARK: - What comes back
+
+    @Test func mapsEveryDirection() async throws {
+        let client = FakeNegotiateClient()
+        client.operations = [
+            operation(.upload, romId: 1),
+            operation(.download, romId: 2),
+            operation(.conflict, romId: 3)
+        ]
+
+        let preview = try await makeUseCase(store: makeStore(), client: client).execute()
+
+        #expect(preview.uploads.map(\.romId) == [1])
+        #expect(preview.downloads.map(\.romId) == [2])
+        #expect(preview.conflicts.map(\.romId) == [3])
+        #expect(!preview.isUpToDate)
+    }
+
+    @Test func reportsAgreementWhenNothingWouldChange() async throws {
+        let client = FakeNegotiateClient()
+        client.operations = [operation(.noOp, romId: 1)]
+
+        let preview = try await makeUseCase(store: makeStore(), client: client).execute()
+
+        #expect(preview.isUpToDate)
+    }
+
+    /// This preview reports battery saves only, so an operation about a state
+    /// came from somewhere else and would misstate what syncing here does.
+    @Test func dropsSaveStateOperations() async throws {
+        let client = FakeNegotiateClient()
+        client.operations = [
+            operation(.download, romId: 1, fileName: "slot0.state", slot: "0"),
+            operation(.download, romId: 2, fileName: "battery.sav")
+        ]
+
+        let preview = try await makeUseCase(store: makeStore(), client: client).execute()
+
+        #expect(preview.downloads.map(\.romId) == [2])
+    }
+
+    /// A newer server can plan something this build has no name for. Showing it
+    /// as one of the four known directions would misdescribe a change the user
+    /// is being asked to approve.
+    @Test func dropsOperationsItCannotName() async throws {
+        let client = FakeNegotiateClient()
+        client.operations = [operation(.unknown, romId: 1), operation(.upload, romId: 2)]
+
+        let preview = try await makeUseCase(store: makeStore(), client: client).execute()
+
+        #expect(preview.operations.map(\.romId) == [2])
+    }
+
+    @Test func dropsOperationsWithoutARom() async throws {
+        let client = FakeNegotiateClient()
+        client.operations = [operation(.upload, romId: nil)]
+
+        let preview = try await makeUseCase(store: makeStore(), client: client).execute()
+
+        #expect(preview.operations.isEmpty)
+    }
+
+    /// The server's wording is kept rather than reworded, so a surprising plan
+    /// can be traced back to what the server actually said.
+    @Test func keepsTheServersReason() async throws {
+        let client = FakeNegotiateClient()
+        client.operations = [operation(.download, reason: "Server save is newer (no sync history)")]
+
+        let preview = try await makeUseCase(store: makeStore(), client: client).execute()
+
+        #expect(preview.downloads.first?.reason == "Server save is newer (no sync history)")
+    }
+
+    // MARK: - States the screen has to explain
+
+    @Test func failsWithoutAServer() async throws {
+        let token = FakeTokenProvider()
+        token.serverURL = nil
+
+        await #expect(throws: SyncPreviewError.notConnected) {
+            try await makeUseCase(store: makeStore(), token: token).execute()
+        }
+    }
+
+    @Test func failsOnAServerWithoutTheSyncAPI() async throws {
+        let device = FakeSyncDevice()
+        device.isSyncAPISupported = false
+
+        await #expect(throws: SyncPreviewError.serverTooOld) {
+            try await makeUseCase(store: makeStore(), device: device).execute()
+        }
+    }
+
+    @Test func failsWhenTheDeviceCannotRegister() async throws {
+        let device = FakeSyncDevice()
+        device.idToReturn = nil
+
+        await #expect(throws: SyncPreviewError.deviceRegistrationFailed) {
+            try await makeUseCase(store: makeStore(), device: device).execute()
+        }
+    }
+
+    @Test func surfacesANegotiationFailure() async throws {
+        let client = FakeNegotiateClient()
+        client.errorToThrow = URLError(.timedOut)
+
+        await #expect(throws: SyncPreviewError.self) {
+            try await makeUseCase(store: makeStore(), client: client).execute()
+        }
+    }
+}


### PR DESCRIPTION
Builds on #154 — review that one first. The diff shown here is only this session's work.

## The blocker turned out not to be the one we expected

Verified empirically against a real RomM 5.2.0 server, not read out of the code:

**Saves are paired by `(rom_id, slot)`. The file name and the emulator play no part.** A client reporting `TestGame.sav / slot=autosave / emulator=delta` gets back the mGBA save under a different name and a different emulator. So the suspected show-stopper — that the app uploads under inconsistent names (`<romBase>.sav` vs `.srm` vs `<romId>.sav`) — is not one. No canonical naming, no migration.

The real blocker is that **a save arriving without a slot is filed as archival and never paired**, and this app sends `slot: nil` everywhere. `CloudSaveSyncService` even says so in a comment and works around it rather than setting one.

Also measured, so it does not have to be discovered later: the pairing dictionary is case-sensitive while the database collation is not, so `"Battery"` against a stored `"battery"` plans an upload *and* a download for the same save. The slot name is a constant with that reasoning attached.

## What is here

**Sync preview, read-only.** Reports the local battery saves under a slot, asks the server for its plan, shows it. Overwriting a save is close to unrepairable, so the first thing built is the part that changes nothing. It reports under a slot even though uploads still send none — that is the point: it shows what a sync *would* do once that changes.

**Reading other apps' saves.** Issue #144 reports where Delta, RetroArch and Manic keep theirs. Those paths are **hints with a fallback**, not fixed locations: the report says it is not exhaustive, it is one device, and two of the three have a component that varies per system or per core. A wrong hint costs a folder walk; a wrong fixed path costs the feature.

The scan runs folder-first. Going ROM-first would mean deriving a key per ROM, and for Delta that is a hash of the entire library on every scan.

Files that look like saves but match nothing are counted and shown, because that number says *what* is wrong: saves found but unmatched means the folder is right and the matching is not; nothing found at all means the folder or the hints are wrong. Opposite fixes, so they must not read the same.

**A setup assistant.** Picking an external app used to be one tap that left three things unsaid, the worst being that Manic needs a paste. Adding one is now its own flow: install, explain the handoff, point at the saves, hand a game over for real. Which steps apply is worked out per app. Only apps that have been through it are offered as a Play target.

## Still open

- Whether the reported save paths hold on a real device. The assistant's folder step answers that for all three apps in one pass, without uploading anything.
- Uploads still send no slot. That is the next change, with a migration that pulls the old archival save down before writing a slotted one, so nothing can be lost.

---

Every commit builds on its own. 334 tests. Screens were rendered in the simulator rather than assumed, which found a ROM id printed as "ROM 4.711" under German number formatting, a count shown twice in one row, and a Skip button that did the same thing as Continue.