### PR TITLE
Let the downloads list own the share sheet

### DIFF
--- a/romm/romm.xcodeproj/project.pbxproj
+++ b/romm/romm.xcodeproj/project.pbxproj
@@ -485,7 +485,6 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
-				de,
 				Base,
 			);
 			mainGroup = 5DA7E4172E43D870003680D9;

--- a/romm/romm/Localizable.xcstrings
+++ b/romm/romm/Localizable.xcstrings
@@ -2,521 +2,145 @@
   "sourceLanguage" : "en",
   "strings" : {
     "© Riley Testut. Licensed under the AGPL-3.0 license." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "© Riley Testut. Lizenziert unter der AGPL-3.0-Lizenz."
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Authentication and login" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authentifizierung und Anmeldung"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Authentication, login" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authentifizierung, Anmeldung"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "BIOS files are downloaded from the RomM server and stored in Documents/LibretroSystem." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BIOS-Dateien werden vom RomM-Server heruntergeladen und unter Documents/LibretroSystem gespeichert."
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Close" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schließen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Cloud Save Sync" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloud-Sync für Saves"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Data operations and repositories" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datenoperationen und Repositories"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Data operations, repository" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datenoperationen, Repository"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Download" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Herunterladen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Download Failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download fehlgeschlagen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Downloaded" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Heruntergeladen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Downloading… %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird geladen … %@"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Open In…" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In App öffnen …"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Send to Device" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An Gerät senden"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Dynamic library not found: %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dynamische Bibliothek nicht gefunden: %1$@"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Emulator Engines" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emulator-Engines"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "General logic and use cases" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allgemeine Logik und Anwendungsfälle"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "General logic, use cases" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allgemeine Logik, Anwendungsfälle"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Hash verified" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hash verifiziert"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Libretro Error" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Libretro-Fehler"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Libretro symbol not found: %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Libretro-Symbol fehlt: %1$@"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Licenses" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lizenzen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Loading %@…" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lade %1$@ …"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Local %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokal %1$@"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Missing locally · File unavailable on the server." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokal nicht vorhanden · Datei auf dem Server nicht verfügbar."
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Missing locally · Platform not found on the RomM server." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokal nicht vorhanden · Plattform auf dem RomM-Server nicht gefunden."
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Missing locally · Server: %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokal nicht vorhanden · Server: %1$@"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Network operations and API calls" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Netzwerkoperationen und API-Aufrufe"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Network operations, API calls" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Netzwerkoperationen, API-Aufrufe"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "No BIOS requirements configured." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine BIOS-Anforderungen konfiguriert."
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "PCSX ReARMed can start when at least one regional variant (SCPH-5500/5501/5502) is available." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PCSX ReARMed startet bereits, wenn mindestens eine Regionalvariante (SCPH-5500/5501/5502) vorliegt."
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "PDF manual system" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PDF-Handbuchsystem"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Performance metrics and timing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leistungsmetriken und Zeitmessung"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Performance metrics, timing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leistungsmetriken, Zeitmessung"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Required BIOS files are missing for %@: %@. Download them in Settings → BIOS Files." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erforderliche BIOS-Dateien fehlen für %1$@: %2$@. Unter Einstellungen → BIOS-Dateien herunterladen."
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "retro_load_game failed." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "retro_load_game ist fehlgeschlagen."
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Search %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ durchsuchen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Search collections" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sammlungen durchsuchen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Search failed: %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suche fehlgeschlagen: %1$@"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Search platforms" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plattformen durchsuchen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Sync game saves and save states with the RomM server" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spielstände und Speicherzustände mit dem RomM-Server synchronisieren"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Synchronization operations" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchronisierungsvorgänge"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "The server does not have %@." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Server hat keine Datei für %1$@."
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "User interface and view updates" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzeroberfläche und Ansichtsaktualisierungen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "User interface, view updates" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzeroberfläche, Ansichtsaktualisierungen"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "View model layer and state" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ViewModel-Schicht und Zustand"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "View model layer, state" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ViewModel-Schicht, Zustand"
-          }
-        }
-      }
+      "extractionState" : "manual"
     }
   },
   "version" : "1.0"

--- a/romm/romm/UI/DI/DependencyFactory.swift
+++ b/romm/romm/UI/DI/DependencyFactory.swift
@@ -147,7 +147,7 @@ protocol PDependencyFactory {
 
     // Local ROM ViewModels
     @MainActor func makeSyncSaveViewModel(rom: DownloadedROM) -> SyncSaveViewModel
-    @MainActor func makeShareROMViewModel(rom: DownloadedROM) -> ShareROMViewModel
+    @MainActor func makeShareROMViewModel() -> ShareROMViewModel
 }
 
 class DefaultDependencyFactory: PDependencyFactory {
@@ -582,8 +582,8 @@ class DefaultDependencyFactory: PDependencyFactory {
         )
     }
 
-    @MainActor func makeShareROMViewModel(rom: DownloadedROM) -> ShareROMViewModel {
-        ShareROMViewModel(rom: rom, getShareFilesUseCase: makeGetROMShareFilesUseCase())
+    @MainActor func makeShareROMViewModel() -> ShareROMViewModel {
+        ShareROMViewModel(getShareFilesUseCase: makeGetROMShareFilesUseCase())
     }
 
     @MainActor func makeLibretroEmulatorViewModel(rom: Rom, core: LibretroCore) -> LibretroEmulatorViewModel {

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/PlatformROMsListView.swift
@@ -31,6 +31,9 @@ struct PlatformROMsListView: View {
     @State private var romPendingLaunch: PendingLaunch?
     /// Slot chosen in the pre-launch sheet; read by the emulator cover builder.
     @State private var pendingResumeSlot: Int?
+    /// Files a Share swipe has staged, held here rather than in the swipe action
+    /// so the presentation survives the row snapping shut.
+    @State private var share: ShareROMViewModel
     private let factory: PDependencyFactory
     private let launchUseCase: PLaunchEmulatorUseCase
     private let updateLastPlayedUseCase: PUpdateLastPlayedUseCase
@@ -44,6 +47,7 @@ struct PlatformROMsListView: View {
         self.launchUseCase = factory.makeLaunchEmulatorUseCase()
         self.updateLastPlayedUseCase = factory.makeUpdateLastPlayedUseCase()
         self.saveStore = factory.saveStore
+        _share = State(initialValue: factory.makeShareROMViewModel())
     }
 
     var body: some View {
@@ -73,7 +77,7 @@ struct PlatformROMsListView: View {
                     }
                 }
                 .swipeActions(edge: .leading, allowsFullSwipe: false) {
-                    ShareSwipeButton(rom: rom)
+                    ShareSwipeButton { share.prepareShare(rom: rom) }
                 }
             }
         }
@@ -124,6 +128,14 @@ struct PlatformROMsListView: View {
             SyncSaveSheet(viewModel: factory.makeSyncSaveViewModel(rom: rom)) { romPendingSync = nil }
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
+        }
+        .sheet(item: $share.shareSheetItem, onDismiss: share.cleanupTemporaryFiles) { item in
+            ShareSheet(activityItems: item.urls)
+        }
+        .alert("Files Not Found", isPresented: $share.showFileNotFoundAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("The ROM files could not be found on this device. They may have been deleted or moved.")
         }
     }
 

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ShareROMViewModel.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ShareROMViewModel.swift
@@ -1,22 +1,24 @@
 import Foundation
 import Observation
 
+/// Collects the files behind a downloaded ROM so the list can hand them to the
+/// share sheet. One instance serves the whole list: the ROM arrives with the tap
+/// rather than at init, because the view that presents the sheet has to outlive
+/// the row that started it.
 @Observable
 @MainActor
 final class ShareROMViewModel {
     var shareSheetItem: ShareSheetItem?
     var showFileNotFoundAlert = false
 
-    private let rom: DownloadedROM
     private let getShareFilesUseCase: PGetROMShareFilesUseCase
     private var temporaryShareDirectory: URL?
 
-    init(rom: DownloadedROM, getShareFilesUseCase: PGetROMShareFilesUseCase) {
-        self.rom = rom
+    init(getShareFilesUseCase: PGetROMShareFilesUseCase) {
         self.getShareFilesUseCase = getShareFilesUseCase
     }
 
-    func prepareShare() {
+    func prepareShare(rom: DownloadedROM) {
         let (files, tempDir) = getShareFilesUseCase.execute(rom: rom)
         if files.isEmpty {
             showFileNotFoundAlert = true
@@ -32,4 +34,9 @@ final class ShareROMViewModel {
         temporaryShareDirectory = nil
         shareSheetItem = nil
     }
+}
+
+struct ShareSheetItem: Identifiable {
+    let id = UUID()
+    let urls: [URL]
 }

--- a/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ShareSwipeButton.swift
+++ b/romm/romm/UI/Devices/LocalDevice/PlatformROMs/ShareSwipeButton.swift
@@ -1,31 +1,18 @@
 import SwiftUI
 
+/// The Share entry in a downloaded ROM's leading swipe actions.
+///
+/// Deliberately holds no presentation of its own. A swipe action's button is
+/// torn out of the hierarchy the moment the row snaps shut, so a `.sheet`
+/// attached to it is dismissed in the same run loop it was asked to appear in,
+/// and nothing ever shows. The list owns the sheet instead.
 struct ShareSwipeButton: View {
-    @State private var viewModel: ShareROMViewModel
-
-    init(rom: DownloadedROM, factory: PDependencyFactory = DefaultDependencyFactory.shared) {
-        _viewModel = State(initialValue: factory.makeShareROMViewModel(rom: rom))
-    }
+    let action: () -> Void
 
     var body: some View {
-        Button {
-            viewModel.prepareShare()
-        } label: {
+        Button(action: action) {
             Label("Share", systemImage: "square.and.arrow.up")
         }
         .tint(.blue)
-        .sheet(item: $viewModel.shareSheetItem, onDismiss: viewModel.cleanupTemporaryFiles) { item in
-            ShareSheet(activityItems: item.urls)
-        }
-        .alert("Files Not Found", isPresented: $viewModel.showFileNotFoundAlert) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text("The ROM files could not be found on this device. They may have been deleted or moved.")
-        }
     }
-}
-
-struct ShareSheetItem: Identifiable {
-    let id = UUID()
-    let urls: [URL]
 }

--- a/romm/romm/UI/Shared/Components/ShareSheet.swift
+++ b/romm/romm/UI/Shared/Components/ShareSheet.swift
@@ -4,32 +4,27 @@ import UniformTypeIdentifiers
 
 /// Shared component for presenting iOS share sheet
 struct ShareSheet: UIViewControllerRepresentable {
+    private let logger = Logger.ui
+
     let activityItems: [Any]
     /// Called with the activity that handled the share. For "Open in <app>" this
     /// is the receiving bundle identifier, which is how a handoff is confirmed.
     var onCompleted: ((String?) -> Void)? = nil
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        print("🔧 Creating UIActivityViewController with \(activityItems.count) items")
-
         // Convert URLs to NSURL file URLs for better compatibility
-        // Based on: https://stackoverflow.com/a/... (CC BY-SA 4.0)
         var filesToShare = [Any]()
 
         for item in activityItems {
             if let url = item as? URL {
                 // Create NSURL with fileURLWithPath for proper file sharing
-                let nsurl = NSURL(fileURLWithPath: url.path)
-                print("   Adding: \(url.lastPathComponent)")
-                print("     Path: \(url.path)")
-                print("     isFileURL: \(url.isFileURL)")
-                filesToShare.append(nsurl)
+                filesToShare.append(NSURL(fileURLWithPath: url.path))
             } else {
-                print("   ⚠️ Non-URL item: \(type(of: item))")
+                logger.warning("Ignoring non-URL share item of type \(type(of: item))")
             }
         }
 
-        print("   Total items to share: \(filesToShare.count)")
+        logger.debug("Sharing \(filesToShare.count) file(s)")
 
         let controller = UIActivityViewController(
             activityItems: filesToShare,
@@ -44,13 +39,13 @@ struct ShareSheet: UIViewControllerRepresentable {
 
         // Be notified of the result when the share sheet is dismissed
         controller.completionWithItemsHandler = { activityType, completed, returnedItems, error in
-            if let error = error {
-                print("❌ Share failed: \(error.localizedDescription)")
+            if let error {
+                logger.error("Share failed: \(error.localizedDescription)")
             } else if completed {
-                print("✅ Share completed with: \(activityType?.rawValue ?? "unknown")")
+                logger.info("Share completed with \(activityType?.rawValue ?? "unknown")")
                 onCompleted?(activityType?.rawValue)
             } else {
-                print("⚠️ Share cancelled")
+                logger.debug("Share cancelled")
             }
         }
 

--- a/romm/rommTests/ShareROMViewModelTests.swift
+++ b/romm/rommTests/ShareROMViewModelTests.swift
@@ -1,0 +1,78 @@
+import Testing
+import Foundation
+@testable import romm
+
+// The view model now serves a whole list rather than a single row, so the ROM
+// it shares arrives with the tap. These tests pin that down, and the two
+// outcomes a tap can have: files staged, or the not-found alert.
+
+private final class StubGetROMShareFilesUseCase: PGetROMShareFilesUseCase {
+    var filesToReturn: [URL] = []
+    var tempDirectoryToReturn: URL?
+    private(set) var sharedROMIds: [Int] = []
+
+    func execute(rom: DownloadedROM) -> (files: [URL], tempDirectory: URL?) {
+        sharedROMIds.append(rom.id)
+        return (filesToReturn, tempDirectoryToReturn)
+    }
+
+    func execute(fileAt url: URL) -> (files: [URL], tempDirectory: URL?) {
+        ([url], nil)
+    }
+}
+
+private func makeDownloadedROM(id: Int, name: String = "Aardvark") -> DownloadedROM {
+    DownloadedROM(
+        id: id,
+        name: name,
+        platformName: "Atari 2600",
+        platformSlug: "atari2600",
+        downloadedAt: Date(timeIntervalSince1970: 0),
+        totalSizeBytes: 33_000,
+        localDirectory: "Atari 2600/\(name)",
+        files: [DownloadedROMFile(id: UUID(), fileName: "\(name).bin", fileSizeBytes: 33_000, md5Hash: nil)],
+        urlCover: nil
+    )
+}
+
+@MainActor
+struct ShareROMViewModelTests {
+
+    @Test func prepareShareStagesTheFilesItWasGiven() {
+        let stub = StubGetROMShareFilesUseCase()
+        stub.filesToReturn = [URL(fileURLWithPath: "/tmp/ROMShare-1/Aardvark.bin")]
+        stub.tempDirectoryToReturn = URL(fileURLWithPath: "/tmp/ROMShare-1")
+        let vm = ShareROMViewModel(getShareFilesUseCase: stub)
+
+        vm.prepareShare(rom: makeDownloadedROM(id: 42))
+
+        #expect(vm.shareSheetItem?.urls.map(\.lastPathComponent) == ["Aardvark.bin"])
+        #expect(vm.showFileNotFoundAlert == false)
+        #expect(stub.sharedROMIds == [42])
+    }
+
+    @Test func prepareShareWithoutFilesAlertsInsteadOfPresenting() {
+        let stub = StubGetROMShareFilesUseCase()
+        let vm = ShareROMViewModel(getShareFilesUseCase: stub)
+
+        vm.prepareShare(rom: makeDownloadedROM(id: 7))
+
+        #expect(vm.shareSheetItem == nil)
+        #expect(vm.showFileNotFoundAlert)
+    }
+
+    /// One instance serves every row, so a second tap has to replace the first
+    /// staging rather than keep showing the previous ROM.
+    @Test func secondTapRestagesForTheNewROM() {
+        let stub = StubGetROMShareFilesUseCase()
+        stub.filesToReturn = [URL(fileURLWithPath: "/tmp/ROMShare-1/Aardvark.bin")]
+        let vm = ShareROMViewModel(getShareFilesUseCase: stub)
+
+        vm.prepareShare(rom: makeDownloadedROM(id: 1, name: "Aardvark"))
+        stub.filesToReturn = [URL(fileURLWithPath: "/tmp/ROMShare-2/Draconian.bin")]
+        vm.prepareShare(rom: makeDownloadedROM(id: 2, name: "Draconian"))
+
+        #expect(vm.shareSheetItem?.urls.map(\.lastPathComponent) == ["Draconian.bin"])
+        #expect(stub.sharedROMIds == [1, 2])
+    }
+}

--- a/romm/rommTests/Support/MockDependencyFactory.swift
+++ b/romm/rommTests/Support/MockDependencyFactory.swift
@@ -518,7 +518,7 @@ class MockDependencyFactory: PDependencyFactory {
         )
     }
 
-    @MainActor func makeShareROMViewModel(rom: DownloadedROM) -> ShareROMViewModel {
-        ShareROMViewModel(rom: rom, getShareFilesUseCase: makeGetROMShareFilesUseCase())
+    @MainActor func makeShareROMViewModel() -> ShareROMViewModel {
+        ShareROMViewModel(getShareFilesUseCase: makeGetROMShareFilesUseCase())
     }
 }


### PR DESCRIPTION
Fixes #148.

Share on a downloaded game did nothing. The button sits in the row's swipe actions and carried its own `.sheet`, but a swipe action's button is gone the moment the row snaps shut, so the sheet never got to appear. The list owns the presentation now.

Reproduced against clean main in the simulator, so this is not fallout from the external emulator work. Verified after the fix: swipe, tap Share, sheet opens with the ROM file. Tests green.

Two things I found while testing there, fixed in the second commit:

- The string catalog had German for 47 strings and nothing else, so a German device showed two languages at once, "Herunterladen" next to "Favorite" and "DETAILS". The app is English-only, so German is gone and everything falls back to the English source strings.
- ShareSheet printed a block of debug lines on every share, file paths included, in release builds too. The two useful lines go through Logger.ui now.

Note there are still ~170 raw print() calls elsewhere in the app, left alone here.