### PR TITLE
Read the signing team from a local xcconfig instead of the project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Claude Code MCP config (contains secrets)
 .mcp.json
 
+# Per-developer code signing (team ID + bundle prefix), never commit
+romm/Config/Signing.xcconfig
+
 # Logs (may contain usernames, hostnames, tokens)
 *.log
 log.txt

--- a/README.md
+++ b/README.md
@@ -69,6 +69,54 @@ git submodule update --init --recursive
 
 Then open `romm/romm.xcodeproj` in Xcode and build.
 
+### Building on a device
+
+Building for the Simulator needs nothing extra. To run on a physical device you
+need your own Apple Developer team and a bundle identifier that is unique to you.
+The upstream `de.ilyashallak.*` identifiers are already registered to the
+maintainer and cannot be re-registered to your account.
+
+The project reads those two values from a gitignored `Signing.xcconfig`, so you
+never have to edit `project.pbxproj`:
+
+```sh
+cp romm/Config/Signing.xcconfig.template romm/Config/Signing.xcconfig
+```
+
+Then edit `romm/Config/Signing.xcconfig` and set:
+
+- `DEVELOPMENT_TEAM`, your 10-character Team ID (Xcode > Settings > Accounts, or
+  the Apple Developer site under Membership details)
+- `ROMM_BUNDLE_ID_PREFIX`, a reverse-DNS prefix only you use, e.g. `com.yourname`
+
+Signing is automatic, so Xcode registers the App ID and provisioning profile the
+first time you build to a connected device.
+
+#### The emulator core submodules
+
+`Signing.xcconfig` only applies to this project's targets, not to the DeltaCore
+projects under `Vendor/`. Several of those pin their own `DEVELOPMENT_TEAM`, so a
+device build needs your team applied to them too:
+
+- **Xcode (UI):** in each `Vendor/*/…xcodeproj`, select every target and set your
+  team under Signing & Capabilities. These edits stay in the submodule working
+  trees, don't commit them.
+- **Command line:** pass `DEVELOPMENT_TEAM` on the `xcodebuild` invocation. It
+  applies to every target in the graph, submodules included, so nothing under
+  `Vendor/` needs editing:
+
+  ```sh
+  xcodebuild -project romm/romm.xcodeproj -scheme romm \
+    -destination 'generic/platform=iOS' \
+    -allowProvisioningUpdates \
+    DEVELOPMENT_TEAM=YOURTEAMID \
+    build
+  ```
+
+  `Signing.xcconfig` is still required, it supplies the unique app bundle
+  identifier (`ROMM_BUNDLE_ID_PREFIX`) that no command-line override can set
+  per-target.
+
 ## Credits
 
 > *Standing on the shoulders of giants.*

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,6 +7,14 @@ PROJECT_PATH = 'romm/romm.xcodeproj'
 DEFAULT_SCHEME = 'romm'
 DEFAULT_TARGET = 'romm'
 
+# The signing team is no longer stored in the project file, it comes from a
+# gitignored Signing.xcconfig that a release worktree does not have. So the
+# build has to be told the team explicitly. Override with IOS_DEVELOPMENT_TEAM.
+DEFAULT_DEVELOPMENT_TEAM = '8J69P655GN'
+SIGNING_TEAM_ID = ENV['IOS_DEVELOPMENT_TEAM'].to_s.strip.then do |team|
+  team.empty? ? DEFAULT_DEVELOPMENT_TEAM : team
+end
+
 private_lane :resolve_optional_app_store_api_key do
   key_id = ENV['APP_STORE_CONNECT_API_KEY_KEY_ID'].to_s.strip
   issuer_id = ENV['APP_STORE_CONNECT_API_KEY_ISSUER_ID'].to_s.strip
@@ -70,12 +78,15 @@ platform :ios do
       message: commit_message
     )
 
+    # Both phases need it: xcargs covers the archive, export_team_id the export.
     build_app(
       project: PROJECT_PATH,
       scheme: scheme,
       configuration: 'Release',
       clean: true,
       export_method: 'app-store',
+      export_team_id: SIGNING_TEAM_ID,
+      xcargs: "DEVELOPMENT_TEAM=#{SIGNING_TEAM_ID}",
       output_directory: 'build',
       output_name: 'romm.ipa'
     )

--- a/romm/Config/Shared.xcconfig
+++ b/romm/Config/Shared.xcconfig
@@ -1,0 +1,18 @@
+// Shared.xcconfig
+//
+// Base build configuration for the romm project. Checked into git and wired up
+// as the project's base configuration (Debug + Release).
+//
+// Per-developer signing values live in an optional, gitignored Signing.xcconfig
+// next to this file. Create it once from Signing.xcconfig.template to build on a
+// physical device — see the README, "Building on a device".
+//
+// Without Signing.xcconfig the defaults below apply: no development team (which
+// is all the Simulator needs) and the upstream bundle-identifier prefix.
+
+// Reverse-DNS prefix applied to every target's bundle identifier. Each target
+// appends its own suffix, e.g. $(ROMM_BUNDLE_ID_PREFIX).rommanagerplus.
+ROMM_BUNDLE_ID_PREFIX = de.ilyashallak
+
+// Pull in per-developer overrides if present. Must come last so it wins.
+#include? "Signing.xcconfig"

--- a/romm/Config/Signing.xcconfig.template
+++ b/romm/Config/Signing.xcconfig.template
@@ -1,0 +1,20 @@
+// Signing.xcconfig.template
+//
+// Copy this file to "Signing.xcconfig" in the same directory, then fill in your
+// own values to build romm on a physical device:
+//
+//     cp romm/Config/Signing.xcconfig.template romm/Config/Signing.xcconfig
+//
+// Signing.xcconfig is gitignored, so your team ID never lands in a commit and
+// you never have to edit romm.xcodeproj/project.pbxproj to build.
+
+// Your 10-character Apple Developer Team ID.
+// Find it in Xcode > Settings > Accounts (select your team), or at
+// https://developer.apple.com/account under Membership details.
+DEVELOPMENT_TEAM = YOUR_TEAM_ID
+
+// A reverse-DNS prefix that is unique to you. A bundle identifier is global
+// across Apple's ecosystem, so the upstream "de.ilyashallak" prefix cannot be
+// registered to your team. Use something only you control, e.g. com.yourname.
+// The app then builds as <prefix>.rommanagerplus, tests as <prefix>.rommTests.
+ROMM_BUNDLE_ID_PREFIX = com.example

--- a/romm/romm.xcodeproj/project.pbxproj
+++ b/romm/romm.xcodeproj/project.pbxproj
@@ -170,7 +170,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		5D2B9D032E5BA8C200F5233E /* mft.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:8J69P655GN:Ilyas Hallak"; lastKnownFileType = wrapper.xcframework; name = mft.xcframework; path = "../../mft 2025-08-24 21-54-12/mft.xcframework"; sourceTree = "<group>"; };
+		5D2B9D032E5BA8C200F5233E /* mft.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:8J69P655GN:Ilyas Hallak"; lastKnownFileType = wrapper.xcframework; name = mft.xcframework; path = ../mft.xcframework; sourceTree = SOURCE_ROOT; };
+		5DC0AF16000000000000C001 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config/Shared.xcconfig; sourceTree = "<group>"; };
 		5D93A11E2FBF55AE00086CE8 /* GPGXDeltaCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = GPGXDeltaCore.xcodeproj; path = ../Vendor/GPGXDeltaCore/GPGXDeltaCore.xcodeproj; sourceTree = SOURCE_ROOT; };
 		5D93A1342FBF67DB00086CE8 /* NESDeltaCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = NESDeltaCore.xcodeproj; path = ../Vendor/NESDeltaCore/NESDeltaCore.xcodeproj; sourceTree = SOURCE_ROOT; };
 		5D93A1412FBF67E300086CE8 /* N64DeltaCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = N64DeltaCore.xcodeproj; path = ../Vendor/N64DeltaCore/N64DeltaCore.xcodeproj; sourceTree = SOURCE_ROOT; };
@@ -336,6 +337,7 @@
 		5DA7E4172E43D870003680D9 = {
 			isa = PBXGroup;
 			children = (
+				5DC0AF16000000000000C001 /* Shared.xcconfig */,
 				5DCA1106000000000000C101 /* CHANGELOG.md */,
 				5DFA9001000000000000F101 /* FAQ.md */,
 				5D93A8952FC2419700086CE8 /* Libretro */,
@@ -680,6 +682,7 @@
 /* Begin XCBuildConfiguration section */
 		5DA7E4452E43D872003680D9 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5DC0AF16000000000000C001 /* Shared.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -713,7 +716,6 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 8J69P655GN;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -742,6 +744,7 @@
 		};
 		5DA7E4462E43D872003680D9 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5DC0AF16000000000000C001 /* Shared.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -775,7 +778,6 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 8J69P655GN;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -802,7 +804,6 @@
 				CODE_SIGN_ENTITLEMENTS = romm/romm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 41;
-				DEVELOPMENT_TEAM = 8J69P655GN;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -824,7 +825,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.5;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = de.ilyashallak.rommanagerplus;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(ROMM_BUNDLE_ID_PREFIX).rommanagerplus";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -847,7 +848,6 @@
 				CODE_SIGN_ENTITLEMENTS = romm/romm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 41;
-				DEVELOPMENT_TEAM = 8J69P655GN;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -869,7 +869,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.5;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = de.ilyashallak.rommanagerplus;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(ROMM_BUNDLE_ID_PREFIX).rommanagerplus";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;


### PR DESCRIPTION
Building on a device currently means editing `DEVELOPMENT_TEAM` and the bundle identifier in `project.pbxproj`, so you end up with a dirty working tree you have to keep out of every commit. This came in as a patch from a user who couldn't open a PR themselves.

Both values now live in `romm/Config/Signing.xcconfig`, gitignored, pulled in optionally by the checked-in `Shared.xcconfig`. Copy the template once and you're set. Without it the Simulator still builds fine, it just gets no team.

Fastlane needed a change too. The release worktree has no `Signing.xcconfig`, so it now passes the team explicitly, overridable via `IOS_DEVELOPMENT_TEAM`.

Verified: Simulator build green without any local config, and a Release archive signs the app plus all 17 embedded frameworks as 8J69P655GN, no `-allowProvisioningUpdates` needed.

Also repoints `mft.xcframework` at the copy inside the repo. It pointed at a directory next to the checkout that nobody cloning would have.